### PR TITLE
Move ivy.xml for qpopt inside apache-hawq for better dependency management

### DIFF
--- a/src/backend/gpopt/ivy-build.xml
+++ b/src/backend/gpopt/ivy-build.xml
@@ -1,0 +1,69 @@
+<project name="cdb3" default="resolve" xmlns:ivy="antlib:org.apache.ivy.ant">
+
+  <!-- ================================================================ -->
+  <!-- This file is used to support retrieving the appropriate Pivotal  -->
+  <!-- Optimizer versioned files (header and libraries).  It is only    -->
+  <!-- used for commercial builds and can otherwise be ignored.         -->
+  <!-- ================================================================ -->
+
+  <target name="resolve" if="BLD_ARCH">
+    <ivy:settings file="${BLD_TOP}/build-utils/dependencies/ivysettings.xml"/>
+    <ivy:resolve conf="${BLD_ARCH}"
+                 log="download-only"/>
+  </target>
+
+  <target name="clean">
+    <ivy:cleancache />
+  </target>
+
+
+  <target name="post-resolve-trigger">
+    <echo>
+      ======================================================================
+        Post Resolve Trigger
+      ======================================================================
+      
+      organisation=${dep.organisation}
+      module=${dep.module}
+      revision=${dep.revision}
+      platform=${BLD_ARCH}      
+
+    </echo>
+
+   <exec executable="${BLD_TOP}/build-utils/dependencies/ivy.sh">
+    <arg value="${dep.module}"/>
+    <arg value="${dep.revision}"/>
+    <arg value="${dep.organisation}"/>
+    <arg value="${BLD_ARCH}"/>
+  </exec>
+
+  </target>
+
+  <target name="download-untar-trigger">
+    <echo>
+======================================================================
+  Post download artifact
+======================================================================
+    organisation=${dep.organisation}
+    module=${dep.module}
+    revision=${dep.revision}
+    artifact=${dep.artifact}
+    origin=${dep.origin}
+    local=${dep.local}
+    size=${dep.size}</echo>
+
+  <exec executable="${BLD_TOP}/build-utils/dependencies/ivy_util.sh">
+    <arg value="${dep.file}"/>
+    <arg value="${dep.revision}"/>
+  </exec>
+
+   <exec executable="${BLD_TOP}/build-utils/dependencies/ivy.sh">
+    <arg value="${dep.module}"/>
+    <arg value="${dep.revision}"/>
+    <arg value="${dep.organisation}"/>
+    <arg value="${BLD_ARCH}"/>
+  </exec>
+
+  </target>
+  
+</project>

--- a/src/backend/gpopt/ivy.xml
+++ b/src/backend/gpopt/ivy.xml
@@ -18,8 +18,8 @@
     </configurations>
 
     <dependencies>
-      <dependency org="emc"             name="optimizer"       rev="1.612"          conf="osx106_x86->osx106_x86_32;osx106_x86_32->osx106_x86_32;rhel5_x86_64->rhel5_x86_64;suse10_x86_64->suse10_x86_64" />
-      <dependency org="emc"             name="libgpos"         rev="1.129"          conf="osx106_x86->osx106_x86_32;osx106_x86_32->osx106_x86_32;rhel5_x86_64->rhel5_x86_64;suse10_x86_64->suse10_x86_64" />
+      <dependency org="emc"             name="optimizer"       rev="1.614"          conf="osx106_x86->osx106_x86_32;osx106_x86_32->osx106_x86_32;rhel5_x86_64->rhel5_x86_64;suse10_x86_64->suse10_x86_64" />
+      <dependency org="emc"             name="libgpos"         rev="1.131"          conf="osx106_x86->osx106_x86_32;osx106_x86_32->osx106_x86_32;rhel5_x86_64->rhel5_x86_64;suse10_x86_64->suse10_x86_64" />
       <dependency org="xerces"          name="xerces-c"        rev="3.1.1-p1"       conf="osx106_x86->osx106_x86_32;osx106_x86_32->osx106_x86_32;rhel5_x86_64->rhel5_x86_64;suse10_x86_64->suse10_x86_64" />
     </dependencies>
 </ivy-module>

--- a/src/backend/gpopt/ivy.xml
+++ b/src/backend/gpopt/ivy.xml
@@ -1,0 +1,25 @@
+<ivy-module version="2.0">
+    <info organisation="Pivotal"
+          module="hawq" />
+
+    <!-- ================================================================ -->
+    <!-- This file is used to support retrieving the appropriate Pivotal  -->
+    <!-- Optimizer versioned files (header and libraries).  It is only    -->
+    <!-- used for commercial builds and can otherwise be ignored.         -->
+    <!-- ================================================================ -->
+
+    <configurations>
+      <conf name="osx105_x86"    description="osx105_x86"    visibility="public"/>
+      <conf name="osx106_x86"    description="osx106_x86"    visibility="public"/>
+      <conf name="osx106_x86_32" description="osx106_x86_32" visibility="public"/>
+      <conf name="rhel5_x86_64"  description="rhel5_x86_64"  visibility="public"/>
+      <conf name="rhel6_x86_64"  description="rhel6_x86_64"  visibility="public"/>
+      <conf name="suse10_x86_64" description="suse10_x86_64" visibility="public"/>
+    </configurations>
+
+    <dependencies>
+      <dependency org="emc"             name="optimizer"       rev="1.612"          conf="osx106_x86->osx106_x86_32;osx106_x86_32->osx106_x86_32;rhel5_x86_64->rhel5_x86_64;suse10_x86_64->suse10_x86_64" />
+      <dependency org="emc"             name="libgpos"         rev="1.129"          conf="osx106_x86->osx106_x86_32;osx106_x86_32->osx106_x86_32;rhel5_x86_64->rhel5_x86_64;suse10_x86_64->suse10_x86_64" />
+      <dependency org="xerces"          name="xerces-c"        rev="3.1.1-p1"       conf="osx106_x86->osx106_x86_32;osx106_x86_32->osx106_x86_32;rhel5_x86_64->rhel5_x86_64;suse10_x86_64->suse10_x86_64" />
+    </dependencies>
+</ivy-module>


### PR DESCRIPTION
This is part 1 of 2 step check-in to have better way managing dependencies between HAWQ and optimizer.

Originally, we have ivy.xml managed separately from apache-hawq, and caused inconsistency between HAWQ and optimizer components.

With this fix, we can change the dependency the same time we change the HAWQ code, hence reduce failures due to inconsistent dependencies.