### PR TITLE
HAWQ-67. Wrong variable type for saving fgetc() return value

### DIFF
--- a/src/backend/resourcemanager/resourcepool.c
+++ b/src/backend/resourcemanager/resourcepool.c
@@ -3621,7 +3621,7 @@ void refreshSlavesFileHostSize(FILE *fp)
 	initializeSelfMaintainBuffer(&smb, PCONTEXT);
 	while( true )
 	{
-		char c = fgetc(fp);
+		int c = fgetc(fp);
 		if ( c == EOF )
 		{
 			if ( feof(fp) == 0 )
@@ -3653,7 +3653,8 @@ void refreshSlavesFileHostSize(FILE *fp)
 		else
 		{
 			/* Add this character into the buffer. */
-			appendSelfMaintainBuffer(&smb, &c, 1);
+			char cval = c;
+			appendSelfMaintainBuffer(&smb, &cval, 1);
 		}
 	}
 


### PR DESCRIPTION
This is to fix a bug of processing return value of fgetc(). char variable may cut the return value, int is utilized now.