### PR TITLE
HAWQ-156. Fix hd_work_mgr unit tests.

### DIFF
--- a/src/backend/access/external/test/hd_work_mgr_mock.c
+++ b/src/backend/access/external/test/hd_work_mgr_mock.c
@@ -26,57 +26,21 @@
 #include "hd_work_mgr_mock.h"
 
 /*
- * Helper functions to create and restore GpAliveSegmentsInfo.cdbComponentDatabases element
+ * Helper functions to create and free QueryResource element
  * used by hd_work_mgr
  */
 
-/*
- * Builds an array of CdbComponentDatabaseInfo.
+/* Builds the QueryResource for a query.
  * Each segment is assigned a sequence number and an ip.
  * segs_num - the number of segments
  * segs_hostips - array of the ip of each segment
- * primaries_map - array of which segments are primaries
  */
-void buildCdbComponentDatabases(int segs_num,
-								char* segs_hostips[],
-								bool primaries_map[])
-{
-	CdbComponentDatabases *test_cdb = palloc0(sizeof(CdbComponentDatabases));
-	CdbComponentDatabaseInfo* component = NULL;
-	test_cdb->total_segment_dbs = segs_num;
-	test_cdb->segment_db_info =
-			(CdbComponentDatabaseInfo *) palloc0(sizeof(CdbComponentDatabaseInfo) * test_cdb->total_segment_dbs);
-
-	for (int i = 0; i < test_cdb->total_segment_dbs; ++i)
-	{
-		component = &test_cdb->segment_db_info[i];
-		component->segindex = i;
-		component->role = primaries_map[i] ? SEGMENT_ROLE_PRIMARY : SEGMENT_ROLE_MIRROR;
-		component->hostip = pstrdup(segs_hostips[i]);
-	}
-
-	orig_cdb = GpAliveSegmentsInfo.cdbComponentDatabases;
-	orig_seg_count = GpAliveSegmentsInfo.aliveSegmentsCount;
-	GpAliveSegmentsInfo.cdbComponentDatabases = test_cdb;
-	GpAliveSegmentsInfo.aliveSegmentsCount = segs_num;
-}
-
-void restoreCdbComponentDatabases()
-{
-	/* free test CdbComponentDatabases */
-	if (GpAliveSegmentsInfo.cdbComponentDatabases)
-		freeCdbComponentDatabases(GpAliveSegmentsInfo.cdbComponentDatabases);
-
-	GpAliveSegmentsInfo.cdbComponentDatabases = orig_cdb;
-	GpAliveSegmentsInfo.aliveSegmentsCount = orig_seg_count;
-}
-
-/* Builds the QueryResource for a query */
 void buildQueryResource(int segs_num,
                         char * segs_hostips[])
 {
-	resource = (QueryResource *)palloc(sizeof(QueryResource));
+	resource = (QueryResource *)palloc0(sizeof(QueryResource));
 
+	resource->numSegments = segs_num;
 	resource->segments = NULL;
 	for (int i = 0; i < segs_num; ++i)
 	{
@@ -87,8 +51,6 @@ void buildQueryResource(int segs_num,
 
 		resource->segments = lappend(resource->segments, segment);
 	}
-
-	return resource;
 }
 
 /* Restores the QueryResource for a query */

--- a/src/backend/access/external/test/hd_work_mgr_mock.h
+++ b/src/backend/access/external/test/hd_work_mgr_mock.h
@@ -28,74 +28,19 @@
 #include "c.h"
 #include "../hd_work_mgr.c"
 
-static CdbComponentDatabases *orig_cdb = NULL;
-static int orig_seg_count = -1;
 
 static QueryResource * resource = NULL;
 
-struct AliveSegmentsInfo
-{
-	uint64			fts_statusVersion;
-	TransactionId	tid;
-
-	/* Release gangs */
-	bool			cleanGangs;
-
-	/* Used for debug & test */
-	bool			forceUpdate;
-	int				failed_segmentid_start;
-	int				failed_segmentid_number;
-
-	/* Used for disptacher. */
-	int4			aliveSegmentsCount;
-	int4			singleton_segindex;
-	Bitmapset		*aliveSegmentsBitmap;
-	struct CdbComponentDatabases *cdbComponentDatabases;
-};
-
-typedef struct AliveSegmentsInfo AliveSegmentsInfo;
-
-AliveSegmentsInfo GpAliveSegmentsInfo = {0, 0, false, false, 0, 0, UNINITIALIZED_GP_IDENTITY_VALUE, 0, NULL, NULL};
-
 /*
- * Helper functions copied from backend/cdb/cdbutils.c
- */
-
-/*
- * _freeCdbComponentDatabases
- *
- * Releases the storage occupied by the CdbComponentDatabases
- * struct pointed to by the argument.
- */
-void
-_freeCdbComponentDatabases(CdbComponentDatabases *pDBs);
-
-/*
- * _freeCdbComponentDatabaseInfo:
- * Releases any storage allocated for members variables of a CdbComponentDatabaseInfo struct.
- */
-void
-_freeCdbComponentDatabaseInfo(CdbComponentDatabaseInfo *cdi);
-
-/*
- * Helper functions to create and restore GpAliveSegmentsInfo.cdbComponentDatabases element
+ * Helper functions to create and free QueryResource element
  * used by hd_work_mgr
  */
 
 /*
- * Builds an array of CdbComponentDatabaseInfo.
- * Each segment is assigned a sequence number and an ip.
- * segs_num - the number of segments
- * segs_hostips - array of the ip of each segment
- * primaries_map - array of which segments are primaries
+ * Builds a mock QueryResource which is used when
+ * GetActiveQueryResource is called to get the
+ * list of available segments.
  */
-void buildCdbComponentDatabases(int segs_num,
-								char* segs_hostips[],
-								bool primaries_map[]);
-
-
-void restoreCdbComponentDatabases();
-
 void buildQueryResource(int segs_num,
                         char * segs_hostips[]);
 void freeQueryResource();


### PR DESCRIPTION
The tests were using an the wrong cast to access segment info. The old struct CdbComponentDatabaseInfo should have been replaced by Segment.