### PR TITLE
HAWQ-97. Optimizing metadata versioning event generation

### DIFF
--- a/src/backend/utils/cache/inval.c
+++ b/src/backend/utils/cache/inval.c
@@ -389,7 +389,6 @@ AddVersioningEventMessage(InvalidationListHeader *hdr, mdver_event *mdev)
 	/* Check for last event in the queue. If we're trying to add a nuke, and it's already nuke, skip it */
 	if (MdVer_IsRedundantNukeEvent(hdr, mdev))
 	{
-		elog(gp_mdversioning_loglevel, "Adding nuke event to XVQ when the last added is already nuke. Skipping.");
 		return;
 	}
 

--- a/src/backend/utils/cache/inval.c
+++ b/src/backend/utils/cache/inval.c
@@ -1519,7 +1519,7 @@ MdVer_PreProcessInvalidMsgs(InvalidationListHeader *dest,
 		/* 1. Move messages to the beginning of the chunk */
 		for (int i = last_good_index; i < last_good_chunk->nitems; i++)
 		{
-			last_good_chunk[i - last_good_index] = last_good_chunk[i];
+			last_good_chunk->msgs[i - last_good_index] = last_good_chunk->msgs[i];
 		}
 		/* 2. Update nitems value */
 		last_good_chunk->nitems = last_good_chunk->nitems - last_good_index;

--- a/src/backend/utils/cache/test/Makefile
+++ b/src/backend/utils/cache/test/Makefile
@@ -32,7 +32,8 @@ inval_REAL_OBJS=\
         $(top_srcdir)/src/port/thread.o \
         $(top_srcdir)/src/timezone/localtime.o \
         $(top_srcdir)/src/timezone/strftime.o \
-        $(top_srcdir)/src/timezone/pgtz.o
+        $(top_srcdir)/src/timezone/pgtz.o \
+        $(top_srcdir)/src/backend/utils/mdver/mdver_dep_translator.o
 
 include ../../../../Makefile.mock
 

--- a/src/backend/utils/cache/test/inval_test.c
+++ b/src/backend/utils/cache/test/inval_test.c
@@ -218,8 +218,7 @@ void test__MdVer_IsRedundantNukeEvent__chunks(void **state)
 	 * chunk, so we don't have to add more messages to it. Just test that we
 	 * correctly skip over it. */
 	InvalidationChunk *second_chunk = (InvalidationChunk *)
-								MemoryContextAlloc(CurTransactionContext,
-										sizeof(InvalidationChunk) +
+								palloc0(sizeof(InvalidationChunk) +
 										(FIRSTCHUNKSIZE - 1) *sizeof(SharedInvalidationMessage));
 	second_chunk->nitems = 0;
 	second_chunk->maxitems = FIRSTCHUNKSIZE;
@@ -248,6 +247,121 @@ void test__MdVer_IsRedundantNukeEvent__chunks(void **state)
 	assert_false(result);
 }
 
+/* ==================== MdVer_PreProcessInvalidMsgs ==================== */
+/*
+ *
+ */
+
+static InvalidationListHeader *
+create_list_one_chunk(void) {
+	InvalidationListHeader *hdr = (InvalidationListHeader *) palloc0(sizeof(InvalidationListHeader));
+
+	/* Create a chunk */
+	InvalidationChunk *first_chunk = (InvalidationChunk *)
+					palloc0(sizeof(InvalidationChunk) +
+							(FIRSTCHUNKSIZE - 1) *sizeof(SharedInvalidationMessage));
+
+	first_chunk->nitems = 0;
+	first_chunk->maxitems = FIRSTCHUNKSIZE;
+	first_chunk->next = NULL;
+
+	hdr->velist = first_chunk;
+	return hdr;
+}
+
+static void add_event_to_chunk(InvalidationChunk *chunk, bool is_nuke, int key) {
+
+	/* Create a message */
+	SharedInvalidationMessage msg;
+	msg.ve.id = SHAREDVERSIONINGMSG_ID;
+	msg.ve.local = true;
+	if (is_nuke)
+	{
+		msg.ve.verEvent.key = MDVER_NUKE_KEY;
+		msg.ve.verEvent.old_ddl_version = 0;
+		msg.ve.verEvent.old_dml_version = 0;
+		msg.ve.verEvent.new_ddl_version = 0;
+		msg.ve.verEvent.new_dml_version = 0;
+	}
+	else
+	{
+		msg.ve.verEvent.key = key;
+		msg.ve.verEvent.old_ddl_version = key + 1;
+		msg.ve.verEvent.old_dml_version = key + 2;
+		msg.ve.verEvent.new_ddl_version = key + 3;
+		msg.ve.verEvent.new_dml_version = key + 4;
+	}
+
+	chunk->msgs[chunk->nitems++] = msg;
+}
+
+/* Test that when appending a list with no nukes to dest, nothing changes */
+void test__MdVer_PreProcessInvalidMsgs__no_nuke(void **state)
+{
+	InvalidationListHeader* dest = create_list_one_chunk();
+	add_event_to_chunk(dest->velist, false /* is_nuke */, 100 /* key */);
+
+	InvalidationListHeader *src = create_list_one_chunk();
+	add_event_to_chunk(src->velist, false /* is_nuke */, 200 /* key */);
+	add_event_to_chunk(src->velist, false /* is_nuke */, 210 /* key */);
+
+	MdVer_PreProcessInvalidMsgs(dest, src);
+
+	assert_int_equal(dest->velist->nitems, 1);
+	assert_int_equal(dest->velist->msgs[0].ve.verEvent.key, 100);
+
+	assert_int_equal(src->velist->nitems, 2);
+	assert_int_equal(src->velist->msgs[0].ve.verEvent.key, 200);
+	assert_int_equal(src->velist->msgs[1].ve.verEvent.key, 210);
+
+}
+
+/* Test that when appending a list with a nuke in first chunk, dest gets updated */
+void test__MdVer_PreProcessInvalidMsgs__nuke_first_chunk(void **state)
+{
+	InvalidationListHeader* dest = create_list_one_chunk();
+	add_event_to_chunk(dest->velist, false /* is_nuke */, 100 /* key */);
+
+	InvalidationListHeader *src = create_list_one_chunk();
+	add_event_to_chunk(src->velist, false /* is_nuke */, 200 /* key */);
+	add_event_to_chunk(src->velist, true /* is_nuke */, 210 /* key */);
+	add_event_to_chunk(src->velist, false /* is_nuke */, 220 /* key */);
+	add_event_to_chunk(src->velist, true /* is_nuke */, 230 /* key */);
+	add_event_to_chunk(src->velist, true /* is_nuke */, 240 /* key */);
+	add_event_to_chunk(src->velist, false /* is_nuke */, 250 /* key */);
+	/* src now is: 200->nuke->220->nuke->nuke->250 */
+
+	MdVer_PreProcessInvalidMsgs(dest, src);
+
+	/* After processing, we should have:
+	 *    src: null
+	 *    dest: nuke->250
+	 */
+	assert_int_equal(dest->velist->nitems, 2);
+	assert_int_equal(dest->velist->msgs[0].ve.verEvent.key, MDVER_NUKE_KEY);
+	assert_int_equal(dest->velist->msgs[1].ve.verEvent.key, 250);
+
+	assert_true(NULL == src->velist);
+}
+
+/* Test that when appending a list with a nuke in first chunk, dest gets updated */
+void test__MdVer_PreProcessInvalidMsgs__nuke_second_chunk(void **state)
+{
+	InvalidationListHeader* dest = create_list_one_chunk();
+	add_event_to_chunk(dest->velist, false /* is_nuke */, 100 /* key */);
+
+	InvalidationListHeader *src = create_list_one_chunk();
+	add_event_to_chunk(src->velist, false /* is_nuke */, 200 /* key */);
+	add_event_to_chunk(src->velist, true /* is_nuke */, 210 /* key */);
+	add_event_to_chunk(src->velist, false /* is_nuke */, 220 /* key */);
+	add_event_to_chunk(src->velist, true /* is_nuke */, 230 /* key */);
+	add_event_to_chunk(src->velist, true /* is_nuke */, 240 /* key */);
+	add_event_to_chunk(src->velist, false /* is_nuke */, 250 /* key */);
+	/* src now is: 200->nuke->220->nuke->nuke->250 */
+
+
+}
+
 int
 main(int argc, char* argv[]) {
 	cmockery_parse_arguments(argc, argv);
@@ -260,7 +374,10 @@ main(int argc, char* argv[]) {
 			unit_test(test__InvalidateSystemCaches__resets_mdvsn_disabled),
 			unit_test(test__InvalidateSystemCaches__resets_mdvsn_no_xact),
 			unit_test(test__MdVer_IsRedundantNukeEvent__no_action),
-			unit_test(test__MdVer_IsRedundantNukeEvent__chunks)
+			unit_test(test__MdVer_IsRedundantNukeEvent__chunks),
+			unit_test(test__MdVer_PreProcessInvalidMsgs__no_nuke),
+			unit_test(test__MdVer_PreProcessInvalidMsgs__nuke_first_chunk),
+			unit_test(test__MdVer_PreProcessInvalidMsgs__nuke_second_chunk)
 	};
 	return run_tests(tests);
 }

--- a/src/backend/utils/cache/test/inval_test.c
+++ b/src/backend/utils/cache/test/inval_test.c
@@ -135,6 +135,10 @@ void test__InvalidateSystemCaches__resets_mdvsn_no_xact(void **state)
 
 
 /* Helper functions for the MdVer queue pre-processing */
+
+/*
+ * Creates a new invalidation list, and adds a new empty chunk to it
+ */
 static InvalidationListHeader *
 create_list_one_chunk(void) {
 	InvalidationListHeader *hdr = (InvalidationListHeader *) palloc0(sizeof(InvalidationListHeader));
@@ -152,7 +156,13 @@ create_list_one_chunk(void) {
 	return hdr;
 }
 
-static void add_event_to_chunk(InvalidationChunk *chunk, bool is_nuke, int key) {
+/*
+ * Adds a new event to an existing InvalidationChunk.
+ * If is_nuke is true, adds a nuke event. Otherwise, uses the given key
+ * to populate the event fields.
+ */
+static void
+add_event_to_chunk(InvalidationChunk *chunk, bool is_nuke, int key) {
 
 	/* Create a message */
 	SharedInvalidationMessage msg;

--- a/src/backend/utils/mdver/mdver_dep_translator.c
+++ b/src/backend/utils/mdver/mdver_dep_translator.c
@@ -23,9 +23,6 @@
 #include "catalog/pg_operator.h"
 #include "catalog/pg_aggregate.h"
 
-/* We use Oid = InvalidOid to signal that it's a NUKE event */
-#define MDVER_NUKE_KEY InvalidOid
-
 static void mdver_dt_add_cache_events(List **events);
 static mdver_event *mdver_new_nuke_event(void);
 static void mdver_add_nuke_event(List **events);

--- a/src/backend/utils/mdver/mdver_dep_translator.c
+++ b/src/backend/utils/mdver/mdver_dep_translator.c
@@ -28,6 +28,7 @@
 
 static void mdver_dt_add_cache_events(List **events);
 static mdver_event *mdver_new_nuke_event(void);
+static void mdver_add_nuke_event(List **events);
 
 /*
  * Generate all the invalidation messages caused by updating a tuple in a catalog table
@@ -78,7 +79,7 @@ mdver_dt_catcache_inval(Relation relation, HeapTuple tuple, SysCacheInvalidateAc
 	case SysCacheInvalidate_Update_InPlace:
 		/* fall through */
 	case SysCacheInvalidate_VacuumMove:
-		events = lappend(events, mdver_new_nuke_event());
+		mdver_add_nuke_event(&events);
 		break;
 	default:
 		insist_log(false, "Unkown syscache invalidation operation");
@@ -90,6 +91,26 @@ mdver_dt_catcache_inval(Relation relation, HeapTuple tuple, SysCacheInvalidateAc
 	{
 		mdver_dt_add_cache_events(&events);
 	}
+}
+
+/*
+ * Add a new nuke event to the list of events generated.
+ * Avoid adding consecutive nuke events since they are composable.
+ */
+static void
+mdver_add_nuke_event(List **events)
+{
+	/* Don't append a nuke if the last event in the queue is already a nuke */
+	if (NIL != *events) {
+		ListCell *tail = list_tail(*events);
+		mdver_event *last_event = lfirst(tail);
+		if (mdver_is_nuke_event(last_event)) {
+			return;
+		}
+	}
+
+	/* Last event is not nuke, or events was empty. Append to queue */
+	*events = lappend(*events, mdver_new_nuke_event());
 }
 
 /*

--- a/src/backend/utils/mdver/test/Makefile
+++ b/src/backend/utils/mdver/test/Makefile
@@ -1,0 +1,38 @@
+top_builddir=../../../../..
+subdir=src/backend/utils/mdver
+
+TARGETS=mdver_dep_translator
+
+mdver_dep_translator_REAL_OBJS=\
+		$(top_srcdir)/src/backend/access/hash/hashfunc.o \
+        $(top_srcdir)/src/backend/bootstrap/bootparse.o \
+        $(top_srcdir)/src/backend/lib/stringinfo.o \
+        $(top_srcdir)/src/backend/nodes/bitmapset.o \
+        $(top_srcdir)/src/backend/nodes/equalfuncs.o \
+        $(top_srcdir)/src/backend/nodes/list.o \
+        $(top_srcdir)/src/backend/parser/gram.o \
+        $(top_srcdir)/src/backend/regex/regcomp.o \
+        $(top_srcdir)/src/backend/regex/regerror.o \
+        $(top_srcdir)/src/backend/regex/regexec.o \
+        $(top_srcdir)/src/backend/regex/regfree.o \
+        $(top_srcdir)/src/backend/storage/page/itemptr.o \
+        $(top_srcdir)/src/backend/utils/adt/datum.o \
+        $(top_srcdir)/src/backend/utils/adt/like.o \
+        $(top_srcdir)/src/backend/utils/hash/dynahash.o \
+        $(top_srcdir)/src/backend/utils/hash/hashfn.o \
+        $(top_srcdir)/src/backend/utils/mb/mbutils.o \
+        $(top_srcdir)/src/backend/utils/mb/wchar.o \
+        $(top_srcdir)/src/backend/utils/misc/guc.o \
+        $(top_srcdir)/src/backend/utils/init/globals.o \
+        $(top_srcdir)/src/port/pgsleep.o \
+        $(top_srcdir)/src/port/path.o \
+        $(top_srcdir)/src/port/pgstrcasecmp.o \
+        $(top_srcdir)/src/port/qsort.o \
+        $(top_srcdir)/src/port/strlcpy.o \
+        $(top_srcdir)/src/port/thread.o \
+        $(top_srcdir)/src/timezone/localtime.o \
+        $(top_srcdir)/src/timezone/strftime.o \
+        $(top_srcdir)/src/timezone/pgtz.o
+
+include ../../../../Makefile.mock
+

--- a/src/backend/utils/mdver/test/mdver_dep_translator_test.c
+++ b/src/backend/utils/mdver/test/mdver_dep_translator_test.c
@@ -1,0 +1,88 @@
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include "cmockery.h"
+
+#include "c.h"
+#include "postgres.h"
+
+#include "../mdver_dep_translator.c"
+
+
+/* ==================== mdver_add_nuke_event ==================== */
+/*
+ * Tests that mdver_add_nuke_event doesn't do anything when passed
+ * a NIL event list
+ */
+void test__mdver_add_nuke_event_nil(void **state)
+{
+	List *events = NIL;
+	mdver_add_nuke_event(&events);
+}
+
+/*
+ * Tests that mdver_add_nuke_event adds an event when the last
+ * event is not nuke
+ */
+void test__mdver_add_nuke_event_no_nuke(void **state)
+{
+
+	/* Create an empty list of events */
+	List *events = NIL;
+
+	/* Let's create some non-nuke event and add it to the list */
+	mdver_event *mdev = (mdver_event *) palloc0(sizeof(mdver_event));
+	mdev->key = 100;
+	mdev->new_ddl_version = 1;
+	mdev->new_dml_version = 2;
+	events = lappend(events, mdev);
+
+	/* Now add a nuke event */
+	mdver_add_nuke_event(&events);
+
+	/* Adding the nuke increased the length, it should be 2 */
+	assert_int_equal(2 /* length */, length(events));
+
+}
+
+/*
+ * Tests that mdver_add_nuke_event adds an event when the last
+ * event is not nuke
+ */
+void test__mdver_add_nuke_event_after_nuke(void **state)
+{
+	/* Create an empty list of events */
+	List *events = NIL;
+
+	/* Let's create some non-nuke event and add it to the list */
+	mdver_event *mdev = (mdver_event *) palloc0(sizeof(mdver_event));
+	mdev->key = 100;
+	mdev->new_ddl_version = 1;
+	mdev->new_dml_version = 2;
+	events = lappend(events, mdev);
+
+	/* Create a nuke event and add it to the list */
+	mdev =  (mdver_event *) palloc0(sizeof(mdver_event));
+	mdev->key = MDVER_NUKE_KEY;
+	events = lappend(events, mdev);
+
+	/* Now add a nuke event */
+	mdver_add_nuke_event(&events);
+
+	/* Adding the nuke shouldn't have changed the length - it's still 2 */
+	assert_int_equal(2 /* length */, length(events));
+}
+
+int
+main(int argc, char* argv[]) {
+	cmockery_parse_arguments(argc, argv);
+
+	const UnitTest tests[] = {
+			unit_test(test__mdver_add_nuke_event_nil),
+			unit_test(test__mdver_add_nuke_event_no_nuke),
+			unit_test(test__mdver_add_nuke_event_after_nuke)
+	};
+	return run_tests(tests);
+}
+
+

--- a/src/include/utils/mdver.h
+++ b/src/include/utils/mdver.h
@@ -17,6 +17,9 @@
 
 #define INVALID_MD_VERSION 0
 
+/* We use Oid = InvalidOid to signal that it's a NUKE event */
+#define MDVER_NUKE_KEY InvalidOid
+
 typedef struct mdver_entry
 {
 	Oid key; /* Key of the versioned entry */


### PR DESCRIPTION
A DDL command usually generates more than one Nuke Versioning event during its execution. All these nuke events are then pushed to Shared Versioning Queue (SVQ) at commit, and then all of them get propagated to other backends. 

This is extra work and it can be optimized. We should push only one Nuke VE instead of several.

Also, when moving messages from the Current Command Invalidation Queue (CVQ) to the Prior Command Invalidation Queue (XVQ), pre-process the event queue to eliminate any events that will have no effect. If a versioning event is followed by a nuke event, it will have no effect.
 Moreover, when a nuke event is moved to XVQ, everything prior in XVQ will  also have no effect.
 
Solution is  to look for Nuke events in CVQ. Find the last one (in the order of creation), then move all messages from then on to XVQ, overwriting XVQ.
