### PR TITLE
HAWQ-233. Fix HAWQ initialization failed on Centos7

### DIFF
--- a/configure
+++ b/configure
@@ -4538,6 +4538,32 @@ $as_echo "no" >&6; }
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 
+  # Disable optimizations that do aggresive-loop-optimization for variable length array; needed for gcc 4.8+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking if $CC supports -fno-aggressive-loop-optimizations" >&5
+$as_echo_n "checking if $CC supports -fno-aggressive-loop-optimizations... " >&6; }
+pgac_save_CFLAGS=$CFLAGS
+CFLAGS="$pgac_save_CFLAGS -fno-aggressive-loop-optimizations"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+else
+  CFLAGS="$pgac_save_CFLAGS"
+                    { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
 elif test "$ICC" = yes; then
   # Intel's compiler has a bug/misoptimization in checking for
   # division by NAN (NaN == 0), -mp1 fixes it, so add it to the CFLAGS.

--- a/configure.in
+++ b/configure.in
@@ -341,6 +341,8 @@ if test "$GCC" = yes -a "$ICC" = no; then
   PGAC_PROG_CC_CFLAGS_OPT([-fno-strict-aliasing])
   # Disable optimizations that assume no overflow; needed for gcc 4.3+
   PGAC_PROG_CC_CFLAGS_OPT([-fwrapv])
+  # Disable optimizations that do aggresive-loop-optimization for variable length array; needed for gcc 4.8+
+  PGAC_PROG_CC_CFLAGS_OPT([-fno-aggressive-loop-optimizations])
 elif test "$ICC" = yes; then
   # Intel's compiler has a bug/misoptimization in checking for
   # division by NAN (NaN == 0), -mp1 fixes it, so add it to the CFLAGS.


### PR DESCRIPTION
Hi,
We have investigated this issue, and we found the root cause is that gcc-4.8 introduced new feature "-faggressive-loop-optimizations". This optimization feature is enabled by default, and it will break variable length array under some condition.

Similar issue can be found from PostgreSQL 9.2. See the following links for detail:
1. http://www.postgresql.org/message-id/14242.1365200084@sss.pgh.pa.us
2. https://gcc.gnu.org/gcc-4.8/changes.html
3. http://pkgs.fedoraproject.org/cgit/postgresql.git/commit/?h=f19&id=2a75d7af27fdf03e875f76f4c272c8435f565d10

So, we just borrow the idea to fix this issue and create a patch. Please review it.
Thanks.