### PR TITLE
HAWQ-73. Fix bug of 'Fail to unregister in HAWQ resource manager beca…

### DIFF
--- a/src/backend/resourcemanager/requesthandler_ddl.c
+++ b/src/backend/resourcemanager/requesthandler_ddl.c
@@ -45,7 +45,7 @@ void freeUpdateActionList(MCTYPE context, List **actions);
  * mapping with the definition of table pg_resqueue in pg_resqueue.h
  */
 const char* PG_Resqueue_Column_Names[Natts_pg_resqueue] = {
-	"name",
+	"rsqname",
 	"parentoid",
 	"activestats",
 	"memorylimit",

--- a/src/backend/resourcemanager/resqueuemanager.c
+++ b/src/backend/resourcemanager/resqueuemanager.c
@@ -43,7 +43,7 @@ static char RSQTBLAttrNames[RSQ_TBL_ATTR_COUNT]
 	"nvseglowerlimitperseg",
 
 	"oid",
-	"name",
+	"rsqname",
 	"creationtime",
 	"updatetime",
 	"status"


### PR DESCRIPTION
…use of RPC error'

This bug is caused by wrong self-built sql statement. 

postgres=# create resource queue test_queue_1 with (parent='pg_root', memory_limit_cluster=50%, core_limit_cluster=50%);
CREATE QUEUE
postgres=# alter resource queue test_queue_1 with(memory_limit_cluster=40%, core_limit_cluster=40%);
ALTER QUEUE
postgres=# drop resource queue test_queue_1;
DROP QUEUE
postgres=# \q
jiny2:hawqmain yjin$