### PR TITLE
HAWQ-123. Add 'Partition by' description in psql

### DIFF
--- a/src/bin/psql/describe.c
+++ b/src/bin/psql/describe.c
@@ -2704,7 +2704,7 @@ add_partition_by_footer(const char* oid, PQExpBufferData *inoutbuf, PQExpBufferD
 
 	PQclear(result);
 
-	if(nRows)
+	if (nRows)
 	{
 		/* query partition key on the root partition */
 		printfPQExpBuffer(buf,
@@ -2748,7 +2748,10 @@ add_partition_by_footer(const char* oid, PQExpBufferData *inoutbuf, PQExpBufferD
 			partColName = PQgetvalue(result, i, 0);
 
 			if (!partColName)
+			{
+				resetPQExpBuffer(inoutbuf);
 				return 1;
+			}
 			appendPQExpBuffer(inoutbuf, "%s", partColName);
 		}
 		appendPQExpBuffer(inoutbuf, ")");


### PR DESCRIPTION
When user runs \d or \d+ on a partition table, it will display partition
keys on the current level for the partition table with the clause of
'Partition by: (partition_key_1, ..., partition_key_n)' after
'Distributed by' clause. But if user runs \d or \d+ on a non-partition
table or leaf level partition table, the 'Partition by' clause will not
be displayed.

Haisheng Yuan