### PR TITLE
HAWQ-232: recovery Pass3 do not need to redo all relfile and relation dir create/drop for on flight transaction

### DIFF
--- a/src/backend/access/transam/persistentfilesysobjname.c
+++ b/src/backend/access/transam/persistentfilesysobjname.c
@@ -67,7 +67,7 @@ char *PersistentFileSysObjName_ObjectName(
 		else
 		{
 			/* All other tablespaces are accessed via filespace locations */
-			sprintf(path, "%u/%u/%u%u",
+			sprintf(path, "%u/%u/%u/%u",
 					 name->variant.rel.relFileNode.spcNode,
 					 name->variant.rel.relFileNode.dbNode,
 					 name->variant.rel.relFileNode.relNode,

--- a/src/backend/access/transam/xlog_mm.c
+++ b/src/backend/access/transam/xlog_mm.c
@@ -437,6 +437,7 @@ append_file_parts(mm_fs_obj_type type,
 static bool
 emit_mmxlog_fs_record(mm_fs_obj_type type, Oid filespace,
 					  Oid tablespace, Oid database, Oid relfilenode,
+					  ItemPointer persistentTid, int64 persistentSerialNum,
 					  int32 segnum, uint8 flags, XLogRecPtr *beginLoc)
 {
 	XLogRecData		rdata;
@@ -480,6 +481,8 @@ emit_mmxlog_fs_record(mm_fs_obj_type type, Oid filespace,
 	xlrec.relfilenode = relfilenode;
 	xlrec.segnum = segnum;
 	xlrec.shared = is_filespace_shared(filespace);
+    xlrec.persistentTid = *persistentTid;
+    xlrec.persistentSerialNum = persistentSerialNum;
 
 	Insist(!path || strlen(path) <= MAXPGPATH);
 
@@ -516,7 +519,7 @@ emit_mmxlog_fs_record(mm_fs_obj_type type, Oid filespace,
 
 /* External interface to filespace removal logging */
 void
-mmxlog_log_remove_filespace(Oid filespace)
+mmxlog_log_remove_filespace(Oid filespace,ItemPointer persistentTid, int64 persistentSerialNum)
 {
 	bool emitted;
 	XLogRecPtr beginLoc;
@@ -531,6 +534,8 @@ mmxlog_log_remove_filespace(Oid filespace)
 						  InvalidOid /* tablespace */,
 						  InvalidOid /* database */,
 						  InvalidOid /* relfilenode */,
+						  persistentTid,
+						  persistentSerialNum,
 						  0 /* segnum */,
 						  MMXLOG_REMOVE_DIR,
 						  &beginLoc);
@@ -552,7 +557,7 @@ mmxlog_log_remove_filespace(Oid filespace)
 
 /* External interface to tablespace removal logging */
 void
-mmxlog_log_remove_tablespace(Oid tablespace)
+mmxlog_log_remove_tablespace(Oid tablespace,ItemPointer persistentTid, int64 persistentSerialNum)
 {
 	bool emitted;
 	XLogRecPtr beginLoc;
@@ -567,6 +572,8 @@ mmxlog_log_remove_tablespace(Oid tablespace)
 						  tablespace,
 						  InvalidOid /* database */,
 						  InvalidOid /* relfilenode */,
+						  persistentTid,
+						  persistentSerialNum,
 						  0 /* segnum */,
 						  MMXLOG_REMOVE_DIR,
 						  &beginLoc);
@@ -588,7 +595,8 @@ mmxlog_log_remove_tablespace(Oid tablespace)
 
 /* External interface to database removal logging */
 void
-mmxlog_log_remove_database(Oid tablespace, Oid database)
+mmxlog_log_remove_database(Oid tablespace, Oid database,
+		ItemPointer persistentTid, int64 persistentSerialNum)
 {
 	bool emitted;
 	XLogRecPtr beginLoc;
@@ -603,6 +611,8 @@ mmxlog_log_remove_database(Oid tablespace, Oid database)
 						  tablespace,
 						  database,
 						  InvalidOid /* relfilenode */,
+						  persistentTid,
+						  persistentSerialNum,
 						  0 /* segnum */,
 						  MMXLOG_REMOVE_DIR,
 						  &beginLoc);
@@ -625,7 +635,8 @@ mmxlog_log_remove_database(Oid tablespace, Oid database)
 
 /* External interface to relation removal logging */
 void
-mmxlog_log_remove_relation(Oid tablespace, Oid database, Oid relfilenode)
+mmxlog_log_remove_relation(Oid tablespace, Oid database, Oid relfilenode,
+		ItemPointer persistentTid, int64 persistentSerialNum)
 {
 	bool emitted;
 	XLogRecPtr beginLoc;
@@ -642,6 +653,8 @@ mmxlog_log_remove_relation(Oid tablespace, Oid database, Oid relfilenode)
 								tablespace,
 								database,
 								relfilenode,
+								persistentTid,
+								persistentSerialNum,
 								0 /* segnum */,
 								MMXLOG_REMOVE_DIR,
 								&beginLoc);
@@ -666,7 +679,7 @@ mmxlog_log_remove_relation(Oid tablespace, Oid database, Oid relfilenode)
 /* External interface to relfilenode removal logging */
 void
 mmxlog_log_remove_relfilenode(Oid tablespace, Oid database, Oid relfilenode,
-							  int32 segnum)
+							  int32 segnum,ItemPointer persistentTid, int64 persistentSerialNum)
 {
 	bool emitted;
 	XLogRecPtr beginLoc;
@@ -681,6 +694,8 @@ mmxlog_log_remove_relfilenode(Oid tablespace, Oid database, Oid relfilenode,
 						  tablespace,
 						  database,
 						  relfilenode,
+						  persistentTid,
+						  persistentSerialNum,
 						  segnum,
 						  MMXLOG_REMOVE_FILE,
 						  &beginLoc);
@@ -705,7 +720,7 @@ mmxlog_log_remove_relfilenode(Oid tablespace, Oid database, Oid relfilenode,
 
 /* External interface to filespace creation logging */
 void
-mmxlog_log_create_filespace(Oid filespace)
+mmxlog_log_create_filespace(Oid filespace,ItemPointer persistentTid, int64 persistentSerialNum)
 {
 	bool emitted;
 	XLogRecPtr beginLoc;
@@ -717,6 +732,8 @@ mmxlog_log_create_filespace(Oid filespace)
 						  InvalidOid /* tablespace */,
 						  InvalidOid /* database */,
 						  InvalidOid /* relfilenode */,
+						  persistentTid,
+						  persistentSerialNum,
 						  0 /* segnum */,
 						  MMXLOG_CREATE_DIR,
 						  &beginLoc);
@@ -738,7 +755,7 @@ mmxlog_log_create_filespace(Oid filespace)
 
 /* External interface to tablespace creation logging */
 void
-mmxlog_log_create_tablespace(Oid filespace, Oid tablespace)
+mmxlog_log_create_tablespace(Oid filespace, Oid tablespace, ItemPointer persistentTid, int64 persistentSerialNum)
 {
 	bool emitted;
 	XLogRecPtr beginLoc;
@@ -750,6 +767,8 @@ mmxlog_log_create_tablespace(Oid filespace, Oid tablespace)
 						  tablespace,
 						  InvalidOid /* database */,
 						  InvalidOid /* relfilenode */,
+						  persistentTid,
+						  persistentSerialNum,
 						  0 /* segnum */,
 						  MMXLOG_CREATE_DIR,
 						  &beginLoc);
@@ -772,7 +791,8 @@ mmxlog_log_create_tablespace(Oid filespace, Oid tablespace)
 
 /* External interface to database creation logging */
 void
-mmxlog_log_create_database(Oid tablespace, Oid database)
+mmxlog_log_create_database(Oid tablespace, Oid database,
+		ItemPointer persistentTid, int64 persistentSerialNum)
 {
 	bool emitted;
 	XLogRecPtr beginLoc;
@@ -784,6 +804,8 @@ mmxlog_log_create_database(Oid tablespace, Oid database)
 						  tablespace,
 						  database,
 						  InvalidOid /* relfilenode */,
+						  persistentTid,
+						  persistentSerialNum,
 						  0 /* segnum */,
 						  MMXLOG_CREATE_DIR,
 						  &beginLoc);
@@ -808,7 +830,8 @@ mmxlog_log_create_database(Oid tablespace, Oid database)
  * External interface to relation create logging
  */
 void
-mmxlog_log_create_relation(Oid tablespace, Oid database, Oid relfilenode)
+mmxlog_log_create_relation(Oid tablespace, Oid database, Oid relfilenode,
+		ItemPointer persistentTid, int64 persistentSerialNum)
 {
 	bool emitted;
 	XLogRecPtr beginLoc;
@@ -819,6 +842,8 @@ mmxlog_log_create_relation(Oid tablespace, Oid database, Oid relfilenode)
 								tablespace,
 								database,
 								relfilenode,
+								persistentTid,
+								persistentSerialNum,
 								0 /*segnum */,
 								MMXLOG_CREATE_DIR,
 								&beginLoc);
@@ -843,7 +868,8 @@ mmxlog_log_create_relation(Oid tablespace, Oid database, Oid relfilenode)
 /* External interface to relfilenode creation logging */
 void
 mmxlog_log_create_relfilenode(Oid tablespace, Oid database,
-							  Oid relfilenode, int32 segnum)
+							  Oid relfilenode, int32 segnum,
+							  ItemPointer persistentTid, int64 persistentSerialNum)
 {
 	bool emitted;
 	XLogRecPtr beginLoc;
@@ -855,6 +881,8 @@ mmxlog_log_create_relfilenode(Oid tablespace, Oid database,
 						  tablespace,
 						  database,
 						  relfilenode,
+						  persistentTid,
+						  persistentSerialNum,
 						  segnum,
 						  MMXLOG_CREATE_FILE,
 						  &beginLoc);

--- a/src/backend/cdb/cdbpersistentdatabase.c
+++ b/src/backend/cdb/cdbpersistentdatabase.c
@@ -611,7 +611,8 @@ void PersistentDatabase_MarkCreatePending(
 	 * This XLOG must be generated under the persistent write-lock.
 	 */
 #ifdef MASTER_MIRROR_SYNC
-	mmxlog_log_create_database(dbDirNode->tablespace, dbDirNode->database); 
+	mmxlog_log_create_database(dbDirNode->tablespace, dbDirNode->database,
+			persistentTid, persistentSerialNum);
 #endif
 
 
@@ -1053,7 +1054,8 @@ PersistentDatabase_DroppedVerifiedActionCallback(
 		 * This XLOG must be generated under the persistent write-lock.
 		 */
 #ifdef MASTER_MIRROR_SYNC
-		mmxlog_log_remove_database(dbDirNode->tablespace, dbDirNode->database);
+		mmxlog_log_remove_database(dbDirNode->tablespace, dbDirNode->database,
+				persistentTid, persistentSerialNum);
 #endif
 				
 		break;
@@ -1288,7 +1290,8 @@ void PersistentDatabase_MarkJustInTimeCreatePending(
 	 */
 #ifdef MASTER_MIRROR_SYNC
 	mmxlog_log_create_database(dbDirNode->tablespace,
-							   dbDirNode->database);	
+							   dbDirNode->database,
+							   persistentTid, persistentSerialNum);
 #endif
 	
 	WRITE_PERSISTENT_STATE_ORDERED_UNLOCK;

--- a/src/backend/cdb/cdbpersistentfilespace.c
+++ b/src/backend/cdb/cdbpersistentfilespace.c
@@ -612,7 +612,7 @@ void PersistentFilespace_MarkCreatePending(
 	 * This XLOG must be generated under the persistent write-lock.
 	 */
 #ifdef MASTER_MIRROR_SYNC
-	mmxlog_log_create_filespace(filespaceOid);
+	mmxlog_log_create_filespace(filespaceOid,persistentTid, persistentSerialNum);
 #endif
 
 
@@ -1029,7 +1029,7 @@ PersistentFilespace_DroppedVerifiedActionCallback(
 		 * This XLOG must be generated under the persistent write-lock.
 		 */
 #ifdef MASTER_MIRROR_SYNC
-		mmxlog_log_remove_filespace(filespaceOid);
+		mmxlog_log_remove_filespace(filespaceOid,persistentTid, persistentSerialNum);
 #endif
 
 		break;

--- a/src/backend/cdb/cdbpersistentrelation.c
+++ b/src/backend/cdb/cdbpersistentrelation.c
@@ -628,7 +628,8 @@ void PersistentRelation_MarkCreatePending(
 	mmxlog_log_create_relation(
 						relFileNode->spcNode,
 						relFileNode->dbNode,
-						relFileNode->relNode);
+						relFileNode->relNode,
+						persistentTid, persistentSerialNum);
 #endif
 
 	/*
@@ -1046,7 +1047,8 @@ PersistentRelation_DroppedVerifiedActionCallback(
 		 * This XLOG must be generated under the persistent write-lock.
 		 */
 #ifdef MASTER_MIRROR_SYNC
-		mmxlog_log_remove_relation(relFileNode->spcNode, relFileNode->dbNode, relFileNode->relNode);
+		mmxlog_log_remove_relation(relFileNode->spcNode, relFileNode->dbNode, relFileNode->relNode,
+				persistentTid, persistentSerialNum);
 #endif
 		break;
 

--- a/src/backend/cdb/cdbpersistentrelfile.c
+++ b/src/backend/cdb/cdbpersistentrelfile.c
@@ -324,7 +324,8 @@ void PersistentRelfile_AddCreatePending(
 						relFileNode->spcNode,
 						relFileNode->dbNode,
 						relFileNode->relNode,
-						segmentFileNum);	
+						segmentFileNum,
+						persistentTid, serialNum);
 #endif
 
 	#ifdef FAULT_INJECTOR
@@ -826,7 +827,8 @@ PersistentRelfile_DroppedVerifiedActionCallback(
 							relFileNode->spcNode, 
 							relFileNode->dbNode, 
 							relFileNode->relNode,
-							segmentFileNum);
+							segmentFileNum,
+							persistentTid, persistentSerialNum);
 #endif
 				
 		break;

--- a/src/backend/cdb/cdbpersistenttablespace.c
+++ b/src/backend/cdb/cdbpersistenttablespace.c
@@ -711,7 +711,8 @@ void PersistentTablespace_MarkCreatePending(
 #ifdef MASTER_MIRROR_SYNC
 	mmxlog_log_create_tablespace(
 						filespaceOid,
-						tablespaceOid);
+						tablespaceOid,
+						persistentTid, persistentSerialNum);
 #endif
 
 	#ifdef FAULT_INJECTOR
@@ -1075,7 +1076,7 @@ PersistentTablespace_DroppedVerifiedActionCallback(
 		 * This XLOG must be generated under the persistent write-lock.
 		 */
 #ifdef MASTER_MIRROR_SYNC
-		mmxlog_log_remove_tablespace(tablespaceOid);
+		mmxlog_log_remove_tablespace(tablespaceOid,persistentTid, persistentSerialNum);
 #endif
 				
 		break;

--- a/src/include/access/xlogmm.h
+++ b/src/include/access/xlogmm.h
@@ -12,6 +12,7 @@
  */
 #define MASTER_MIRROR_SYNC
 
+#include "c.h"
 #include "access/xlog.h"
 #include "access/xlogdefs.h"
 #include "lib/stringinfo.h"
@@ -42,6 +43,9 @@ typedef struct xl_mm_fs_obj
 
 	bool shared;
 	char path[MAXPGPATH];
+    
+	ItemPointerData persistentTid;
+	int64 persistentSerialNum;
 } xl_mm_fs_obj;
 
 /*
@@ -120,23 +124,23 @@ extern void mmxlog_desc(StringInfo buf, XLogRecPtr beginLoc, XLogRecord *record)
  * Functions to generate WAL records to remove file system objects on the
  * master / standby master.
  */
-extern void mmxlog_log_remove_filespace(Oid filespace);
-extern void mmxlog_log_remove_tablespace(Oid tablespace);
-extern void mmxlog_log_remove_database(Oid tablespace, Oid database);
-extern void mmxlog_log_remove_relation(Oid tablespace, Oid database, Oid relfilenode);
+extern void mmxlog_log_remove_filespace(Oid filespace,ItemPointer persistentTid, int64 persistentSerialNum);
+extern void mmxlog_log_remove_tablespace(Oid tablespace,ItemPointer persistentTid, int64 persistentSerialNum);
+extern void mmxlog_log_remove_database(Oid tablespace, Oid database,ItemPointer persistentTid, int64 persistentSerialNum);
+extern void mmxlog_log_remove_relation(Oid tablespace, Oid database, Oid relfilenode,ItemPointer persistentTid, int64 persistentSerialNum);
 extern void mmxlog_log_remove_relfilenode(Oid tablespace, Oid database,
-										  Oid relfilenode, int32 segnum);
+										  Oid relfilenode, int32 segnum,ItemPointer persistentTid, int64 persistentSerialNum);
 
 /*
  * Functions to generate WAL records to add file system objects on the
  * master / standby master.
  */
-extern void mmxlog_log_create_filespace(Oid filespace);
-extern void mmxlog_log_create_tablespace(Oid filespace, Oid tablespace);
-extern void mmxlog_log_create_database(Oid tablespace, Oid database);
-extern void mmxlog_log_create_relation(Oid tablespace, Oid database, Oid relfilenode);
+extern void mmxlog_log_create_filespace(Oid filespace,ItemPointer persistentTid, int64 persistentSerialNum);
+extern void mmxlog_log_create_tablespace(Oid filespace, Oid tablespace,ItemPointer persistentTid, int64 persistentSerialNum);
+extern void mmxlog_log_create_database(Oid tablespace, Oid database,ItemPointer persistentTid, int64 persistentSerialNum);
+extern void mmxlog_log_create_relation(Oid tablespace, Oid database, Oid relfilenode,ItemPointer persistentTid, int64 persistentSerialNum);
 extern void mmxlog_log_create_relfilenode(Oid tablespace, Oid database,
-										  Oid relfilenode, int32 segnum);
+										  Oid relfilenode, int32 segnum,ItemPointer persistentTid, int64 persistentSerialNum);
 extern void mmxlog_append_checkpoint_data(XLogRecData rdata[5]);
 extern void mmxlog_read_checkpoint_data(char *cpdata, int masterMirroringLen, int checkpointLen, XLogRecPtr *beginLoc);
 extern bool mmxlog_filespace_get_path(


### PR DESCRIPTION
Because all persistent table state and relation dir and relfile on hdfs are keep in consistent status at recovery PASS2,  recovery PASS3 do not need to redo all relfile and relation dir create/drop for on flight transaction.