### PR TITLE
HAWQ-241: Remove  MirroredLock related codes

### DIFF
--- a/src/backend/access/transam/varsup.c
+++ b/src/backend/access/transam/varsup.c
@@ -55,8 +55,6 @@ GetNewTransactionId(bool isSubXact, bool setProcXid)
 {
 	TransactionId xid;
 
-	MIRRORED_LOCK_DECLARE;
-
 	/*
 	 * During bootstrap initialization, we return the special bootstrap
 	 * transaction id.
@@ -68,7 +66,6 @@ GetNewTransactionId(bool isSubXact, bool setProcXid)
 		return BootstrapTransactionId;
 	}
 
-	MIRRORED_LOCK;
 	LWLockAcquire(XidGenLock, LW_EXCLUSIVE);
 
 	xid = ShmemVariableCache->nextXid;
@@ -197,7 +194,6 @@ GetNewTransactionId(bool isSubXact, bool setProcXid)
 	}
 
 	LWLockRelease(XidGenLock);
-	MIRRORED_UNLOCK;
 
 	return xid;
 }

--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -943,8 +943,6 @@ AtSubStart_ResourceOwner(void)
 void
 RecordTransactionCommit(void)
 {
-	MIRRORED_LOCK_DECLARE;
-
 	CHECKPOINT_START_LOCK_DECLARE;
 
 	int32						persistentCommitSerializeLen;
@@ -1011,8 +1009,6 @@ RecordTransactionCommit(void)
 			 *
 			 * The lock order is: MirroredLock then CheckpointStartLock.
 			 */
-			MIRRORED_LOCK;
-				
 			CHECKPOINT_START_LOCK;
 		}
 
@@ -1167,8 +1163,6 @@ RecordTransactionCommit(void)
 		if (madeTCentries)
 		{
 			CHECKPOINT_START_UNLOCK;
-
-			MIRRORED_UNLOCK;
 		}
 
 		END_CRIT_SECTION();
@@ -2249,8 +2243,6 @@ StartTransaction(void)
 void
 CommitTransaction(void)
 {
-	MIRRORED_LOCK_DECLARE;
-
 	CHECKPOINT_START_LOCK_DECLARE;
 
 	TransactionState s = CurrentTransactionState;
@@ -2330,14 +2322,7 @@ CommitTransaction(void)
 		/*
 		 * We need to ensure the recording of the [distributed-]commit record and the
 		 * persistent post-commit work will be done either before or after a checkpoint.
-		 *
-		 * When we use CheckpointStartLock, we make sure we already have the
-		 * MirroredLock first.
-		 *
-		 * The lock order is: MirroredLock then CheckpointStartLock.
 		 */
-		MIRRORED_LOCK;
-			
 		CHECKPOINT_START_LOCK;
 	}
 
@@ -2444,8 +2429,6 @@ CommitTransaction(void)
 	if (willHaveObjectsFromSmgr)
 	{
 		CHECKPOINT_START_UNLOCK;
-		
-		MIRRORED_UNLOCK;
 	}
 	
 	AtEOXact_MultiXact();
@@ -2735,8 +2718,6 @@ PrepareTransaction(void)
 void
 AbortTransaction(void)
 {
-	MIRRORED_LOCK_DECLARE;
-
 	CHECKPOINT_START_LOCK_DECLARE;
 
 	TransactionState s = CurrentTransactionState;
@@ -2833,14 +2814,7 @@ AbortTransaction(void)
 		/*
 		 * We need to ensure the recording of the abort record and the
 		 * persistent post-abort work will be done either before or after a checkpoint.
-		 *
-		 * When we use CheckpointStartLock, we make sure we already have the
-		 * MirroredLock first.
-		 *
-		 * The lock order is: MirroredLock then CheckpointStartLock.
 		 */
-		MIRRORED_LOCK;
-			
 		CHECKPOINT_START_LOCK;
 	}
 
@@ -2899,8 +2873,6 @@ AbortTransaction(void)
 	if (willHaveObjectsFromSmgr)
 	{
 		CHECKPOINT_START_UNLOCK;
-		
-		MIRRORED_UNLOCK;
 	}
 	
 	AtEOXact_MultiXact();

