### PR TITLE
HAWQ-83. Rename resource manager's GUC names in hawq-site.xml.

### DIFF
--- a/src/backend/utils/misc/etc/hawq-site.xml
+++ b/src/backend/utils/misc/etc/hawq-site.xml
@@ -50,7 +50,7 @@
      
     <!-- HAWQ resource manager parameters -->
     <property>
-        <name>hawq_resourcemanager_server_type</name>
+        <name>hawq_global_rm_type</name>
         <value>none</value>
         <description>The resource manager type to start for allocating resource. 
                      'none' means hawq resource manager exclusively uses whole
@@ -63,7 +63,7 @@
         <name>hawq_resourcemanager_segment_limit_memory_use</name>
         <value>64GB</value>
         <description>The limit of memory usage in a hawq segment when 
-                     hawq_resourcemanager_server_type is set 'none'.
+                     hawq_global_rm_type is set 'none'.
         </description>
     </property>
 
@@ -71,7 +71,7 @@
         <name>hawq_resourcemanager_segment_limit_core_use</name>
         <value>16</value>
         <description>The limit of virtual core usage in a hawq segment when 
-                     hawq_resourcemanager_server_type is set 'none'.
+                     hawq_global_rm_type is set 'none'.
         </description>
     </property>
     

--- a/src/backend/utils/misc/etc/template-hawq-site.xml
+++ b/src/backend/utils/misc/etc/template-hawq-site.xml
@@ -57,7 +57,7 @@
     </property>
 
     <property>
-        <name>hawq_resourcemanager_server_type</name>
+        <name>hawq_global_rm_type</name>
         <value>%enable_yarn%</value>
     </property>
 
@@ -67,12 +67,12 @@
     </property>
     
     <property>
-        <name>hawq_resourcemanager_master_address_port</name>
+        <name>hawq_rm_master_port</name>
         <value>5437</value>
     </property>
     
     <property>
-        <name>hawq_resourcemanager_segment_address_port</name>
+        <name>hawq_rm_segment_port</name>
         <value>5438</value>
     </property>
     


### PR DESCRIPTION
Since we have changed the GUC design for RM. Now we need to update the related GUC names in hawq-site.xml.
For example:
hawq_resourcemanager_server_type --> hawq_global_rm_type.
