### PR TITLE
Hawq 142

### DIFF
--- a/contrib/pgcrypto/Makefile
+++ b/contrib/pgcrypto/Makefile
@@ -47,7 +47,7 @@ else
 subdir = contrib/pgcrypto
 top_builddir = ../..
 include $(top_builddir)/src/Makefile.global
-include $(top_builddir)/../build-utils/makefiles/gppkg.mk
+include $(top_builddir)/contrib/contrib-global.mk
 endif
 
 # Add libraries that pgcrypto depends (or might depend) on into the

--- a/contrib/pgcrypto/Makefile
+++ b/contrib/pgcrypto/Makefile
@@ -47,6 +47,7 @@ else
 subdir = contrib/pgcrypto
 top_builddir = ../..
 include $(top_builddir)/src/Makefile.global
+include $(top_builddir)/../build-utils/makefiles/gppkg.mk
 endif
 
 # Add libraries that pgcrypto depends (or might depend) on into the

--- a/contrib/pgcrypto/internal.c
+++ b/contrib/pgcrypto/internal.c
@@ -583,10 +583,8 @@ px_find_digest(const char *name, PX_MD **res)
 	PX_MD	   *h;
 
 	for (p = int_digest_list; p->name; p++)
-		if (pg_strcasecmp(p->name, name) == 0)
 	{
-		if (fips_mode && !p->fips)
-			continue;
+		if (pg_strcasecmp(p->name, name) == 0)
 		{
 			h = px_alloc(sizeof(*h));
 			p->init(h);

--- a/contrib/pgcrypto/openssl.c
+++ b/contrib/pgcrypto/openssl.c
@@ -862,7 +862,7 @@ static PX_Alias ossl_aliases[] = {
 	{"rijndael", "aes-cbc"},
 	{"rijndael-cbc", "aes-cbc"},
 	{"rijndael-ecb", "aes-ecb"},
-	{NULL}
+	{NULL, NULL}
 };
 
 static const struct ossl_cipher ossl_bf_cbc = {
@@ -954,27 +954,17 @@ px_find_cipher(const char *name, PX_Cipher **res)
 	ossldata   *od;
 
 	name = px_resolve_alias(ossl_aliases, name);
-	if (fips_mode)
-	{
-		if (!strcmp(name, fips_crypto_algo_str))
-	 		return PXE_NOT_ALLOWED_FIPS;
-	}
 
 	for (i = ossl_cipher_types; i->name; i++)
 		if (!strcmp(i->name, name))
 			break;
+
 	if (i->name == NULL)
 		return PXE_NO_CIPHER;
 
 	od = px_alloc(sizeof(*od));
 	memset(od, 0, sizeof(*od));
 	od->ciph = i->ciph;
-
-	if (fips_mode)
-	{
-		if (!i->fips)
-			return PXE_NOT_ALLOWED_FIPS;
-	}
 
 	c = px_alloc(sizeof(*c));
 	c->block_size = gen_ossl_block_size;

--- a/contrib/pgcrypto/pgcrypto.c
+++ b/contrib/pgcrypto/pgcrypto.c
@@ -138,11 +138,6 @@ pg_gen_salt(PG_FUNCTION_ARGS)
 	text	   *res;
 	char		buf[PX_MAX_SALT_LEN + 1];
 
-	if (fips_mode)
-		ereport(ERROR,
-				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-				 errmsg("gen_salt is insecure in fips mode")));
-
 	arg0 = PG_GETARG_TEXT_P(0);
 
 	len = VARSIZE(arg0) - VARHDRSZ;
@@ -175,11 +170,6 @@ pg_gen_salt_rounds(PG_FUNCTION_ARGS)
 	int			len;
 	text	   *res;
 	char		buf[PX_MAX_SALT_LEN + 1];
-
-	if (fips_mode)
-	 	ereport(ERROR,
-	 			(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-	 			errmsg("gen_salt is insecure in fips mode")));
 
 	arg0 = PG_GETARG_TEXT_P(0);
 	rounds = PG_GETARG_INT32(1);
@@ -219,11 +209,6 @@ pg_crypt(PG_FUNCTION_ARGS)
 			   *cres,
 			   *resbuf;
 	text	   *res;
-
-	if (fips_mode)
-	 	ereport(ERROR,
-	 			(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-	 			errmsg("gen_salt is insecure in fips mode")));
 
 	arg0 = PG_GETARG_TEXT_P(0);
 	arg1 = PG_GETARG_TEXT_P(1);

--- a/contrib/pgcrypto/pgp-pubenc.c
+++ b/contrib/pgcrypto/pgp-pubenc.c
@@ -199,13 +199,15 @@ pgp_write_pubenc_sesskey(PGP_Context *ctx, PushFilter *dst)
 	PGP_PubKey *pk = ctx->pub_key;
 	uint8		ver = 3;
 	PushFilter *pkt = NULL;
-	uint8		algo = pk->algo;
+	uint8		algo;
 
 	if (pk == NULL)
 	{
 		px_debug("no pubkey?\n");
 		return PXE_BUG;
 	}
+
+	algo = pk->algo;
 
 	/*
 	 * now write packet

--- a/contrib/pgcrypto/pgp.c
+++ b/contrib/pgcrypto/pgp.c
@@ -35,8 +35,6 @@
 #include "mbuf.h"
 #include "pgp.h"
 
-#include "postmaster/postmaster.h"
-
 /*
  * Defaults.
  */
@@ -109,15 +107,8 @@ pgp_get_digest_code(const char *name)
 	const struct digest_info *i;
 
 	for (i = digest_list; i->name; i++)
-	{
 		if (pg_strcasecmp(i->name, name) == 0)
-		{
-			if (fips_mode && !i->fips)
-				return PXE_NOT_ALLOWED_FIPS;
-			else
-				return i->code;
-		}
-	}
+			return i->code;
 	return PXE_PGP_UNSUPPORTED_HASH;
 }
 
@@ -127,15 +118,8 @@ pgp_get_cipher_code(const char *name)
 	const struct cipher_info *i;
 
 	for (i = cipher_list; i->name; i++)
-	{
 		if (pg_strcasecmp(i->name, name) == 0)
-		{
-			if (fips_mode && !i->fips)
-				return PXE_NOT_ALLOWED_FIPS;
-			else
-				return i->code;
-		}
-	}
+			return i->code;
 	return PXE_PGP_UNSUPPORTED_CIPHER;
 }
 

