### PR TITLE
HAWQ-10. Skip hcatalog database when calculating the sizes of databases

### DIFF
--- a/src/backend/catalog/gp_toolkit.sql.in
+++ b/src/backend/catalog/gp_toolkit.sql.in
@@ -1768,7 +1768,8 @@ AS
 	WHERE
 		datname <> 'template0' 
 	AND datname <> 'template1'
-	AND datname <> 'postgres';
+	AND datname <> 'postgres'
+	AND datname <> 'hcatalog';
 		
 GRANT SELECT ON TABLE %%JETPACK_PREFIX%%size_of_database TO public;
 


### PR DESCRIPTION
Update the gp_toolkit.sql.in to skip hcatalog database when calculating the sizes of database.