### PR TITLE
HAWQ-226. Core dump caused by data locality.

### DIFF
--- a/src/backend/cdb/cdbdatalocality.c
+++ b/src/backend/cdb/cdbdatalocality.c
@@ -2661,7 +2661,6 @@ static void allocate_random_relation(Relation_Data* rel_data,
 			/*for hash file whose bucket number doesn't equal to segment number*/
 			if (rel_file->hostIDs == NULL) {
 				rel_file->splits[0].host = 0;
-				assignment_context->total_split_num += 1;
 				continue;
 			}
 			MemSet(hostOccurTimes, 0,	sizeof(int) * context->dds_context.size);


### PR DESCRIPTION
total split number is counted twice when hostIDs of a file is null in allocate_random_relation() method