### PR TITLE
HAWQ-265. Change metadata share memory flush strategy to prevent out of share memory problem when create too many hdfs_file.

### DIFF
--- a/src/backend/cdb/cdbmetadatacache.c
+++ b/src/backend/cdb/cdbmetadatacache.c
@@ -65,7 +65,6 @@
 #include "fmgr.h"
 #include "utils/builtins.h"
 
-#define MAX_HDFS_FILE_NUM               (2 << 15)       // 1PB / 32G = 32K, 2^15
 #define MAX_HDFS_HOST_NUM               1024
 #define MAX_BLOCK_INFO_LEN              128
 #define BLOCK_INFO_BIT_NUM              16
@@ -184,7 +183,7 @@ MetadataCache_ShmemSize(void)
 {
     Size size;
     
-    size = hash_estimate_size((Size)MAX_HDFS_FILE_NUM, sizeof(MetadataCacheEntry));
+    size = hash_estimate_size((Size)metadata_cache_max_hdfs_file_num, sizeof(MetadataCacheEntry));
 
     size = add_size(size, hash_estimate_size((Size)MAX_HDFS_HOST_NUM, sizeof(BlockInfoEntry)) * METADATA_BLOCK_INFO_TYPE_NUM);
 
@@ -267,7 +266,7 @@ MetadataCacheHashTableInit(void)
     info.hash = tag_hash;
     hash_flags = (HASH_ELEM | HASH_FUNCTION);
 
-    MetadataCache = ShmemInitHash("Metadata Cache", MAX_HDFS_FILE_NUM, MAX_HDFS_FILE_NUM, &info, hash_flags);
+    MetadataCache = ShmemInitHash("Metadata Cache", metadata_cache_max_hdfs_file_num, metadata_cache_max_hdfs_file_num, &info, hash_flags);
     if (NULL == MetadataCache)
     {
         return false;

--- a/src/backend/cdb/cdbmetadatacache_process.c
+++ b/src/backend/cdb/cdbmetadatacache_process.c
@@ -410,11 +410,18 @@ ProcessMetadataCacheCheck()
     HdfsFileInfo *file_info;
 
     double free_block_ratio = (FREE_BLOCK_NUM * 1.0) / metadata_cache_block_capacity;
+    long cache_entry_num = hash_get_num_entries(MetadataCache);
+    double cache_entry_ratio = (cache_entry_num * 1.0) / metadata_cache_max_hdfs_file_num;
 
     elog(DEBUG1, "[MetadataCache] ProcessMetadataCacheCheck free_block_ratio:%f", free_block_ratio);
 
-    if (free_block_ratio < metadata_cache_free_block_max_ratio)
+    if (free_block_ratio < metadata_cache_free_block_max_ratio || cache_entry_ratio > metadata_cache_flush_ratio)
     {
+    	if(cache_entry_num == metadata_cache_max_hdfs_file_num)
+    	{
+    		elog(WARNING, "[MetadataCache] ProcessMetadataCacheCheck : Metadata cache is full.");
+    	}
+    	elog(DEBUG1, "[MetadataCache] ProcessMetadataCacheCheck cache_entry_ratio:%f", cache_entry_ratio);
         if (NULL == MetadataCacheLRUList) 
         {
             GenerateMetadataCacheLRUList();
@@ -436,7 +443,10 @@ ProcessMetadataCacheCheck()
             DestroyHdfsFileInfo(file_info);
             total_remove_files++;
 
-            if (((FREE_BLOCK_NUM * 1.0) / metadata_cache_block_capacity) >= metadata_cache_free_block_normal_ratio)
+            double cache_entry_ratio = hash_get_num_entries(MetadataCache) / metadata_cache_max_hdfs_file_num;
+
+            if (((FREE_BLOCK_NUM * 1.0) / metadata_cache_block_capacity) >= metadata_cache_free_block_normal_ratio
+            		&& cache_entry_ratio < metadata_cache_reduce_ratio)
             {
                 break;
             }

--- a/src/backend/cdb/cdbmetadatacache_process.c
+++ b/src/backend/cdb/cdbmetadatacache_process.c
@@ -417,9 +417,9 @@ ProcessMetadataCacheCheck()
 
     if (free_block_ratio < metadata_cache_free_block_max_ratio || cache_entry_ratio > metadata_cache_flush_ratio)
     {
-    	if(cache_entry_num == metadata_cache_max_hdfs_file_num)
+    	if(cache_entry_num >= metadata_cache_max_hdfs_file_num)
     	{
-    		elog(WARNING, "[MetadataCache] ProcessMetadataCacheCheck : Metadata cache is full.");
+    		elog(LOG, "[MetadataCache] ProcessMetadataCacheCheck : Metadata cache is full.The cache entry num is:%ld. The metadata_cache_max_hdfs_file_num is:%d", cache_entry_num, metadata_cache_max_hdfs_file_num);
     	}
     	elog(DEBUG1, "[MetadataCache] ProcessMetadataCacheCheck cache_entry_ratio:%f", cache_entry_ratio);
         if (NULL == MetadataCacheLRUList) 

--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -278,6 +278,10 @@ int metadata_cache_refresh_max_num;
 double metadata_cache_free_block_max_ratio;
 double metadata_cache_free_block_normal_ratio;
 
+int metadata_cache_max_hdfs_file_num;
+double metadata_cache_flush_ratio;
+double metadata_cache_reduce_ratio;
+
 char *metadata_cache_testfile;
 bool debug_fake_datalocality;
 bool datalocality_remedy_enable;

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -6540,7 +6540,7 @@ static struct config_int ConfigureNamesInt[] =
 				NULL
 		},
 		&metadata_cache_max_hdfs_file_num,
-		524288, 32768, 8388608, NULL, NULL
+		524288, 131072, 8388608, NULL, NULL
 	},
 
 	/* End-of-list marker */

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -6504,7 +6504,7 @@ static struct config_int ConfigureNamesInt[] =
 				NULL
 		},
 		&metadata_cache_check_interval,
-		60, 10, 3600, NULL, NULL
+		30, 10, 3600, NULL, NULL
 	},
 	{
 		{

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -6533,6 +6533,15 @@ static struct config_int ConfigureNamesInt[] =
 		&metadata_cache_refresh_max_num,
 		1000, 1, 10000, NULL, NULL
 	},
+	{
+		{
+			"hawq_metadata_cache_max_hdfs_file_num", PGC_POSTMASTER, DEVELOPER_OPTIONS,
+				gettext_noop("max hdfs file num in metadata."),
+				NULL
+		},
+		&metadata_cache_max_hdfs_file_num,
+		524288, 32768, 8388608, NULL, NULL
+	},
 
 	/* End-of-list marker */
 	{
@@ -6558,6 +6567,22 @@ static struct config_real ConfigureNamesReal[] =
 		},
 		&metadata_cache_free_block_normal_ratio,
 		0.2, 0.05, 1.0, NULL, NULL
+	},
+	{
+		{"hawq_metadata_cache_flush_ratio", PGC_POSTMASTER, DEVELOPER_OPTIONS,
+				gettext_noop("metadata cache flush ratio."),
+				NULL
+		},
+		&metadata_cache_flush_ratio,
+		0.85, 0.50, 1.0, NULL, NULL
+	},
+	{
+		{"hawq_metadata_cache_reduce_ratio", PGC_POSTMASTER, DEVELOPER_OPTIONS,
+				gettext_noop("metadata cache reduce ratio."),
+				NULL
+		},
+		&metadata_cache_reduce_ratio,
+		0.7, 0.50, 1.0, NULL, NULL
 	},
 
 	{

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -1137,6 +1137,10 @@ extern int metadata_cache_refresh_max_num;
 extern double metadata_cache_free_block_max_ratio;
 extern double metadata_cache_free_block_normal_ratio;
 
+extern int metadata_cache_max_hdfs_file_num;
+extern double metadata_cache_flush_ratio;
+extern double metadata_cache_reduce_ratio;
+
 extern char *metadata_cache_testfile;
 extern bool debug_fake_datalocality;
 extern bool datalocality_remedy_enable;


### PR DESCRIPTION
please review. thanks.