### PR TITLE
HAWQ-197. Adding a huge number of GRM containers cause socket connect…

### DIFF
--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -356,6 +356,7 @@ int		rm_session_lease_heartbeat_interval; /* How many seconds to wait before sen
 int		rm_tolerate_nseg_limit;
 int		rm_rejectrequest_nseg_limit;
 int		rm_nvseg_variance_among_seg_limit;
+int		rm_container_batch_limit;
 
 char   *rm_resourcepool_test_filename;
 

--- a/src/backend/resourcemanager/resourcepool.c
+++ b/src/backend/resourcemanager/resourcepool.c
@@ -1417,8 +1417,6 @@ void addGRMContainerToResPool(GRMContainer container)
 			  segresource->Stat->ID,
 			  segresource->Stat->Info.HostNameLen,
 			  GET_SEGRESOURCE_HOSTNAME(segresource));
-
-	validateResourcePoolStatus(false);
 }
 
 void dropGRMContainerFromResPool(GRMContainer ctn)
@@ -3149,6 +3147,7 @@ void moveAllAcceptedGRMContainersToResPool(void)
 		return;
 	}
 
+	int counter = 0;
 	while( PRESPOOL->AcceptedContainers != NULL )
 	{
 		GRMContainer ctn = (GRMContainer)
@@ -3163,6 +3162,15 @@ void moveAllAcceptedGRMContainersToResPool(void)
 				  PRESPOOL->AddPendingContainerCount);
 		addNewResourceToResourceManager(ctn->MemoryMB, ctn->Core);
 		removePendingResourceRequestInRootQueue(ctn->MemoryMB, ctn->Core, true);
+
+		counter++;
+		if ( counter >= rm_container_batch_limit )
+		{
+			elog(LOG, "%d GRM containers left, they will be added into "
+					  "resourcepool next processing cycle.",
+					  list_length(PRESPOOL->AcceptedContainers));
+			break;
+		}
 	}
 	validateResourcePoolStatus(true);
 }

--- a/src/backend/utils/misc/etc/hawq-site.xml
+++ b/src/backend/utils/misc/etc/hawq-site.xml
@@ -110,13 +110,16 @@ under the License.
     <property>
         <name>hawq_rm_yarn_queue_name</name>
         <value>default</value>
-        <description>The YARN queue name to register hawq resource manager.</description>
+        <description>The YARN queue name to register hawq resource manager.
+        </description>
     </property>
 
     <property>
         <name>hawq_rm_yarn_app_name</name>
         <value>hawq</value>
-        <description>The application name to register hawq resource manager in YARN.</description>
+        <description>The application name to register hawq resource manager 
+                     in YARN.
+        </description>
     </property>
 
 </configuration>

--- a/src/backend/utils/misc/etc/hawq-site.xml
+++ b/src/backend/utils/misc/etc/hawq-site.xml
@@ -110,16 +110,13 @@ under the License.
     <property>
         <name>hawq_rm_yarn_queue_name</name>
         <value>default</value>
-        <description>The YARN queue name to register hawq resource manager.
-        </description>
+        <description>The YARN queue name to register hawq resource manager.</description>
     </property>
 
     <property>
         <name>hawq_rm_yarn_app_name</name>
         <value>hawq</value>
-        <description>The application name to register hawq resource manager 
-                     in YARN.
-        </description>
+        <description>The application name to register hawq resource manager in YARN.</description>
     </property>
 
 </configuration>

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -6548,6 +6548,15 @@ static struct config_int ConfigureNamesInt[] =
 	},
 
 	{
+		{"hawq_rm_container_batch_limit", PGC_POSTMASTER, RESOURCES_MGM,
+			gettext_noop("the batch process limit for global resource manager containers."),
+			NULL
+		},
+		&rm_container_batch_limit,
+		1000, 1, 65535, NULL, NULL
+	},
+
+	{
 		{"hawq_rm_nresqueue_limit", PGC_POSTMASTER, RESOURCES_MGM,
 			gettext_noop("the maximum number of resource queue."),
 			NULL

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -1207,6 +1207,7 @@ extern int	   rm_session_lease_heartbeat_interval;
 extern int	   rm_tolerate_nseg_limit;
 extern int	   rm_rejectrequest_nseg_limit;
 extern int	   rm_nvseg_variance_among_seg_limit;
+extern int	   rm_container_batch_limit;
 extern char   *rm_resourcepool_test_filename;
 extern bool	   rm_force_fifo_queue;
 


### PR DESCRIPTION
This fix is to make resource manager move at most hawq_rm_container_batch_limit GRM containers. And a frequently called validation function is removed.