### PR TITLE
HAWQ-251. Add gpfaultinjector back for hawq2.0 using.

### DIFF
--- a/tools/bin/gpfaultinjector
+++ b/tools/bin/gpfaultinjector
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+#
+# Copyright (c) Greenplum Inc 2010. All Rights Reserved.
+#
+#
+# THIS IMPORT MUST COME FIRST
+# import mainUtils FIRST to get python version check
+#
+from gppylib.mainUtils import *
+
+# now reset of imports
+from gppylib.programs.clsInjectFault import *
+
+#-------------------------------------------------------------------------
+if __name__ == '__main__':
+    simple_main( GpInjectFaultProgram.createParser, GpInjectFaultProgram.createProgram)
+


### PR DESCRIPTION
We need to add gpfaultinjector back, but will require some changes to make it work for HAWQ2.0.
This ticket will only add it back, we will have another ticket to do modifications.