### PR TITLE
HAWQ-136. Uneven resource allocation request caused queuing queries u…

### DIFF
--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -6334,7 +6334,7 @@ static struct config_int ConfigureNamesInt[] =
 			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&rm_log_level,
-		DEBUG5, DEBUG5, NOTICE, NULL, NULL
+		DEBUG3, DEBUG5, NOTICE, NULL, NULL
 	},
 
 	{


### PR DESCRIPTION
This fix is to make resource manager always acquire GRM containers (YARN for example) to make HAWQ acquried GRM resource evenly dispatched in the whole cluster. This may cause more resource acquired from GRM(YARN etc.)

If resource manager wants more resource, it always try to level up the minimum water level of the whole cluster HAWQ acquired resource.