### PR TITLE
HAWQ-255: change CHECKPOINT_START_LOCK to a fine grained scope so that checkpoint not blocked.

### DIFF
--- a/src/backend/cdb/cdbpersistentfilesysobj.c
+++ b/src/backend/cdb/cdbpersistentfilesysobj.c
@@ -2120,18 +2120,6 @@ void PersistentFileSysObj_EndXactDrop(
 
 	bool					ignoreNonExistence)
 {
-	// NOTE: The caller must already have the MirroredLock.
-
-	if (fsObjName->type == PersistentFsObjType_RelationFile)
-	{
-		/*
-		 * We use this lock to guard data resynchronization.
-		 */
-		LockRelationForResynchronize(
-						PersistentFileSysObjName_GetRelFileNodePtr(fsObjName),
-						AccessExclusiveLock);
-	}
-
 	PersistentFileSysObj_DropObject(
 							fsObjName,
 							relStorageMgr,
@@ -2141,13 +2129,6 @@ void PersistentFileSysObj_EndXactDrop(
 							ignoreNonExistence,
 							Debug_persistent_print,
 							Persistent_DebugPrintLevel());
-
-	if (fsObjName->type == PersistentFsObjType_RelationFile)
-	{
-		UnlockRelationForResynchronize(
-						PersistentFileSysObjName_GetRelFileNodePtr(fsObjName),
-						AccessExclusiveLock);
-	}
 }
 
 void PersistentFileSysObj_UpdateRelationBufpoolKind(

--- a/src/backend/storage/buffer/bufmgr.c
+++ b/src/backend/storage/buffer/bufmgr.c
@@ -2464,8 +2464,6 @@ RelationTruncate(Relation rel, BlockNumber nblocks, bool markPersistentAsPhysica
 
 	if (markPersistentAsPhysicallyTruncated)
 	{
-		LockRelationForResynchronize(&rel->rd_node, AccessExclusiveLock);
-
 		/*
 		 * Fetch gp_persistent_relation_node information so we can mark the persistent entry.
 		 */
@@ -2522,12 +2520,6 @@ RelationTruncate(Relation rel, BlockNumber nblocks, bool markPersistentAsPhysica
 
 	}
 
-	// -------- MirroredLock ----------
-	
-	if (markPersistentAsPhysicallyTruncated)
-	{
-		UnlockRelationForResynchronize(&rel->rd_node, AccessExclusiveLock);
-	}
 }
 
 /* ---------------------------------------------------------------------

--- a/src/backend/storage/lmgr/lmgr.c
+++ b/src/backend/storage/lmgr/lmgr.c
@@ -339,30 +339,6 @@ UnlockRelationForResyncExtension(RelFileNode *relFileNode, LOCKMODE lockmode)
 	LockRelease(&tag, lockmode, false);
 }
 
-void
-LockRelationForResynchronize(RelFileNode *relFileNode, LOCKMODE lockmode)
-{
-	LOCKTAG		tag;
-
-	SET_LOCKTAG_RELATION_RESYNCHRONIZE(tag,
-						 relFileNode->dbNode,
-						 relFileNode->relNode);
-
-	LockAcquire(&tag, lockmode, false, false);
-}
-
-void
-UnlockRelationForResynchronize(RelFileNode *relFileNode, LOCKMODE lockmode)
-{
-	LOCKTAG		tag;
-
-	SET_LOCKTAG_RELATION_RESYNCHRONIZE(tag,
-						 relFileNode->dbNode,
-						 relFileNode->relNode);
-
-	LockRelease(&tag, lockmode, false);
-}
-
 LockAcquireResult
 LockRelationAppendOnlySegmentFile(RelFileNode *relFileNode, int32 segno, LOCKMODE lockmode, bool dontWait)
 {

--- a/src/include/storage/lmgr.h
+++ b/src/include/storage/lmgr.h
@@ -42,10 +42,6 @@ extern void UnlockRelationForExtension(Relation relation, LOCKMODE lockmode);
 extern void LockRelationForResyncExtension(RelFileNode *relFileNode, LOCKMODE lockmode);
 extern void UnlockRelationForResyncExtension(RelFileNode *relFileNode, LOCKMODE lockmode);
 
-/* Lock a relation for resynchronize */
-extern void LockRelationForResynchronize(RelFileNode *relFileNode, LOCKMODE lockmode);
-extern void UnlockRelationForResynchronize(RelFileNode *relFileNode, LOCKMODE lockmode);
-
 /* Lock a relation for Append-Only segment files. */
 extern LockAcquireResult LockRelationAppendOnlySegmentFile(RelFileNode *relFileNode, int32 segno, LOCKMODE lockmode, bool dontWait);
 extern void UnlockRelationAppendOnlySegmentFile(RelFileNode *relFileNode, int32 segno, LOCKMODE lockmode, int32 contentid);


### PR DESCRIPTION
In some scenarios the request order of this lock and CheckpointStartLock may cause deadlock, MirroredLock and LockRelationForResynchronize()  are useless in hawq now, and it may cause deadlock in AbortTransaction()/CommitTransaction()/smgrDoDeleteActions(), so we remove them.

MirroredLock was removed at previous checkin. LockRelationForResynchronize() need to be removed here.