### PR TITLE
HAWQ-131. check hawq_rm_rejectrequest_nseg_limit should use > instead…

### DIFF
--- a/src/backend/resourcemanager/requesthandler.c
+++ b/src/backend/resourcemanager/requesthandler.c
@@ -358,7 +358,7 @@ bool handleRMRequestAcquireResource(void **arg)
 
 	/* Check if HAWQ has enough alive segments. */
 	int unavailcount = PRESPOOL->SlavesHostCount - PRESPOOL->AvailNodeCount;
-	if ( unavailcount >= rm_rejectrequest_nseg_limit )
+	if ( unavailcount > rm_rejectrequest_nseg_limit )
 	{
 		elog(WARNING, "Resource manager finds %d segments not available yet, all "
 					  "resource allocation requests are rejected.",


### PR DESCRIPTION
This is bug fix to make logic of checking hawq_rm_rejectrequest_nseg_limit keep align with logic of checking hawq_rm_rejectrequest_nseg_limit.