### PR TITLE
HAWQ-128. Cleanup pg_resqueue impact in catalog and dump correspondin…

### DIFF
--- a/src/backend/catalog/caql/caqlaccess.c
+++ b/src/backend/catalog/caql/caqlaccess.c
@@ -939,15 +939,6 @@ caql_getattr(cqContext *pCtx, AttrNumber attnum, bool *isnull)
 	Assert(HeapTupleIsValid(pCtx->cq_lasttup));
 
 	return caql_getattr_internal(pCtx, pCtx->cq_lasttup, attnum, isnull);
-
-	/*
-	 * NOTE: could this be used if caql is extended to support joins, eg
-	 * what would attnum be for
-	 * "SELECT * FROM pg_resqueue, pg_resqueuecapability ..." ?
-	 * Potentially, the attnum is just the ordinal position of the combined
-	 * SELECT list, eg you could reference pg_resqueuecapability.restypid
-	 * as (Natts_pg_resqueue+Anum_pg_resourcetype_restypid).
-	 */
 }
 
 /* ----------------------------------------------------------------

--- a/src/backend/catalog/system_views.sql
+++ b/src/backend/catalog/system_views.sql
@@ -371,15 +371,15 @@ CREATE VIEW pg_stat_database AS
             pg_stat_get_db_blocks_hit(D.oid) AS blks_hit 
     FROM pg_database D;
 
-CREATE VIEW pg_stat_resqueues AS
-	SELECT
-		Q.oid AS queueid,
-		Q.rsqname AS queuename,
-		pg_stat_get_queue_num_exec(Q.oid) AS n_queries_exec,
-		pg_stat_get_queue_num_wait(Q.oid) AS n_queries_wait,
-		pg_stat_get_queue_elapsed_exec(Q.oid) AS elapsed_exec,
-		pg_stat_get_queue_elapsed_wait(Q.oid) AS elapsed_wait
-	FROM pg_resqueue AS Q;
+-- CREATE VIEW pg_stat_resqueues AS
+--	SELECT
+--		Q.oid AS queueid,
+--		Q.rsqname AS queuename,
+--		pg_stat_get_queue_num_exec(Q.oid) AS n_queries_exec,
+--		pg_stat_get_queue_num_wait(Q.oid) AS n_queries_wait,
+--		pg_stat_get_queue_elapsed_exec(Q.oid) AS elapsed_exec,
+--		pg_stat_get_queue_elapsed_wait(Q.oid) AS elapsed_wait
+--	FROM pg_resqueue AS Q;
 
 -- Resource queue views
 

--- a/src/backend/resourcemanager/resqueuemanager.c
+++ b/src/backend/resourcemanager/resqueuemanager.c
@@ -860,22 +860,6 @@ int updateResourceQueueAttributes(List 			 	*attributes,
 						 queue->ResourceOvercommit);
 			break;
 
-		case RSQ_DDL_ATTR_NVSEG_UPPER_LIMIT:
-			res = SimpleStringToInt32(attrvalue, &(queue->NVSegUpperLimit));
-			if ( res != FUNC_RETURN_OK )
-			{
-				snprintf(errorbuf, errorbufsize,
-						 "Virtual segment upper limit %s is not valid.",
-						 attrvalue->Str);
-				ELOG_ERRBUF_MESSAGE(WARNING, errorbuf)
-				return res;
-			}
-
-			elog(DEBUG3, "Resource manager updateResourceQueueAttributes() "
-						 "updated virtual segment size upper limit %d",
-						 queue->NVSegUpperLimit);
-			break;
-
 		case RSQ_TBL_ATTR_ALLOCATION_POLICY:
 			res = SimpleStringToMapIndexInt8(
 						attrvalue,
@@ -891,6 +875,67 @@ int updateResourceQueueAttributes(List 			 	*attributes,
 				ELOG_ERRBUF_MESSAGE(WARNING, errorbuf)
 				return res;
 			}
+			break;
+
+		case RSQ_DDL_ATTR_NVSEG_UPPER_LIMIT:
+			res = SimpleStringToInt32(attrvalue, &(queue->NVSegUpperLimit));
+			if ( res != FUNC_RETURN_OK )
+			{
+				snprintf(errorbuf, errorbufsize,
+						 "Virtual segment upper limit %s is not valid.",
+						 attrvalue->Str);
+				ELOG_ERRBUF_MESSAGE(WARNING, errorbuf)
+				return res;
+			}
+
+			elog(DEBUG3, "Resource manager updateResourceQueueAttributes() "
+						 "updated virtual segment size upper limit %d",
+						 queue->NVSegUpperLimit);
+			break;
+		case RSQ_DDL_ATTR_NVSEG_LOWER_LIMIT:
+			res = SimpleStringToInt32(attrvalue, &(queue->NVSegLowerLimit));
+			if ( res != FUNC_RETURN_OK )
+			{
+				snprintf(errorbuf, errorbufsize,
+						 "Virtual segment lower limit %s is not valid.",
+						 attrvalue->Str);
+				ELOG_ERRBUF_MESSAGE(WARNING, errorbuf)
+				return res;
+			}
+
+			elog(DEBUG3, "Resource manager updateResourceQueueAttributes() "
+						 "updated virtual segment size lower limit %d",
+						 queue->NVSegLowerLimit);
+			break;
+		case RSQ_DDL_ATTR_NVSEG_UPPER_LIMIT_PERSEG:
+			res = SimpleStringToDouble(attrvalue, &(queue->NVSegUpperLimitPerSeg));
+			if ( res != FUNC_RETURN_OK )
+			{
+				snprintf(errorbuf, errorbufsize,
+						 "Virtual segment upper limit per segment %s is not valid.",
+						 attrvalue->Str);
+				ELOG_ERRBUF_MESSAGE(WARNING, errorbuf)
+				return res;
+			}
+
+			elog(DEBUG3, "Resource manager updateResourceQueueAttributes() "
+						 "updated virtual segment size upper limit per segment %lf",
+						 queue->NVSegUpperLimitPerSeg);
+			break;
+		case RSQ_DDL_ATTR_NVSEG_LOWER_LIMIT_PERSEG:
+			res = SimpleStringToDouble(attrvalue, &(queue->NVSegLowerLimitPerSeg));
+			if ( res != FUNC_RETURN_OK )
+			{
+				snprintf(errorbuf, errorbufsize,
+						 "Virtual segment lower limit per segment %s is not valid.",
+						 attrvalue->Str);
+				ELOG_ERRBUF_MESSAGE(WARNING, errorbuf)
+				return res;
+			}
+
+			elog(DEBUG3, "Resource manager updateResourceQueueAttributes() "
+						 "updated virtual segment size lower limit per segment %lf",
+						 queue->NVSegLowerLimitPerSeg);
 			break;
 
 		case RSQ_TBL_ATTR_STATUS:

--- a/src/test/regress/expected/validator_function.out
+++ b/src/test/regress/expected/validator_function.out
@@ -20,14 +20,14 @@ REVOKE EXECUTE ON FUNCTION foo() FROM user1;
 COMMIT;
 -- DEBUG info
 SELECT usesuper FROM pg_user WHERE usename = current_user;
- usesuper
+ usesuper 
 ----------
  t
 (1 row)
 
 -- foo() works
 SELECT foo();
- foo
+ foo 
 -----
  t
 (1 row)
@@ -42,9 +42,9 @@ FROM (
   SELECT oid FROM pg_proc
   WHERE proname = 'foo'
 ) AS bar;
- plpgsql_validator
+ plpgsql_validator 
 -------------------
-
+ 
 (1 row)
 
 -- Wrong validator of a different language fails on foo()
@@ -53,7 +53,7 @@ FROM (
   SELECT oid FROM pg_proc
   WHERE proname = 'foo'
 ) AS bar;
-ERROR:  language validation function 2248 called for language 10889 in stead of 10888
+ERROR:  language validation function 2248 called for language 10886 in stead of 10885
 -- --------------------------------------
 -- Cannot run validator on functions to
 -- which user has no privilege to execute
@@ -61,7 +61,7 @@ ERROR:  language validation function 2248 called for language 10889 in stead of 
 SET SESSION AUTHORIZATION user1;
 -- DEBUG info
 SELECT usesuper FROM pg_user WHERE usename = 'user1' AND current_user = 'user1';
- usesuper
+ usesuper 
 ----------
  f
 (1 row)

--- a/src/tools/pgindent/typedefs.list
+++ b/src/tools/pgindent/typedefs.list
@@ -844,7 +844,6 @@ FormData_pg_partition
 FormData_pg_partition_rule
 FormData_pg_pltemplate
 FormData_pg_proc
-FormData_pg_resourcetype
 FormData_pg_resqueue
 FormData_pg_rewrite
 FormData_pg_sequence
@@ -900,7 +899,6 @@ Form_pg_partition
 Form_pg_partition_rule
 Form_pg_pltemplate
 Form_pg_proc
-Form_pg_resourcetype
 Form_pg_resqueue
 Form_pg_rewrite
 Form_pg_sequence

--- a/tools/bin/gpdetective
+++ b/tools/bin/gpdetective
@@ -720,7 +720,7 @@ class GPDetective:
 
         self.writeSelect('pg_stat_resqueue.log',
         '''
-            SELECT * FROM pg_catalog.pg_stat_resqueues            
+            SELECT * FROM pg_catalog.pg_resqueue_status            
         ''')
         
         self.writeSelect('pg_stat_database.log',

--- a/tools/bin/gppylib/gpcatalog.py
+++ b/tools/bin/gppylib/gpcatalog.py
@@ -364,11 +364,9 @@ class GPCatalog():
             
             # MPP-11858: pg_resqueue/pg_resqueuecapability oid inconsistencies
             self._tables['pg_resqueue']._setKnownDifferences("oid")
-            self._tables['pg_resqueuecapability']._setKnownDifferences("oid")
 
             # pg_resqueue is master only in 4.0
             self._tables['pg_resqueue']._setMasterOnly()
-            self._tables['pg_resqueuecapability']._setMasterOnly()
 
 
     def _validate(self):

--- a/tools/bin/lib/gpcheckcat
+++ b/tools/bin/lib/gpcheckcat
@@ -3972,30 +3972,6 @@ def getClassOidForRelfilenode(relfilenode):
         setError(ERROR_NOREPAIR)
         myprint('  Execution error: ' + str(e))
 
-
-#-------------------------------------------------------------------------------
-def getResourceTypeOid(oid):
-    qry = """ 
-          SELECT oid
-          FROM ( 
-               SELECT oid FROM pg_resourcetype WHERE restypid = %d
-               UNION ALL
-               SELECT oid FROM gp_dist_random('pg_resourcetype')
-                WHERE restypid = %d
-          ) alloids
-          GROUP BY oid ORDER BY count(*) desc LIMIT 1
-          """ % (oid, oid)
-
-    try:
-        db = connect()
-        curs = db.query(qry)
-        if len(curs.dictresult()) == 0: return 0
-        return curs.dictresult().pop()['oid']
-    except Exception, e:
-        setError(ERROR_NOREPAIR)
-        myprint('  Execution error: ' + str(e))
-
-  
 #-------------------------------------------------------------------------------
 # Process results of tests (CC and FK) for a particular catalog:
 #   - Categorize entry into GPObject
@@ -4158,12 +4134,9 @@ def processForeignKeyResult(catname, pkcatname, colname, allValues):
 
         # Special cases:
         #    1. pg_class(oid) referencing pg_type(oid) - relation & composite type
-        #    2. pg_resqueuecapability(restypid) referencing pg_resourcetype(restypid)
         if pkcatname == 'pg_type' and fkeytab == 'pg_class':
             rowObjName = 'pg_class'
             oid = getOidFromPK(rowObjName, fkeys)
-        elif pkcatname == 'pg_resourcetype' and gpColName == 'restypid':
-            oid = getResourceTypeOid(oid)
         gpObj = getGPObject(oid, rowObjName)
         gpObj.setForeignKeyIssue(issue)
 


### PR DESCRIPTION
1) Make pg_dumpall able to dump resource queue DDL statments. Support building tree structured resource queues from pg_dumpall output.

2) pg_stat_resqueues() is expired, pg_resqueue_status can provide the same information.

postgres=# select * from pg_resqueue_status;
  rsqname   | segmem | segcore  | segsize | segsizemax | inusemem | inusecore | rsqholders | rsqwaiters | paused
------------+--------+----------+---------+------------+----------+-----------+------------+------------+--------
 pg_root    | 128    | 0.062500 | 64      | 64         | 0        | 0.000000  | 0          | 0          | F
 pg_default | 128    | 0.062500 | 32      | 64         | 0        | 0.000000  | 0          | 0          | F
(2 rows)

3) Removed some legacy code referencing pg_resourcetype and pg_resqueuecapability.