### PR TITLE
HAWQ-94. Handle one case when reaching EOF for AO large tuple

### DIFF
--- a/src/backend/cdb/cdbappendonlystorageread.c
+++ b/src/backend/cdb/cdbappendonlystorageread.c
@@ -718,7 +718,7 @@ AppendOnlyStorageRead_PositionToNextBlock(
 	else
 		*blockLimitLen = storageRead->maxBufferLen;
 
-	return true;
+	return (*blockLimitLen > 0);
 }
 
 


### PR DESCRIPTION
When *blockLimitLen = 0, we should return false to indicate this is the end of file.