### PR TITLE
HAWQ-205. PXF Throws NullPointerException when DELIMITER missing in Hive table definition

### DIFF
--- a/pxf/pxf-hive/src/main/java/org/apache/hawq/pxf/plugins/hive/HiveResolver.java
+++ b/pxf/pxf-hive/src/main/java/org/apache/hawq/pxf/plugins/hive/HiveResolver.java
@@ -588,6 +588,11 @@ public class HiveResolver extends Plugin implements ReadResolver {
 
         String userDelim = input.getUserProperty("DELIMITER");
 
+	if (userDelim == null) {
+            throw new IllegalArgumentException(
+                    "DELIMITER is a required option" ) ;
+	}
+
         final int VALID_LENGTH = 1;
         final int VALID_LENGTH_HEX = 4;
 

--- a/pxf/pxf-service/src/main/java/org/apache/hawq/pxf/service/FragmentsResponse.java
+++ b/pxf/pxf-service/src/main/java/org/apache/hawq/pxf/service/FragmentsResponse.java
@@ -59,7 +59,7 @@ public class FragmentsResponse implements StreamingOutput {
      * Serializes a fragments list in JSON,
      * To be used as the result string for HAWQ.
      * An example result is as follows:
-     * <code>{"PXFFragments":[{"replicas":["sdw1.corp.emc.com","sdw3.corp.emc.com","sdw8.corp.emc.com"],"sourceName":"text2.csv", "index":"0", "metadata":<base64 metadata for fragment>, "userData":"<data_specific_to_third_party_fragmenter>"},{"replicas":["sdw2.corp.emc.com","sdw4.corp.emc.com","sdw5.corp.emc.com"],"sourceName":"text_data.csv","index":"0","metadata":<base64 metadata for fragment>,"userData":"<data_specific_to_third_party_fragmenter>"}]}</code>
+     * &lt;code&gt;{"PXFFragments":[{"replicas":["sdw1.corp.emc.com","sdw3.corp.emc.com","sdw8.corp.emc.com"],"sourceName":"text2.csv", "index":"0", "metadata":"&lt;base64 metadata for fragment&gt;", "userData":"&lt;data_specific_to_third_party_fragmenter&gt;"},{"replicas":["sdw2.corp.emc.com","sdw4.corp.emc.com","sdw5.corp.emc.com"],"sourceName":"text_data.csv","index":"0","metadata":"&lt;base64 metadata for fragment&gt;","userData":"&lt;data_specific_to_third_party_fragmenter&gt;"}]}&lt;/code&gt;
      */
     @Override
     public void write(OutputStream output) throws IOException,

--- a/pxf/pxf-service/src/main/java/org/apache/hawq/pxf/service/rest/WritableResource.java
+++ b/pxf/pxf-service/src/main/java/org/apache/hawq/pxf/service/rest/WritableResource.java
@@ -82,7 +82,7 @@ import org.apache.hawq.pxf.service.utilities.Utilities;
 
 
 /**
- * This class handles the subpath /<version>/Writable/ of this
+ * This class handles the subpath /&lt;version&gt;/Writable/ of this
  * REST component
  */
 @Path("/" + Version.PXF_PROTOCOL_VERSION + "/Writable/")


### PR DESCRIPTION
Some minor changes to avoid a null pointer exception when DELIMITER isn't provided (even though required) and also some markup fixes for Javadoc stuff preventing builds.