### PR TITLE
HAWQ-88. set default value of guc hash_to_random_flag to  be ENFORCE_…

### DIFF
--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -6383,7 +6383,7 @@ static struct config_int ConfigureNamesInt[] =
 				GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 			},
 			&hash_to_random_flag,
-			0, 0, 2 ,NULL, NULL
+			2, 0, 2 ,NULL, NULL
 	},
 
 	{


### PR DESCRIPTION
…KEEP_HASH
guc hash_to_random_flag has three values: HASH_TO_RANDOM_BASEDON_DATALOCALITY, ENFORCE_HASH_TO_RANDOM and ENFORCE_KEEP_HASH.
It determines the different behaviour of whether to convert a hash table to random when vseg number equals to table bucket number(since when vseg num doesn't equal to bucket number, it must be converted to random)
We now set this guc to ENFORCE_KEEP_HASH by default.