### PR TITLE
HAWQ-116. Default active_statements setting blocks the goh_portals test

### DIFF
--- a/src/test/regress/expected/goh_portals.out
+++ b/src/test/regress/expected/goh_portals.out
@@ -2,6 +2,7 @@
 -- Cursor regression tests
 --
 -- setup
+ALTER RESOURCE QUEUE pg_default WITH (active_statements=30);
 CREATE TABLE test1 (a int, b int, c int, d int);
 CREATE TABLE test2 (a int, b int, c int, d int);
 INSERT INTO test1 SELECT x, 2 * x, 3 * x, 4 * x FROM generate_series(1, 1000) x;
@@ -537,3 +538,4 @@ ROLLBACK;
 -- teardown
 DROP TABLE test1;
 DROP TABLE test2;
+ALTER RESOURCE QUEUE pg_default WITH (active_statements=20);

--- a/src/test/regress/sql/goh_portals.sql
+++ b/src/test/regress/sql/goh_portals.sql
@@ -2,6 +2,8 @@
 -- Cursor regression tests
 --
 -- setup
+ALTER RESOURCE QUEUE pg_default WITH (active_statements=30);
+
 CREATE TABLE test1 (a int, b int, c int, d int);
 CREATE TABLE test2 (a int, b int, c int, d int);
 INSERT INTO test1 SELECT x, 2 * x, 3 * x, 4 * x FROM generate_series(1, 1000) x;
@@ -200,3 +202,5 @@ ROLLBACK;
 -- teardown
 DROP TABLE test1;
 DROP TABLE test2;
+
+ALTER RESOURCE QUEUE pg_default WITH (active_statements=20);


### PR DESCRIPTION
The parallel count is too small to run this test.