--- a/contrib/pgcrypto/px.c
+++ b/contrib/pgcrypto/px.c
@@ -113,12 +113,7 @@ px_resolve_alias(const PX_Alias *list, const char *name)
 	while (list->name)
 	{
 		if (pg_strcasecmp(list->alias, name) == 0)
-		{
-			if (fips_mode && !list->fips)
-				return fips_crypto_algo_str;
-			else
-				return list->name;
-		}
+			return list->name;
 		list++;
 	}
 	return name;

--- a/src/backend/libpq/crypt.c
+++ b/src/backend/libpq/crypt.c
@@ -33,7 +33,6 @@ hash_password(const char *passwd, char *salt, size_t salt_len, char *buf)
 		case PASSWORD_HASH_MD5:
 			return pg_md5_encrypt(passwd, salt, salt_len, buf);
 		case PASSWORD_HASH_SHA_256:
-		case PASSWORD_HASH_SHA_256_FIPS:
 			return pg_sha256_encrypt(passwd, salt, salt_len, buf);
 			break;
 		default:

--- a/src/backend/libpq/pg_sha2.c
+++ b/src/backend/libpq/pg_sha2.c
@@ -48,18 +48,6 @@ pg_sha256_encrypt(const char *pass, char *salt, size_t salt_len,
 	memcpy(target + passwd_len, salt, salt_len);
 	target[passwd_len + salt_len] = '\0';
 
-	/* 
-	 * Users might require a FIPS compliant implementation. They can specify
-	 * this by setting the password_hash_algorithm  GUC to SHA-256-FIPS.
-	 */
-	if (password_hash_algorithm == PASSWORD_HASH_SHA_256_FIPS && !fips_mode)
-	{
-		ereport(ERROR,
-				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-				 errmsg("FIPS certified SHA-256 is not enabled"),
-				 errhint("Use fips_mode=on setting to enable")));
-	}
-
 	SHA256_Init(&ctx);
 	SHA256_Update(&ctx, (uint8 *)target, passwd_len + salt_len);
 	SHA256_Final(digest, &ctx);

--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -257,7 +257,6 @@ static int	SendStop = false;
 
 /* still more option variables */
 bool		EnableSSL = false;
-bool		fips_mode = false;
 bool		SilentMode = false; /* silent_mode */
 
 int			PreAuthDelay = 0;

--- a/src/backend/utils/misc/postgresql.conf.sample
+++ b/src/backend/utils/misc/postgresql.conf.sample
@@ -68,7 +68,6 @@
 
 #authentication_timeout = 1min		# 1s-600s
 #ssl = off				# (change requires restart)
-#fips_mode = off			# use OpenSSL FIPS mode.
 #ssl_ciphers = 'ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH'	# allowed SSL ciphers
 					# (change requires restart)
 #password_encryption = on

--- a/src/include/libpq/password_hash.h
+++ b/src/include/libpq/password_hash.h
@@ -23,8 +23,7 @@ typedef enum
 {
 	PASSWORD_HASH_NONE = 0,
 	PASSWORD_HASH_MD5,
-	PASSWORD_HASH_SHA_256,
-	PASSWORD_HASH_SHA_256_FIPS
+	PASSWORD_HASH_SHA_256
 } PasswdHashAlg;
 
 extern PasswdHashAlg password_hash_algorithm;

--- a/src/include/postmaster/postmaster.h
+++ b/src/include/postmaster/postmaster.h
@@ -15,7 +15,6 @@
 
 /* GUC options */
 extern bool EnableSSL;
-extern PGDLLIMPORT bool fips_mode;
 extern bool SilentMode;
 extern int	ReservedBackends;
 extern int	PostPortNumber;


### PR DESCRIPTION
This fix is to remove fips mode. OpenSSL's FIPS mode is not stable, and not easy to maintain. 