--- a/src/backend/cdb/cdbappendonlystoragewrite.c
+++ b/src/backend/cdb/cdbappendonlystoragewrite.c
@@ -633,8 +633,6 @@ void AppendOnlyStorageWrite_TransactionFlushAndCloseFile(
 
 	int64						*fileLen_uncompressed)
 {
-	MIRRORED_LOCK_DECLARE;
-
 	RelFileNode relFileNode;
 	int32 segmentFileNum;
 
@@ -655,19 +653,10 @@ void AppendOnlyStorageWrite_TransactionFlushAndCloseFile(
 
 	startEof = storageWrite->startEof;
 
-	/*
-	 * Use the MirroredLock here to cover the flush (and close) and evaluation below whether
-	 * we must catchup the mirror.
-	 */
-	MIRRORED_LOCK;
-
 	AppendOnlyStorageWrite_FlushAndCloseFile(
 										storageWrite,
 										newLogicalEof,
 										fileLen_uncompressed);
-
-	MIRRORED_UNLOCK;
-
 }
 
 // -----------------------------------------------------------------------------

--- a/src/backend/cdb/cdbpersistentfilesysobj.c
+++ b/src/backend/cdb/cdbpersistentfilesysobj.c
@@ -2242,8 +2242,6 @@ void PersistentFileSysObj_PreparedEndXactAction(
 
 	int								prepareAppendOnlyIntentCount)
 {
-	MIRRORED_LOCK_DECLARE;
-
 	PersistentFileSysObjStateChangeResult *stateChangeResults;
 
 	int i;
@@ -2262,13 +2260,6 @@ void PersistentFileSysObj_PreparedEndXactAction(
 	stateChangeResults =
 			(PersistentFileSysObjStateChangeResult*)
 					palloc0(persistentObjects->typed.fileSysActionInfosCount * sizeof(PersistentFileSysObjStateChangeResult));
-
-	/*
-	 * We need to do the transition to 'Aborting Create' or 'Drop Pending' and perform
-	 * the file-system drop while under one acquistion of the MirroredLock.  Otherwise,
-	 * we could race with resynchronize's ReDrop.
-	 */
-	MIRRORED_LOCK;
 
 	/*
 	 * We need to complete this work, or let Crash Recovery complete it.
@@ -2571,8 +2562,6 @@ injectfaultexit:
 jumpoverinjectfaultexit:
 
 	PersistentFileSysObj_FlushXLog();
-
-	MIRRORED_UNLOCK;
 
 	END_CRIT_SECTION();
 

--- a/src/backend/commands/dbcommands.c
+++ b/src/backend/commands/dbcommands.c
@@ -373,8 +373,6 @@ static void copy_append_only_segment_file(
 	int64			persistentSerialNum,
 	char			*buffer)
 {
-	MIRRORED_LOCK_DECLARE;
-
 	char srcFileName[MAXPGPATH];
 	char dstFileName[MAXPGPATH];
 	char extension[12];
@@ -484,12 +482,6 @@ static void copy_append_only_segment_file(
 		bufferLen = (Size) Min(2*BLCKSZ, endOffset - readOffset);						
 	}
 
-	/*
-	 * Use the MirroredLock here to cover the flush (and close) and evaluation below whether
-	 * we must catchup the mirror.
-	 */
-	MIRRORED_LOCK;
-
 	MirroredAppendOnly_FlushAndClose(
 							&mirroredDstOpen,
 							&primaryError);
@@ -500,9 +492,6 @@ static void copy_append_only_segment_file(
 				 errdetail("%s", HdfsGetLastError())));
 
 	FileClose(srcFile);
-	
-	MIRRORED_UNLOCK;
-
 }
 
 // -----------------------------------------------------------------------------

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -10603,8 +10603,6 @@ copy_append_only_data(
 	
 	char			*buffer)
 {
-	MIRRORED_LOCK_DECLARE;
-
 	char srcFileName[MAXPGPATH];
 	char dstFileName[MAXPGPATH];
 	char extension[12];
@@ -10709,12 +10707,6 @@ copy_append_only_data(
 		bufferLen = (Size) Min(2*BLCKSZ, endOffset - readOffset); 					
 	}
 	
-	/*
-	 * Use the MirroredLock here to cover the flush (and close) and evaluation below whether
-	 * we must catchup the mirror.
-	 */
-	MIRRORED_LOCK;
-
 	MirroredAppendOnly_FlushAndClose(
 							&mirroredDstOpen,
 							&primaryError
@@ -10730,8 +10722,6 @@ copy_append_only_data(
 				 errdetail("%s", HdfsGetLastError())));
 
 	FileClose(srcFile);
-
-	MIRRORED_UNLOCK;
 
 	if (Debug_persistent_print)
 		elog(Persistent_DebugPrintLevel(), 

--- a/src/backend/storage/smgr/smgr.c
+++ b/src/backend/storage/smgr/smgr.c
@@ -1307,8 +1307,6 @@ smgrDoDeleteActions(
 	int					*listCount,
 	bool				forCommit)
 {
-	MIRRORED_LOCK_DECLARE;
-
 	CHECKPOINT_START_LOCK_DECLARE;
 
 	PendingDelete *current;
@@ -1340,13 +1338,6 @@ smgrDoDeleteActions(
 	 * to reduce the time that the lock is held, thus allowing a larger window of time for filerep
 	 * resynchronization to obtain the lock.
 	 */
-
-	/*
-	 * We need to do the transition to 'Aborting Create' or 'Drop Pending' and perform
-	 * the file-system drop while under one acquistion of the MirroredLock.  Otherwise,
-	 * we could race with resynchronize's ReDrop.
-	 */
-	MIRRORED_LOCK;
 
 	/*
 	 * The logic will eventually obtain a CheckpointStartLock in PersistentRelation_Dropped(),
@@ -1618,8 +1609,6 @@ smgrDoDeleteActions(
 	PersistentFileSysObj_FlushXLog();
 
 	CHECKPOINT_START_UNLOCK;
-
-	MIRRORED_UNLOCK;
 
 	if (stateChangeResults != NULL)
 		pfree(stateChangeResults);


### PR DESCRIPTION
MirroredLock is no use in hawq because there is no segment mirroring, and it is not used by master mirroring which uses xlog directly.

The reason why we need to remove it is: in some scenarios the request order of this lock and CheckpointStartLock may cause deadlock.
