### PR TITLE
HAWQ-259. YARN mode resource manager gets YARN cluster report once be…

### DIFF
--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -336,11 +336,15 @@ int		rm_request_timeoutcheck_interval; 	/* How many seconds to wait before
 int		rm_session_lease_heartbeat_interval;/* How many seconds to wait before
 											   sending another heart-beat to
 											   resource manager. */
+int		rm_nocluster_timeout;				/* How many seconds to wait before
+											   getting enough number of available
+											   segments registered. */
 
 int		rm_tolerate_nseg_limit;
 int		rm_rejectrequest_nseg_limit;
 int		rm_nvseg_variance_among_seg_limit;
 int		rm_container_batch_limit;
+
 
 char   *rm_resourcepool_test_filename;
 

--- a/src/backend/resourcemanager/include/dynrm.h
+++ b/src/backend/resourcemanager/include/dynrm.h
@@ -191,6 +191,7 @@ struct DynRMGlobalData{
     ConnectionTrackManager   ConnTrackManager;	   /* Connection track. 	  */
     ResourcePool     	 	 ResourcePoolInstance; /* Node management.		  */
     volatile bool			 ResManagerMainKeepRun;
+    uint64_t				 ResourceManagerStartTime;
 
     /*------------------------------------------------------------------------*/
     /* INTERCONN:: RM server and RM agents.                                   */

--- a/src/backend/resourcemanager/include/resourcepool.h
+++ b/src/backend/resourcemanager/include/resourcepool.h
@@ -498,6 +498,8 @@ struct ResourcePoolData {
 	/* Slaves file content. */
 	int64_t			SlavesFileTimestamp;
 	int				SlavesHostCount;
+
+	int				RBClusterReportCounter;
 };
 
 typedef struct ResourcePoolData *ResourcePool;

--- a/src/backend/resourcemanager/resourcebroker/resourcebroker_API.c
+++ b/src/backend/resourcemanager/resourcebroker/resourcebroker_API.c
@@ -68,6 +68,8 @@ int RB_getClusterReport(const char *queuename, List **machines, double *maxcapac
 	}
 
 	*maxcapacity = 1;
+	PRESPOOL->RBClusterReportCounter++;
+
 	return FUNC_RETURN_OK;
 }
 

--- a/src/backend/resourcemanager/resourcebroker/resourcebroker_LIBYARN.c
+++ b/src/backend/resourcemanager/resourcebroker/resourcebroker_LIBYARN.c
@@ -536,6 +536,8 @@ int handleRB2RM_ClusterReport(void)
 	int			piperes     = 0;
 	List	   *segstats	= NULL;
 
+	PRESPOOL->RBClusterReportCounter++;
+
 	/* Read whole result head. */
 	RPCResponseRBGetClusterReportHeadData response;
 	piperes = readPipe(fd, (char *)&response, sizeof(response));

--- a/src/backend/resourcemanager/resourcemanager.c
+++ b/src/backend/resourcemanager/resourcemanager.c
@@ -528,6 +528,8 @@ int MainHandlerLoop(void)
 {
 	int res = FUNC_RETURN_OK;
 
+	DRMGlobalInstance->ResourceManagerStartTime = gettime_microsec();
+
 	while( DRMGlobalInstance->ResManagerMainKeepRun )
 	{
 		/* STEP 1. Check resource broker status. */
@@ -852,6 +854,10 @@ int initializeDRMInstance(MCTYPE context)
 	if ( res != FUNC_RETURN_OK ) {
 		elog(WARNING, "Fail to get local host name.");
 	}
+
+	/* Set resource manager server startup time to 0, i.e. not started yet. */
+	DRMGlobalInstance->ResourceManagerStartTime = 0;
+
 	return res;
 }
 
@@ -2860,10 +2866,11 @@ void processResourceBrokerTasks(void)
 		 */
         curtime = gettime_microsec();
 
-		if ( (curtime - PRESPOOL->LastUpdateTime  >
+		if ( (PRESPOOL->Segments.NodeCount > 0 ) &&
+			 (curtime - PRESPOOL->LastUpdateTime  >
 			  rm_cluster_report_period * 1000000LL ||
 			  hasSegmentGRMCapacityNotUpdated() ) &&
-			  curtime - PRESPOOL->LastRequestTime >    5LL * 1000000LL)
+			 (curtime - PRESPOOL->LastRequestTime > 5LL * 1000000LL) )
 		{
 			double  maxcap  = 0.0;
 			List   *report	= NULL;

--- a/src/backend/resourcemanager/resourcepool.c
+++ b/src/backend/resourcemanager/resourcepool.c
@@ -362,6 +362,8 @@ void initializeResourcePoolManager(void)
 	{
 		PRESPOOL->pausePhase[i] = false;
 	}
+
+	PRESPOOL->RBClusterReportCounter = 0;
 }
 
 #define CONNECT_TIMEOUT 60
@@ -3423,6 +3425,16 @@ bool hasSegmentGRMCapacityNotUpdated(void)
 	{
 		return false;
 	}
+
+	/*
+	 * If there is no segment registered, we consider no need to update global
+	 * resource manager info.
+	 */
+	if ( PRESPOOL->Segments.NodeCount == 0 )
+	{
+		return false;
+	}
+
 	bool res = false;
 
 	List 	 *allsegres = NULL;

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -6412,6 +6412,15 @@ static struct config_int ConfigureNamesInt[] =
 	},
 
 	{
+		{"hawq_rm_resource_idle_timeout", PGC_POSTMASTER, RESOURCES_MGM,
+			gettext_noop("timeout for having enough number of segments registered."),
+			NULL
+		},
+		&rm_nocluster_timeout,
+		60, 0, 65535, NULL, NULL
+	},
+
+	{
 		{"hawq_rm_session_lease_heartbeat_interval", PGC_POSTMASTER, RESOURCES_MGM,
 			gettext_noop("interval for sending heart-beat to resource manager to keep "
 						 "resource context alive."),

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -6412,7 +6412,7 @@ static struct config_int ConfigureNamesInt[] =
 	},
 
 	{
-		{"hawq_rm_resource_idle_timeout", PGC_POSTMASTER, RESOURCES_MGM,
+		{"hawq_rm_nocluster_timeout", PGC_POSTMASTER, RESOURCES_MGM,
 			gettext_noop("timeout for having enough number of segments registered."),
 			NULL
 		},

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -1185,6 +1185,7 @@ extern int 	   rm_resource_allocation_timeout;
 extern int	   rm_resource_timeout;
 extern int	   rm_request_timeoutcheck_interval;
 extern int	   rm_session_lease_heartbeat_interval;
+extern int	   rm_nocluster_timeout;
 extern int	   rm_tolerate_nseg_limit;
 extern int	   rm_rejectrequest_nseg_limit;
 extern int	   rm_nvseg_variance_among_seg_limit;


### PR DESCRIPTION
The GRM cluster report is triggered only when there is at least one segment registered through FTS heart-beat.

To handle the case, no segment is started in YARN mode, guc hawq_rm_nocluster_timeout is introduced, if when resource manager has waited for the possible segment registeration more than hawq_rm_nocluster_timeout seconds, the resource requests are rejected due to no enough available segment.