### PR TITLE
HAWQ-152. Pass validation test in resource manager for unexactly divi…

### DIFF
--- a/src/backend/resourcemanager/resourcepool.c
+++ b/src/backend/resourcemanager/resourcepool.c
@@ -3323,12 +3323,14 @@ void validateResourcePoolStatus(bool refquemgr)
 			}
 
 			/* Validation 2. The ratio should be correct. */
+			double r1 = alloccore == 0 ? 0 : allocmem/alloccore;
+			double r2 = availcore == 0 ? 0 : availmem/availcore;
 			if ( (allocmem == 0 && alloccore != 0) ||
 				 (allocmem != 0 && alloccore == 0) ||
 				 (availmem == 0 && availcore != 0) ||
 				 (availmem != 0 && availcore == 0) ||
 				 (alloccore != 0 && availcore != 0 &&
-				  trunc(allocmem/alloccore) != trunc(availmem/availcore)))
+				  2 * fabs(r1-r2) / (r1 + r2) > 0.005) )
 			{
 				elog(ERROR, "HAWQ RM Validation. Wrong resource counter ratio. "
 							"Host %s. "
@@ -3414,7 +3416,8 @@ void validateResourcePoolStatus(bool refquemgr)
 						PQUEMGR->RatioTrackers[0]->TotalAllocated.Core);
 		}
 
-		if ( totalavailmem > totalallocmem || totalavailcore > totalalloccore )
+		if ( totalavailmem > totalallocmem ||
+			 totalavailcore > totalalloccore * 1.0001 )
 		{
 				elog(ERROR, "HAWQ RM Validation. Wrong total allocated resource. "
 							"In resource pool available (%d MB, %lf CORE), "


### PR DESCRIPTION
unexactly divisible mem core ratio can lead to some small biases in the counters in resource pool. This code fix is to make internal validation logic tolerate this case.