### PR TITLE
HAWQ-179. New PXF resource to return its protocol version

### DIFF
--- a/pxf/pxf-service/src/main/java/org/apache/hawq/pxf/service/rest/InvalidPathResource.java
+++ b/pxf/pxf-service/src/main/java/org/apache/hawq/pxf/service/rest/InvalidPathResource.java
@@ -8,9 +8,9 @@ package org.apache.hawq.pxf.service.rest;
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -32,10 +32,6 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.core.UriInfo;
-
-class Version {
-    final static String PXF_PROTOCOL_VERSION = "v14";
-}
 
 /**
  * Class for catching paths that are not defined by other resources.

--- a/pxf/pxf-service/src/main/java/org/apache/hawq/pxf/service/rest/VersionResource.java
+++ b/pxf/pxf-service/src/main/java/org/apache/hawq/pxf/service/rest/VersionResource.java
@@ -1,0 +1,68 @@
+package org.apache.hawq.pxf.service.rest;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.ResponseBuilder;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+/**
+ * PXF protocol version. Any call to PXF resources should include the current
+ * version e.g. {@code ...pxf/v14/Bridge}
+ */
+class Version {
+    final static String PXF_PROTOCOL_VERSION = "v14";
+}
+
+/**
+ * Class returning the protocol version used by PXF.
+ *
+ * The expected format of a path is "
+ * {@code http://<host>:<port>/pxf/ProtocolVersion}" The expected response is "
+ * {@code PXF protocol version <version>}"
+ *
+ */
+@Path("/ProtocolVersion")
+public class VersionResource {
+
+    private static final Log Log = LogFactory.getLog(VersionResource.class);
+
+    public VersionResource() {
+    }
+
+    /**
+     * Returns the PXF protocol version used currently.
+     *
+     * @return response with the PXF protocol version
+     */
+    @GET
+    public Response getProtocolVersion() {
+
+        ResponseBuilder b = Response.ok();
+        b.entity("PXF protocol version " + Version.PXF_PROTOCOL_VERSION);
+        b.type(MediaType.TEXT_PLAIN_TYPE);
+        return b.build();
+    }
+}

--- a/pxf/pxf-service/src/test/java/org/apache/hawq/pxf/service/rest/VersionResourceTest.java
+++ b/pxf/pxf-service/src/test/java/org/apache/hawq/pxf/service/rest/VersionResourceTest.java
@@ -1,0 +1,42 @@
+package org.apache.hawq.pxf.service.rest;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+import static org.junit.Assert.assertEquals;
+
+import javax.ws.rs.core.Response;
+
+import org.junit.Test;
+
+public class VersionResourceTest {
+
+    @Test
+    public void getProtocolVersion() throws Exception {
+
+        VersionResource resource = new VersionResource();
+        Response result = resource.getProtocolVersion();
+
+        assertEquals(Response.Status.OK,
+                Response.Status.fromStatusCode(result.getStatus()));
+        assertEquals("PXF protocol version " + Version.PXF_PROTOCOL_VERSION,
+                result.getEntity().toString());
+    }
+}


### PR DESCRIPTION
The path is <pxf host and port>/pxf/ProtocolVersion
Output is "PXF protocol version <version>"