### PR TITLE
HAWQ-115. Format the log of datalocality

### DIFF
--- a/src/backend/cdb/cdbdatalocality.c
+++ b/src/backend/cdb/cdbdatalocality.c
@@ -3254,10 +3254,10 @@ static void print_datalocality_overall_log_information(SplitAllocResult *result,
 	}
 	/* print data locality result*/
 	elog(
-			LOG, "datalocality ratio: %.3f; virtual segments number: %d, "
-			"different host number: %d, segment number per host(avg/min/max): (%d/%d/%d); "
-			"segments size(avg/min/max): (%.3f/"INT64_FORMAT"/"INT64_FORMAT"); "
-			"segments size with penalty(avg/min/max): (%.3f/"INT64_FORMAT"/"INT64_FORMAT"); continuity(avg/min/max): (%.3f/%.3f/%.3f)."
+			LOG, "data locality ratio: %.3f; virtual segment number: %d; "
+			"different host number: %d; virtual segment number per host(avg/min/max): (%d/%d/%d); "
+			"segment size(avg/min/max): (%.3f/"INT64_FORMAT"/"INT64_FORMAT"); "
+			"segment size with penalty(avg/min/max): (%.3f/"INT64_FORMAT"/"INT64_FORMAT"); continuity(avg/min/max): (%.3f/%.3f/%.3f)."
 			,log_context->datalocalityRatio,assignment_context->virtual_segment_num,log_context->numofDifferentHost,
 			log_context->avgSegmentNumofHost,log_context->minSegmentNumofHost,log_context->maxSegmentNumofHost,
 			log_context->avgSizeOverall,log_context->minSizeSegmentOverall,log_context->maxSizeSegmentOverall,


### PR DESCRIPTION


Format the log of datalocality

"datalocality ratio: 0.000; virtual segments number: 1, different host number: 1, segment number per host(avg/min/max): (1/1/1); segments size(avg/min/ max): (0.000/0/0); segments size with penalty(avg/min/max): (0.000/0/0); continuity(avg/min/max): (0.000/0.000/0.000)."

need to formatted to

"data locality ratio: 0.000; virtual segment number: 1; different host number: 1; virtual segment number per host(avg/min/max): (1/1/1); segment size(avg/min/ max): (0.000/0/0); segment size with penalty(avg/min/max): (0.000/0/0); continuity(avg/min/max): (0.000/0.000/0.000)."
