### PR TITLE
HAWQ-224. Fix syntax error of make distprep. a missing '\' in line 11.

### DIFF
--- a/contrib/Makefile
+++ b/contrib/Makefile
@@ -8,7 +8,7 @@ WANTED_DIRS = \
 		pgbench \
 		orafce \
 		extprotocol \
-		gp_cancel_query
+		gp_cancel_query \
 		gp_mdver \
 		hawq-hadoop
 


### PR DESCRIPTION
add ' \' to the end of line 11