### PR TITLE
HAWQ-163. Null container set instance is not checked when allocating …

### DIFF
--- a/src/backend/resourcemanager/resourcepool.c
+++ b/src/backend/resourcemanager/resourcepool.c
@@ -2397,7 +2397,8 @@ int allocateResourceFromResourcePoolIOBytes2(int32_t 	 nodecount,
 				continue;
 			}
 
-			if ( containerset->Available.MemoryMB < memory ||
+			if ( containerset == NULL ||
+				 containerset->Available.MemoryMB < memory ||
 				 containerset->Available.Core < core )
 			{
 				elog(RMLOG, "Segment %s does not contain enough resource of "


### PR DESCRIPTION
This is a fix to check null pointer when allocating vseg in resource pool.