### PR TITLE
HAWQ-167. Update HAWQ VERSION to 2.0.0.0_beta for make rpm package.

### DIFF
--- a/getversion
+++ b/getversion
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-GP_VERSION="2.0.0.0-beta"
+GP_VERSION="2.0.0.0_beta"
 
 GP_BUILDNUMBER=dev
 if [ -f BUILD_NUMBER ] ; then


### PR DESCRIPTION
Previously version number "2.0.0.0-beta" will cause rpm package fail, so change '-' to '_' .