### PR TITLE
HAWQ-135. Fixed coredump when explain generate_serial in optimizer off

### DIFF
--- a/src/backend/cdb/cdbllize.c
+++ b/src/backend/cdb/cdbllize.c
@@ -269,6 +269,11 @@ cdbparallelize(PlannerInfo *root,
 		Assert(root->parse == query);
 		plan = apply_motion(root, plan, query);
 	}
+    else
+    {
+        //default to sequential
+        plan->dispatch = DISPATCH_SEQUENTIAL;
+    }
 
 
 	/* Restore the global count of PARAM_EXEC from the top plan node. */


### PR DESCRIPTION
Need to set query as  DISPATCH_SEQUENTIAL when legacy query optimizer doesn't set it as DISPATCH_PARALLEL.