### PR TITLE
HAWQ-80. Support dynamic relation distribution type in gpopt

### DIFF
--- a/src/backend/cdb/cdbdatalocality.c
+++ b/src/backend/cdb/cdbdatalocality.c
@@ -2531,9 +2531,8 @@ static bool allocate_hash_relation(Relation_Data* rel_data,
 			return true;
 		}
 	}
-	/*for now orca doesn't support convert hash to random*/
 	else if((hash_to_random_flag == ENFORCE_HASH_TO_RANDOM ||
-			(relationDatalocality < hash2RandomDatalocalityThreshold && relationDatalocality >= 0 && !optimizer))
+			(relationDatalocality < hash2RandomDatalocalityThreshold && relationDatalocality >= 0 ))
 			&& hash_to_random_flag != ENFORCE_KEEP_HASH){
 		log_context->totalDataSizePerRelation =0;
 		log_context->localDataSizePerRelation =0;
@@ -3716,7 +3715,6 @@ run_allocation_algorithm(SplitAllocResult *result, List *virtual_segments, Query
 				result->relsType = lappend(result->relsType, relType);
 				MemoryContextSwitchTo(cur_memorycontext);
 				if (needToChangeHash2Random) {
-					result->forbid_optimizer = true;
 					allocate_random_relation(rel_data, &log_context, &idMap, 	&assignment_context, context);
 				}
 			}
@@ -3730,7 +3728,6 @@ run_allocation_algorithm(SplitAllocResult *result, List *virtual_segments, Query
 				relType->isHash = false;
 				result->relsType = lappend(result->relsType, relType);
 				MemoryContextSwitchTo(cur_memorycontext);
-				result->forbid_optimizer = true;
 				allocate_random_relation(rel_data, &log_context,&idMap, &assignment_context, context);
 			}
 
@@ -3837,7 +3834,7 @@ calculate_planner_segment_num(Query *query, QueryResourceLife resourceLife,
 	result = (SplitAllocResult *) palloc(sizeof(SplitAllocResult));
 	result->relsType = NIL;
 	result->datalocalityInfo = makeStringInfo();
-	result->forbid_optimizer = false;
+
 	/* fake data locality */
 	if (debug_fake_datalocality) {
 		fp = fopen("/tmp/cdbdatalocality.result", "w+");

--- a/src/backend/gpopt/gpdbwrappers.cpp
+++ b/src/backend/gpopt/gpdbwrappers.cpp
@@ -199,6 +199,8 @@
 #define ALLOW_isMotionGather
 #define ALLOW_estimate_rel_size
 #define ALLOW_rel_partitioning_is_uniform
+#define ALLOW_GetActiveRelType
+#define ALLOW_GetActiveQueryResource
 
 #define ALLOW_mdver_request_version
 #define ALLOW_mdver_enabled
@@ -2363,6 +2365,30 @@ gpdb::Pdistrpolicy
     GP_WRAP_END;
     return NULL;
 }
+
+
+List *
+gpdb::PlActiveRelTypes(void)
+{
+	GP_WRAP_START;
+	{
+		return GetActiveRelType();
+	}
+	GP_WRAP_END;
+	return NULL;
+}
+
+QueryResource *
+gpdb::PqrActiveQueryResource(void)
+{
+	GP_WRAP_START;
+	{
+		return GetActiveQueryResource();
+	}
+	GP_WRAP_END;
+	return NULL;
+}
+
 
 BOOL
 gpdb::FChildPartDistributionMismatch

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -340,8 +340,7 @@ planner(Query *parse, int cursorOptions,
 		* then fall back to the planner.
 		* TODO: caragg 11/08/2013: Enable ORCA when running in utility mode (MPP-21841)
 		*/
-		if (!ppResult->saResult.forbid_optimizer && optimizer
-				&& AmIMaster() && (GP_ROLE_UTILITY != Gp_role))
+    	if (optimizer && AmIMaster() && (GP_ROLE_UTILITY != Gp_role))
 		{
 			if (gp_log_optimization_time)
 			{

--- a/src/include/cdb/cdbdatalocality.h
+++ b/src/include/cdb/cdbdatalocality.h
@@ -28,8 +28,6 @@ typedef struct SplitAllocResult
   int planner_segments;
   List *relsType;// relation type after datalocality changing
   StringInfo datalocalityInfo;
-  //orca currently doesn't support hash table to be processed as random table.
-  bool forbid_optimizer;
 } SplitAllocResult;
 
 /*

--- a/src/include/gpopt/gpdbwrappers.h
+++ b/src/include/gpopt/gpdbwrappers.h
@@ -55,6 +55,7 @@ struct GpPolicy;
 struct PartitionSelector;
 struct SelectedParts;
 struct Motion;
+struct QueryResource;
 
 namespace gpdb {
 
@@ -488,6 +489,12 @@ namespace gpdb {
     // and the parts are distributed differently, return Random distribution
     GpPolicy *Pdistrpolicy(Relation rel);
     
+    // return active relation distribution types
+    List *PlActiveRelTypes(void);
+
+    // return active query resource
+    QueryResource *PqrActiveQueryResource(void);
+
     // return true if the table is partitioned and hash-distributed, and one of  
     // the child partitions is randomly distributed
     BOOL FChildPartDistributionMismatch(Relation rel);

--- a/src/include/gpopt/translate/CTranslatorRelcacheToDXL.h
+++ b/src/include/gpopt/translate/CTranslatorRelcacheToDXL.h
@@ -307,6 +307,10 @@ namespace gpdxl
 			static 
 			BOOL FDefaultPartition(List *plDefaultLevels, ULONG ulLevel);
 			
+			// treat a hash distributed table as random distributed
+			static
+			BOOL FTreatAsRandom(OID oid, GpPolicy *pgppolicy);
+
 			// retrieve part constraint for index
 			static
 			CMDPartConstraintGPDB *PmdpartcnstrIndex


### PR DESCRIPTION
If there are 3 hash distributed tables in a query, each has a different buckets number, say 8, 24 and 64, the resource negotiator will allocate max(8,24,64)=64 vSegs. In this case, the tables with buckets number 8 and 24 will need to be regarded as random distributed table during planning.