### PR TITLE
HAWQ-160. Fixed "dispatcher encounter error" when cancel query

### DIFF
--- a/src/backend/cdb/dispatcher.c
+++ b/src/backend/cdb/dispatcher.c
@@ -1250,6 +1250,7 @@ dispatch_wait(DispatchData *data)
 		return;
 
 	workermgr_wait_job(data->worker_mgr_state);
+	CHECK_FOR_INTERRUPTS();
 
 	/* Check executors state before return. */
 	if (dispatch_collect_executors_error(data))

--- a/src/backend/cdb/dispatcher_mgt.c
+++ b/src/backend/cdb/dispatcher_mgt.c
@@ -570,6 +570,7 @@ dispmgt_concurrent_connect(List	*executors, int executors_num_per_thread)
 	if (has_error)
 		return false;
 
+	CHECK_FOR_INTERRUPTS();
 	dispmgt_free_concurrent_connect_state(tasks);
 	workermgr_free_workermgr_state(state);
 

--- a/src/backend/cdb/workermgr.c
+++ b/src/backend/cdb/workermgr.c
@@ -153,7 +153,6 @@ workermgr_wait_job(WorkerMgrState *state)
 {
 	state->cancel = false;
 	workermgr_join(state);
-	CHECK_FOR_INTERRUPTS();
 }
 
 static void


### PR DESCRIPTION
CHECK_FOR_INTERRUPTS() can not be called between  PG_TRY(); and  PG_CATCH(); 
because the cancel request ( by passing SIGINT for ProcessInterrupts() to call elog) will be caught by the PG_CATCH(); clause, and the error will be changed to others.

So we just move this line out. 