### PR TITLE
HAWQ-227. Data locality downgrade by wrong insert host.

### DIFF
--- a/src/backend/cdb/cdbdatalocality.c
+++ b/src/backend/cdb/cdbdatalocality.c
@@ -2654,10 +2654,9 @@ static void allocate_random_relation(Relation_Data* rel_data,
 
 
 	/*find the insert node for each block*/
-	int *hostOccurTimes = (int *) palloc(
-						sizeof(int) * context->dds_context.size);
+	int *hostOccurTimes = (int *) palloc(sizeof(int) * context->dds_context.size);
 	for (int fi = 0; fi < fileCount; fi++) {
-	  Relation_File *rel_file = file_vector[fi];
+		Relation_File *rel_file = file_vector[fi];
 		/*for hash file whose bucket number doesn't equal to segment number*/
 		if (rel_file->hostIDs == NULL) {
 			rel_file->splits[0].host = 0;


### PR DESCRIPTION
when we determin the insert host of a block, we should ignore the file contains only one block. because in this case, we cannot know which is the right insert host.  when hosts with same occur times exists we cannot know which is the right insert host either.
