### PR TITLE
HAWQ-237. failed to acquire resource because of no available resource…

### DIFF
--- a/src/backend/resourcemanager/resqueuemanager.c
+++ b/src/backend/resourcemanager/resqueuemanager.c
@@ -4580,7 +4580,7 @@ void timeoutQueuedRequest(void)
 						getDQueueHeadNodeData(&(queuetrack->QueryResRequests));
 				if ( topwaiter == curcon && topwaiter->HeadQueueTime == 0 )
 				{
-					topwaiter->HeadQueueTime = gettime_microsec();
+					topwaiter->HeadQueueTime = curmsec;
 					elog(DEBUG3, "Set timestamp of waiting at head of queue.");
 				}
 			}


### PR DESCRIPTION
This fix is to avoid wrongly calculating request waiting time when it is put at the head of the waiting queue.