### PR TITLE
HAWQ-26. Check cancel signal when Dispatcher waiting for job finish

### DIFF
--- a/src/backend/cdb/workermgr.c
+++ b/src/backend/cdb/workermgr.c
@@ -134,6 +134,7 @@ workermgr_wait_job(WorkerMgrState *state)
 {
 	state->cancel = false;
 	workermgr_join(state);
+	CHECK_FOR_INTERRUPTS();
 }
 
 static void


### PR DESCRIPTION
Add code to check interrupts when dispatcher waiting job finish.