### PR TITLE
HAWQ-104. HAWQ RM resource request timeout mechanism does not work

### DIFF
--- a/src/backend/resourcemanager/communication/rmcomm_QD2RM.c
+++ b/src/backend/resourcemanager/communication/rmcomm_QD2RM.c
@@ -426,8 +426,7 @@ int registerConnectionInRMByStr(int 		   index,
     if ( res != FUNC_RETURN_OK )
     {
     	snprintf(errorbuf, errorbufsize,
-    			 "failed to register in HAWQ resource manager because of "
-    			 "RPC error %s.",
+    			 "failed to register in HAWQ resource manager because of %s.",
 				 getErrorCodeExplain(res));
     	return res;
     }
@@ -440,8 +439,7 @@ int registerConnectionInRMByStr(int 		   index,
     if ( response->Result != FUNC_RETURN_OK )
     {
     	snprintf(errorbuf, errorbufsize,
-    			 "failed to register in HAWQ resource manager because of remote"
-    			 "error %s.",
+    			 "failed to register in HAWQ resource manager because of %s.",
 				 getErrorCodeExplain(response->Result));
     	return response->Result;
     }
@@ -476,8 +474,7 @@ int registerConnectionInRMByOID(int 		   index,
     if ( res != FUNC_RETURN_OK )
     {
     	snprintf(errorbuf, errorbufsize,
-    			 "failed to register in HAWQ resource manager because of "
-    			 "RPC error %s.",
+    			 "failed to register in HAWQ resource manager because of %s.",
 				 getErrorCodeExplain(res));
     	return res;
     }
@@ -490,8 +487,7 @@ int registerConnectionInRMByOID(int 		   index,
     if ( response->Result != FUNC_RETURN_OK )
     {
     	snprintf(errorbuf, errorbufsize,
-    			 "failed to register in HAWQ resource manager because of remote"
-    			 "error %s.",
+    			 "failed to register in HAWQ resource manager because of %s.",
 				 getErrorCodeExplain(response->Result));
     	return response->Result;
     }
@@ -526,8 +522,7 @@ int	unregisterConnectionInRM(int 			   index,
     if ( res != FUNC_RETURN_OK )
     {
     	snprintf(errorbuf, errorbufsize,
-    			 "failed to unregister in HAWQ resource manager because of "
-    			 "RPC error %s.",
+    			 "failed to unregister in HAWQ resource manager because of %s.",
 				 getErrorCodeExplain(res));
     	return res;
     }
@@ -539,8 +534,7 @@ int	unregisterConnectionInRM(int 			   index,
     {
     	res = response->Result;
     	snprintf(errorbuf, errorbufsize,
-    			 "failed to unregister in HAWQ resource manager because of "
-    			 "remote error %s.",
+    			 "failed to unregister in HAWQ resource manager because of %s.",
 				 getErrorCodeExplain(response->Result));
     }
 
@@ -662,7 +656,7 @@ int acquireResourceFromRM(int 		  		  index,
     if ( errres->Result != FUNC_RETURN_OK )
     {
     	snprintf(errorbuf, errorbufsize,
-    			 "failed to acquire resource because of remote error %s.",
+    			 "failed to acquire resource because of %s.",
     			 getErrorCodeExplain(errres->Result));
     	return errres->Result;
     }
@@ -789,8 +783,7 @@ int returnResource(int 		index,
     if ( res != FUNC_RETURN_OK )
     {
     	snprintf(errorbuf, errorbufsize,
-    			 "failed to return resource to HAWQ resource manager because of "
-    			 "RPC error %s.",
+    			 "failed to return resource to HAWQ resource manager because of %s.",
 				 getErrorCodeExplain(res));
     	return res;
     }
@@ -802,8 +795,7 @@ int returnResource(int 		index,
     {
     	res = response->Result;
         snprintf(errorbuf, errorbufsize,
-        		 "Fail to return resource to HAWQ resource manager because of "
-        		 "remote error %s.",
+        		 "failed to return resource to HAWQ resource manager because of %s.",
 				 getErrorCodeExplain(res));
         return res;
     }

--- a/src/backend/resourcemanager/communication/rmcomm_RM2RMSEG.c
+++ b/src/backend/resourcemanager/communication/rmcomm_RM2RMSEG.c
@@ -650,7 +650,7 @@ void processContainersAfterIncreaseMemoryQuota(GRMContainerSet ctns, bool accept
     		/* Add container to KickedContainers if lifetime is long enough */
     		else
     		{
-    			removePendingResourceRequestInRootQueue(ctn->MemoryMB, ctn->Core);
+    			removePendingResourceRequestInRootQueue(ctn->MemoryMB, ctn->Core, false);
     			addGRMContainerToKicked(ctn);
     		}
     	}

--- a/src/backend/resourcemanager/include/resqueuemanager.h
+++ b/src/backend/resourcemanager/include/resqueuemanager.h
@@ -393,7 +393,9 @@ int minusResourceFromReourceManager(int32_t memorymb, double core);
 int addNewResourceToResourceManagerByBundle(ResourceBundle bundle);
 int minusResourceFromResourceManagerByBundle(ResourceBundle bundle);
 
-void removePendingResourceRequestInRootQueue(int32_t memorymb, uint32_t core);
+void removePendingResourceRequestInRootQueue(int32_t 	memorymb,
+											 uint32_t 	core,
+											 bool 		updatependingtime);
 void clearPendingResourceRequestInRootQueue(void);
 void buildAcquireResourceResponseMessage(ConnectionTrack conn);
 

--- a/src/backend/resourcemanager/resourcebroker/resourcebroker_LIBYARN.c
+++ b/src/backend/resourcemanager/resourcebroker/resourcebroker_LIBYARN.c
@@ -321,6 +321,8 @@ int RB_LIBYARN_acquireResource(uint32_t memorymb, uint32_t core, List *preferred
 		res = RESBROK_PIPE_ERROR;
 	}
 
+	elog(DEBUG3, "LIBYARN mode resource broker wrote %d bytes out.", sendBuffer.Cursor+1);
+
 	destroySelfMaintainBuffer(&sendBuffer);
 	elog(LOG, "YARN mode resource broker wrote resource allocation request to "
 			  "resource broker process.");
@@ -830,7 +832,8 @@ int handleRB2RM_AllocatedResource(void)
 	 */
 	removePendingResourceRequestInRootQueue(
 		response.MemoryMB * (response.ExpectedContainerCount - acceptedcount),
-		response.Core     * (response.ExpectedContainerCount - acceptedcount));
+		response.Core     * (response.ExpectedContainerCount - acceptedcount),
+		response.Result == FUNC_RETURN_OK);
 
 	elog(LOG, "Accepted (%d MB, %d CORE) x %d from resource broker, "
 			  "Expected %d containers, skipped %d containers.",

--- a/src/backend/resourcemanager/resourcebroker/resourcebroker_LIBYARN_proc.c
+++ b/src/backend/resourcemanager/resourcebroker/resourcebroker_LIBYARN_proc.c
@@ -770,11 +770,6 @@ int handleRM2RB_AllocateResource(void)
 				 request.Core,
 				 request.ContainerCount);
 
-	if ( YARNJobID == NULL )
-	{
-		return sendRBAllocateResourceErrorData(RESBROK_ERROR_GRM, &request);
-	}
-
 	/* build preferred host list */
 	if (request.MsgLength > 0 && request.PreferredSize > 0) {
 
@@ -806,6 +801,14 @@ int handleRM2RB_AllocateResource(void)
 					  "preferred host, hostname:%s, rackname:%s, container number:%d.",
 					  preferredArray[i].hostname, preferredArray[i].rackname, preferredArray[i].num_containers);
 		}
+	}
+
+	elog(DEBUG3, "LIBYARN mode resource broker process read %d bytes in.",
+				 request.MsgLength + sizeof(RPCRequestRBAllocateResourceContainersData));
+
+	if ( YARNJobID == NULL )
+	{
+		return sendRBAllocateResourceErrorData(RESBROK_ERROR_GRM, &request);
 	}
 
 	/*

--- a/src/backend/resourcemanager/resourcebroker/resourcebroker_NONE.c
+++ b/src/backend/resourcemanager/resourcebroker/resourcebroker_NONE.c
@@ -202,9 +202,10 @@ int RB_NONE_acquireResource(uint32_t memorymb, uint32_t core, List *preferred)
 
 	/* Clean up pending resource quantity. */
 	removePendingResourceRequestInRootQueue( contmemorymb * (contcount - contactcount),
-											 1            * (contcount - contactcount));
+											 1            * (contcount - contactcount),
+											 res == FUNC_RETURN_OK);
 
-	return FUNC_RETURN_OK;
+	return res;
 }
 
 int RB_NONE_returnResource(List **ctnl)

--- a/src/backend/resourcemanager/resourcemanager.c
+++ b/src/backend/resourcemanager/resourcemanager.c
@@ -2137,6 +2137,8 @@ int generateAllocRequestToBroker(void)
 		if ( mctrack->TotalPendingStartTime == 0 )
 		{
 			mctrack->TotalPendingStartTime = gettime_microsec();
+			elog(DEBUG3, "Global resource total pending start time is updated to "UINT64_FORMAT,
+						 mctrack->TotalPendingStartTime);
 		}
 		res = RB_acquireResource(reqmem, reqcore, preferred);
 		if ( res != FUNC_RETURN_OK && res != RESBROK_PIPE_BUSY )

--- a/src/backend/resourcemanager/resourcepool.c
+++ b/src/backend/resourcemanager/resourcepool.c
@@ -2746,7 +2746,7 @@ void moveAllAcceptedGRMContainersToResPool(void)
 		elog(LOG, "AddPendingContainerCount minused 1, current value %d",
 				  PRESPOOL->AddPendingContainerCount);
 		addNewResourceToResourceManager(ctn->MemoryMB, ctn->Core);
-		removePendingResourceRequestInRootQueue(ctn->MemoryMB, ctn->Core);
+		removePendingResourceRequestInRootQueue(ctn->MemoryMB, ctn->Core, true);
 	}
 	validateResourcePoolStatus(true);
 }
@@ -3237,7 +3237,7 @@ void dropAllResPoolGRMContainersToToBeKicked(void)
 	for ( int i = 0 ; i < PQUEMGR->RatioCount ; ++i )
 	{
 		resetResourceBundleData(&(PQUEMGR->RatioTrackers[i]->TotalPending), 0, 0, -1);
-		PQUEMGR->RatioTrackers[i]->TotalPendingStartTime = 0;
+		//PQUEMGR->RatioTrackers[i]->TotalPendingStartTime = 0;
 	}
 
 	refreshMemoryCoreRatioLevelUsage(gettime_microsec());


### PR DESCRIPTION
When yarn is not available or yarn has no enough resource to support query running, the resource request of that query should be timed out based on design. User should use guc to control the timeout value.
This fix is to make this work as before.

