### PR TITLE
HAWQ-89. format the explain analyze results

### DIFF
--- a/src/backend/cdb/cdbdatalocality.c
+++ b/src/backend/cdb/cdbdatalocality.c
@@ -3265,10 +3265,10 @@ static void print_datalocality_overall_log_information(SplitAllocResult *result,
 			log_context->avgContinuityOverall,log_context->minContinuityOverall,log_context->maxContinuityOverall
 			);
 
-	appendStringInfo(result->datalocalityInfo, "datalocality ratio: %.3f; virtual segments number: %d, "
-			"different host number: %d, segment number per host(avg/min/max): (%d/%d/%d); "
-			"segments size(avg/min/max): (%.3f/"INT64_FORMAT"/"INT64_FORMAT"); "
-			"segments size with penalty(avg/min/max): (%.3f/"INT64_FORMAT"/"INT64_FORMAT"); continuity(avg/min/max): (%.3f/%.3f/%.3f)."
+	appendStringInfo(result->datalocalityInfo, "data locality ratio: %.3f; virtual segment number: %d; "
+			"different host number: %d; virtual segment number per host(avg/min/max): (%d/%d/%d); "
+			"segment size(avg/min/max): (%.3f/"INT64_FORMAT"/"INT64_FORMAT"); "
+			"segment size with penalty(avg/min/max): (%.3f/"INT64_FORMAT"/"INT64_FORMAT"); continuity(avg/min/max): (%.3f/%.3f/%.3f)."
 			,log_context->datalocalityRatio,assignment_context->virtual_segment_num,log_context->numofDifferentHost,
 			log_context->avgSegmentNumofHost,log_context->minSegmentNumofHost,log_context->maxSegmentNumofHost,
 			log_context->avgSizeOverall,log_context->minSizeSegmentOverall,log_context->maxSizeSegmentOverall,


### PR DESCRIPTION


Description

There are some inconsistency for usage of "," and ";", and some words need to be rephased.

Dispatcher statistics:
executors used(total/cached/new connection): (1/1/0); dispatcher time(total/connection/dispatch data): (0.109 ms/0.000 ms/0.027 ms).
dispatch data time(max/min/avg): (0.027 ms/0.027 ms/0.027 ms); consume executor data time(max/min/avg): (0.012 ms/0.012 ms/0.012 ms); free executor time(max/min/avg): (0.000 ms/0.000 ms/0.000 ms).
Data locality statistics:
datalocality ratio: 0.000; virtual segments number: 1, different host number: 1, segment number per host(avg/min/max): (1/1/1); segments size(avg/min/max): (10011936.000/10011936/10011936); segments size with penalty(avg/min/max): (20023872.000/20023872/20023872); continuity(avg/min/max): (1.000/1.000/1.000).
Total runtime: 588.479 ms
