### PR TITLE
HAWQ-41. Add a GUC to set max open AO segemnt files

### DIFF
--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -30,6 +30,7 @@
 
 #include <signal.h>
 
+#include "access/appendonlywriter.h"
 #include "access/gin.h"
 #include "access/transam.h"
 #include "access/aosegfiles.h"
@@ -5434,6 +5435,15 @@ static struct config_int ConfigureNamesInt[] =
 		},
 		&MaxAppendOnlyTables,
 		2048, 0, INT_MAX, NULL, NULL
+	},
+
+	{
+	  {"max_appendonly_segfiles", PGC_POSTMASTER, APPENDONLY_TABLES,
+	    gettext_noop("Maximum number of different (unrelated) appendonly table segment files that can be opened concurrently."),
+	    NULL
+	  },
+	  &MaxAORelSegFileStatus,
+	  262144, 2048, INT_MAX, NULL, NULL
 	},
 
 	{

--- a/src/include/access/appendonlywriter.h
+++ b/src/include/access/appendonlywriter.h
@@ -21,12 +21,6 @@
 #include "storage/lock.h"
 #include "tcop/dest.h"
 
-/*
- * Maximum concurrent number of write segment files for AO relation.
- * TODO: may want to make this a guc instead (can only be set at gpinit time).
- */
-#define MAX_AOREL_SEGFILE_STATUS (2048 * 128)
-
 #define NEXT_END_OF_LIST (-1)
 
 /*
@@ -50,7 +44,7 @@
  * GUC variables
  */
 extern int	MaxAppendOnlyTables;	/* Max # of concurrently used AO rels */
-
+extern int MaxAORelSegFileStatus; /* Max # of concurrently used AO segfiles */
 /*
  * Describes the status of a particular file segment number accross an entire
  * AO relation. 


### PR DESCRIPTION
The newly added GUC is max_appendonly_segfiles, which determines
the max number of appendonly relation segment files open
concurrently.

In a large cluster, we usually need to increase the value of this
GUC in order to support high concurrencies.