### PR TITLE
HAWQ-78. Fixed parallel build error(using "make -j8")

### DIFF
--- a/src/backend/catalog/Makefile
+++ b/src/backend/catalog/Makefile
@@ -26,9 +26,10 @@ SUBDIRS = caql core hcatalog
 
 BKIFILES = postgres.bki postgres.description postgres.shdescription
 
+OTHER_TASK = cdb_init.sql cdb_util.sql cdb_schema.sql gp_toolkit.sql gp_toolkit_test.sql $(BKIFILES)
+
 include $(top_srcdir)/src/backend/common.mk
 
-all: cdb_init.sql cdb_util.sql cdb_schema.sql gp_toolkit.sql gp_toolkit_test.sql $(BKIFILES)
 
 cdb_init.sql: cdb_schema.sql filesystem.sql
 	cat $(call vpathsearch,cdb_schema.sql) $(call vpathsearch,cdb_external_extensions.sql) $(call vpathsearch,filesystem.sql) $(call vpathsearch,madlib.sql) > cdb_init.sql

--- a/src/backend/common.mk
+++ b/src/backend/common.mk
@@ -22,7 +22,7 @@ SUBDIROBJS = $(SUBDIRS:%=%/$(subsysfilename))
 
 # top-level backend directory obviously has its own "all" target
 ifneq ($(subdir), src/backend)
-all: $(subsysfilename)
+all: $(subsysfilename) $(OTHER_TASK)
 endif
 
 SUBSYS.o: $(SUBDIROBJS) $(OBJS)

--- a/src/backend/gpopt/Makefile
+++ b/src/backend/gpopt/Makefile
@@ -18,7 +18,7 @@ SUBDIRS = config translate relcache utils
 
 OBJS = Allocators.o CGPOptimizer.o gpdbwrappers.o
 
-include $(top_srcdir)/src/backend/common.mk
+OTHER_TASK = libdxltranslators.$(LDSFX) libgpoptudf.$(LDSFX)
 
 ifeq (Darwin, $(UNAME))
 	LDLIBFLAGS = -dynamiclib -flat_namespace -undefined dynamic_lookup -Wl,-unexported_symbols_list -Wl,unexported_symbols_list.txt
@@ -44,10 +44,7 @@ LIBNAUCRATES_DIR = $(ORCA_DEPENDS_DIR_INTER)/libnaucrates
 LIBGPDBCOST_DIR = $(ORCA_DEPENDS_DIR_INTER)/libgpdbcost
 LIBGPOPT_DIR = $(ORCA_DEPENDS_DIR_INTER)/libgpopt
 
-all: $(SUBDIRS) libdxltranslators.$(LDSFX) libgpoptudf.$(LDSFX)
-
-$(SUBDIRS):
-	$(MAKE) -C $@
+include $(top_srcdir)/src/backend/common.mk
 
 libdxltranslators.$(LDSFX): $(SUBDIROBJS) $(OBJS)
 	$(CXX) $(CXXFLAGS) $(LDLIBFLAGS) \
@@ -71,4 +68,4 @@ install:
 	$(INSTALL_DATA) libdxltranslators.$(LDSFX) '$(DESTDIR)$(libdir)/libdxltranslators.$(LDSFX)'
 	$(INSTALL_DATA) libgpoptudf.$(LDSFX) '$(DESTDIR)$(libdir)/libgpoptudf.$(LDSFX)'
 
-.PHONY: all install $(SUBDIRS)
+.PHONY: install


### PR DESCRIPTION
The error is caused by the dependency not set correctly in Makefile. 

Note: This fix only correct 2 occurrences. If we encounter the same problem in the future,  we need to fix them using same solution. Because there are a lot of Makefile, I don't look through all of them.