### PR TITLE
Skip database 'hcatalog' for physical database operations

### DIFF
--- a/src/backend/cdb/cdbpersistentbuild.c
+++ b/src/backend/cdb/cdbpersistentbuild.c
@@ -892,6 +892,9 @@ PersistentBuild_TruncateAllGpRelationNode(void)
 		dbOid = HeapTupleGetOid(tuple);
 		dattablespace = form_pg_database->dattablespace;
 
+		if (dbOid == HcatalogDbOid)
+			continue;
+
 		if (Debug_persistent_print)
 			elog(Persistent_DebugPrintLevel(), 
 				 "PersistentBuild_TruncateAllGpRelationNode: dbOid %u, '%s'",

--- a/src/backend/utils/adt/dbsize.c
+++ b/src/backend/utils/adt/dbsize.c
@@ -24,6 +24,7 @@
 #include "catalog/catalog.h"
 #include "catalog/catquery.h"
 #include "catalog/namespace.h"
+#include "catalog/pg_database.h"
 #include "catalog/pg_tablespace.h"
 #include "commands/dbcommands.h"
 #include "commands/tablespace.h"
@@ -177,6 +178,11 @@ calculate_database_size(Oid dbOid)
 	AclResult	 aclresult;
 
 	Assert(Gp_role != GP_ROLE_EXECUTE);
+
+	if (dbOid == HcatalogDbOid)
+		ereport(ERROR,
+			(ERRCODE_UNDEFINED_DATABASE,
+			errmsg("database hcatalog (OID 6120) is reserved")));
 
 	/* User must have connect privilege for target database */
 	aclresult = pg_database_aclcheck(dbOid, GetUserId(), ACL_CONNECT);

--- a/src/test/regress/input/hcatalog_lookup.source
+++ b/src/test/regress/input/hcatalog_lookup.source
@@ -134,7 +134,9 @@ select r1.*, r2.* from hcatalog.test_schema.r r1, test_schema.r r2;
 -- negative test: partitioned tables and hcatalog
 alter table test_schema.p exchange partition p1 with table hcatalog.test_schema.r;
 
-
+-- negative test: cannot run pg_database_size on hcatalog
+select pg_catalog.pg_database_size('hcatalog');
+select pg_catalog.pg_database_size(6120);
 
 -- cleanup
 DROP schema test_schema cascade;

--- a/src/test/regress/output/hcatalog_lookup.source
+++ b/src/test/regress/output/hcatalog_lookup.source
@@ -261,6 +261,11 @@ select r1.*, r2.* from hcatalog.test_schema.r r1, test_schema.r r2;
 -- negative test: partitioned tables and hcatalog
 alter table test_schema.p exchange partition p1 with table hcatalog.test_schema.r;
 ERROR:  reference to hcatalog table "hcatalog.test_schema.r" is not allowed in this context
+-- negative test: cannot run pg_database_size on hcatalog
+select pg_catalog.pg_database_size('hcatalog');
+ERROR:  database hcatalog (OID 6120) is reserved (SOMEFILE:SOMEFUNC)
+select pg_catalog.pg_database_size(6120);
+ERROR:  database hcatalog (OID 6120) is reserved (SOMEFILE:SOMEFUNC)
 -- cleanup
 DROP schema test_schema cascade;
 NOTICE:  drop cascades to append only table test_schema.r


### PR DESCRIPTION
\* Code review and testing has already happened for the fix, parking the changes here temporarily until I get commit rights

"hcatalog" as a database object is created solely for the purpose of referencing externally managed data, and it does not actually contain any tables, therefore we should skip the virtual database when calculating dbsize and truncating relation node.