### PR TITLE
HAWQ-114. Set resource queue default parallel limit to 20

### DIFF
--- a/src/include/catalog/pg_resqueue.h
+++ b/src/include/catalog/pg_resqueue.h
@@ -143,7 +143,7 @@ typedef FormData_pg_resqueue *Form_pg_resqueue;
 
 /* Create initial default resource queue */
 DATA(insert OID = 9800 ( "pg_root"    0      "-1"    "100%" "100%" 2 "even" _null_      0 0 0 1 _null_ _null_ "branch"));
-DATA(insert OID = 6055 ( "pg_default" 9800   "100"   "50%"  "50%"  2 "even" "mem:128mb" 0 0 0 1 _null_ _null_ _null_));
+DATA(insert OID = 6055 ( "pg_default" 9800   "20"    "50%"  "50%"  2 "even" "mem:128mb" 0 0 0 1 _null_ _null_ _null_));
 
 /*
  * The possible resource allocation policies.
@@ -154,7 +154,7 @@ enum RESOURCE_QUEUE_ALLOCATION_POLICY_INDEX {
 	RSQ_ALLOCATION_POLICY_COUNT
 };
 
-#define DEFAULT_RESQUEUE_ACTIVESTATS					"100"
+#define DEFAULT_RESQUEUE_ACTIVESTATS					"20"
 #define DEFAULT_RESQUEUE_OVERCOMMIT						"2"
 #define DEFAULT_RESQUEUE_NVSEG_UPPER_LIMIT				"0"
 #define DEFAULT_RESQUEUE_NVSEG_LOWER_LIMIT				"0"
@@ -164,7 +164,7 @@ enum RESOURCE_QUEUE_ALLOCATION_POLICY_INDEX {
 #define DEFAULT_RESQUEUE_ALLOCPOLICY             		"even"
 #define DEFAULT_RESQUEUE_VSEGRESOURCEQUOTA		    	"mem:128mb"
 
-#define DEFAULT_RESQUEUE_ACTIVESTATS_N					100
+#define DEFAULT_RESQUEUE_ACTIVESTATS_N					20
 #define DEFAULT_RESQUEUE_OVERCOMMIT_N					2.0
 #define DEFAULT_RESQUEUE_NVSEG_UPPER_LIMIT_N			0
 #define DEFAULT_RESQUEUE_NVSEG_LOWER_LIMIT_N			0


### PR DESCRIPTION
This is to set default active_statements value to 20 