### PR TITLE
HAWQ-21. Add '\' for the multi-line marco WRITE_PERSISTENT_STATE_ORDE…

### DIFF
--- a/src/include/cdb/cdbpersistentstore.h
+++ b/src/include/cdb/cdbpersistentstore.h
@@ -437,7 +437,7 @@ typedef struct WritePersistentStateLockLocalVars
 
 #define WRITE_PERSISTENT_STATE_ORDERED_LOCK_DECLARE \
 	MIRRORED_LOCK_DECLARE; \
-	CHECKPOINT_START_LOCK_DECLARE;
+	CHECKPOINT_START_LOCK_DECLARE; \
 	WritePersistentStateLockLocalVars writePersistentStateLockLocalVars;
 
 #define WRITE_PERSISTENT_STATE_ORDERED_LOCK \


### PR DESCRIPTION
Add '\' for the multi-line macro WRITE_PERSISTENT_STATE_ORDERED_LOCK_DECLARE.