### PR TITLE
HAWQ-108. Allocated memory space for saving preferred host informatio…

### DIFF
--- a/src/backend/resourcemanager/resourcebroker/resourcebroker_LIBYARN_proc.c
+++ b/src/backend/resourcemanager/resourcebroker/resourcebroker_LIBYARN_proc.c
@@ -808,6 +808,14 @@ int handleRM2RB_AllocateResource(void)
 
 	if ( YARNJobID == NULL )
 	{
+    	if (pBuffer != NULL)
+    	{
+    		rm_pfree(PCONTEXT, pBuffer);
+    	}
+    	if (preferredArray != NULL)
+    	{
+    		rm_pfree(PCONTEXT, preferredArray);
+    	}
 		return sendRBAllocateResourceErrorData(RESBROK_ERROR_GRM, &request);
 	}
 
@@ -830,9 +838,13 @@ int handleRM2RB_AllocateResource(void)
     if ( libyarnres != FUNCTION_SUCCEEDED )
     {
     	if (pBuffer != NULL)
+    	{
     		rm_pfree(PCONTEXT, pBuffer);
+    	}
     	if (preferredArray != NULL)
+    	{
     		rm_pfree(PCONTEXT, preferredArray);
+    	}
     	return sendRBAllocateResourceErrorData(RESBROK_ERROR_GRM, &request);
     }
 


### PR DESCRIPTION
…n is not freed

This is a memory leak bug.

When YARN is not available, in resource broker, the temporarily allocated space is not freed.