### PR TITLE
Hawq 257

### DIFF
--- a/src/backend/access/external/hd_work_mgr.c
+++ b/src/backend/access/external/hd_work_mgr.c
@@ -166,17 +166,8 @@ char** map_hddata_2gp_segments(char* uri, int total_segs, int working_segs, Rela
 	 * 2. Get the fragments data from the PXF service
 	 */
 	data_fragments = get_data_fragment_list(hadoop_uri, &client_context);
-	/*
-	 * if pxf_isilon == false (example: HDFS)
-	 *   The target port for all fragments is the port
-	 *   supplied in the URI.
-	 * if pxf_isilon == true (example: ISILON)
-	 *   in this case PXF is installed on a proprietary server on the same hosts
-	 *   as the Hawq segments. The target port for all fragments is the port
-	 *   supplied in the GUC.
-	 */
-	int port = pxf_isilon ? pxf_service_port : atoi(hadoop_uri->port);
-	assign_pxf_port_to_fragments(port, data_fragments);
+
+	assign_pxf_port_to_fragments(atoi(hadoop_uri->port), data_fragments);
 
 	/* debug - enable when tracing */
 	print_fragment_list(data_fragments);
@@ -290,14 +281,6 @@ static GPHDUri* init(char* uri, ClientContext* cl_context)
 	 * 1. Cherrypick the data relevant for HADOOP from the input uri
 	 */
 	GPHDUri* hadoop_uri = parseGPHDUri(uri);
-	
-	/* if pxf_isilon is true, ignore the port in the uri
-	 * and use pxf_service_port instead to access PXF.
-	 */
-	if (pxf_isilon)
-	{
-		port_to_str(&(hadoop_uri->port), pxf_service_port);
-	}
 
 	/*
 	 * 2. Communication with the Hadoop back-end

--- a/src/backend/access/external/pxfuriparser.c
+++ b/src/backend/access/external/pxfuriparser.c
@@ -81,8 +81,6 @@ parseGPHDUri(const char *uri_str)
 	GPHDUri_parse_data(uri, &cursor);
 	GPHDUri_parse_options(uri, &cursor);
 
-	port_to_str(&(uri->port), pxf_service_port);
-
 	return uri;
 }
 

--- a/src/backend/access/external/pxfuriparser.c
+++ b/src/backend/access/external/pxfuriparser.c
@@ -361,7 +361,15 @@ GPHDUri_parse_authority(GPHDUri *uri, char **cursor)
 		ereport(ERROR,
 				(errcode(ERRCODE_SYNTAX_ERROR),
 				 errmsg("Invalid port: %s for authority host %s",
-						uri->port, uri->host)));	
+						uri->port, uri->host)));
+
+	/* if pxf_isilon is true, ignore the port in the uri
+	 * and use pxf_service_port instead to access PXF.
+	 */
+	if (pxf_isilon)
+	{
+		sprintf(uri->port, "%d", pxf_service_port);
+	}
 }
 
 /*

--- a/src/backend/access/external/test/pxfuriparser_test.c
+++ b/src/backend/access/external/test/pxfuriparser_test.c
@@ -44,7 +44,8 @@ test__parseGPHDUri__ValidURI(void **state)
 
 	assert_string_equal(parsed->protocol, "pxf");
 	assert_string_equal(parsed->host, "1.2.3.4");
-	assert_string_not_equal(parsed->port, "5678"); /* it should be pxf_service_port */
+	assert_string_equal(parsed->port, "5678");
+	assert_true(parsed->ha_nodes == NULL);
 	assert_string_equal(parsed->data, "some/path/and/table.tbl");
 
 	options = parsed->options;
@@ -73,6 +74,87 @@ test__parseGPHDUri__ValidURI(void **state)
 	assert_true(parsed->fragments == NULL);
 
 	freeGPHDUri(parsed);
+}
+
+/*
+ * Test parsing of valid uri with with nameservice instead of host and port
+ * as given in LOCATION in a PXF external table.
+ */
+void
+test__parseGPHDUri__ValidURI_HA(void **state)
+{
+	char* uri = "pxf://hanameservice/some/path/and/table.tbl?FRAGMENTER=SomeFragmenter&ACCESSOR=SomeAccessor&RESOLVER=SomeResolver&ANALYZER=SomeAnalyzer";
+	List* options = NIL;
+	ListCell* cell = NULL;
+	OptionData* option = NULL;
+
+	/* mock GPHD_HA_load_nodes */
+	NNHAConf* ha_conf = (NNHAConf *)palloc0(sizeof(NNHAConf));
+	ha_conf->nameservice = "hanameservice";
+	ha_conf->numn = 2;
+	ha_conf->nodes = ((char**)palloc0(sizeof(char*) * 2));
+	ha_conf->nodes[0] = "node1";
+	ha_conf->restports = ((char**)palloc0(sizeof(char*) * 2));
+	ha_conf->restports[0] = "1001";
+	expect_string(GPHD_HA_load_nodes, nameservice, "hanameservice");
+	will_return(GPHD_HA_load_nodes, ha_conf);
+
+	/* mode GPHD_HA_release_nodes */
+	expect_value(GPHD_HA_release_nodes, conf, ha_conf);
+	will_be_called(GPHD_HA_release_nodes);
+
+	GPHDUri* parsed = parseGPHDUri(uri);
+
+	assert_true(parsed != NULL);
+	assert_string_equal(parsed->uri, uri);
+
+	assert_string_equal(parsed->protocol, "pxf");
+	assert_string_equal(parsed->host, "node1"); /* value should be taken from ha_nodes */
+	assert_string_equal(parsed->port, "1001"); /* it should be taken from ha_nodes */
+	assert_false(parsed->ha_nodes == NULL);
+	assert_string_equal(parsed->data, "some/path/and/table.tbl");
+
+	freeGPHDUri(parsed);
+
+	/* free NNHAConf */
+	if (ha_conf)
+	{
+		pfree(ha_conf->nodes);
+		pfree(ha_conf->restports);
+		pfree(ha_conf);
+	}
+}
+
+/*
+ * Test parsing of valid uri as given in LOCATION in a PXF external table,
+ * with pxf_isilon set to true.
+ */
+void
+test__parseGPHDUri__ValidURI_Isilon(void **state)
+{
+	char* uri = "pxf://servername:5000/some/path/and/table.tbl?FRAGMENTER=SomeFragmenter&ACCESSOR=SomeAccessor&RESOLVER=SomeResolver&ANALYZER=SomeAnalyzer";
+	List* options = NIL;
+	ListCell* cell = NULL;
+	OptionData* option = NULL;
+
+	/* set pxf_isilon to true */
+	pxf_isilon = true;
+
+	GPHDUri* parsed = parseGPHDUri(uri);
+
+	assert_true(parsed != NULL);
+	assert_string_equal(parsed->uri, uri);
+
+	assert_string_equal(parsed->protocol, "pxf");
+	assert_string_equal(parsed->host, "servername");
+	assert_int_equal(atoi(parsed->port), pxf_service_port); /* it should be pxf_service_port */
+	assert_true(parsed->ha_nodes == NULL);
+	assert_string_equal(parsed->data, "some/path/and/table.tbl");
+
+	freeGPHDUri(parsed);
+
+	/* set pxf_isilon back to false */
+	pxf_isilon = false;
 }
 
 /*
@@ -356,6 +438,8 @@ main(int argc, char* argv[])
 
 	const UnitTest tests[] = {
 			unit_test(test__parseGPHDUri__ValidURI),
+			unit_test(test__parseGPHDUri__ValidURI_HA),
+			unit_test(test__parseGPHDUri__ValidURI_Isilon),
 			unit_test(test__parseGPHDUri__NegativeTestNoProtocol),
 			unit_test(test__parseGPHDUri__NegativeTestNoOptions),
 			unit_test(test__parseGPHDUri__NegativeTestMissingEqual),

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -6189,16 +6189,6 @@ static struct config_int ConfigureNamesInt[] =
 	},
 
 	{
-		{"pxf_service_port", PGC_POSTMASTER, EXTERNAL_TABLES,
-			gettext_noop("PXF service port"),
-			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
-		},
-		&pxf_service_port,
-		51200, 1, 65535, NULL, NULL
-	},
-
-	{
 		{"hawq_master_address_port", PGC_POSTMASTER, PRESET_OPTIONS,
 			gettext_noop("master server address port number"),
 			NULL

--- a/src/bin/gpfusion/gpbridgeapi.c
+++ b/src/bin/gpfusion/gpbridgeapi.c
@@ -295,10 +295,10 @@ PxfServer* get_pxf_server(GPHDUri* gphd_uri, const Relation rel)
 		return NULL;
 	}
 
-	/* if pxf_isilon is false, ignore the port in the uri
+	/* if pxf_isilon is true, ignore the port in the uri
 	 * and use pxf_service_port instead to access PXF.
 	 */
-	if (!pxf_isilon)
+	if (pxf_isilon)
 	{
 		sprintf(gphd_uri->port, "%d", pxf_service_port);
 	}

--- a/src/bin/gpfusion/gpbridgeapi.c
+++ b/src/bin/gpfusion/gpbridgeapi.c
@@ -295,16 +295,6 @@ PxfServer* get_pxf_server(GPHDUri* gphd_uri, const Relation rel)
 		return NULL;
 	}
 
-	/* if pxf_isilon is true, ignore the port in the uri
-	 * and use pxf_service_port instead to access PXF.
-	 */
-	if (pxf_isilon)
-	{
-		sprintf(gphd_uri->port, "%d", pxf_service_port);
-	}
-
-
-
 	/*
 	 * Enrich the curl HTTP header
 	 */

--- a/src/bin/gpfusion/gpbridgeapi.c
+++ b/src/bin/gpfusion/gpbridgeapi.c
@@ -268,7 +268,7 @@ static void init_client_context(ClientContext *client_context)
 /*
  * get list of data nodes' rest servers,
  * and choose one (based on modulo segment id).
- * if pxf_isilon is true, there are no PXF instances on the datanodes .
+ * if pxf_isilon is true, there are no PXF instances on the datanodes.
  * TODO: add locality
  */
 PxfServer* get_pxf_server(GPHDUri* gphd_uri, const Relation rel)
@@ -291,7 +291,19 @@ PxfServer* get_pxf_server(GPHDUri* gphd_uri, const Relation rel)
 	/* set HTTP header that guarantees response in JSON format */
 	churl_headers_append(client_context.http_headers, REST_HEADER_JSON_RESPONSE, NULL);
 	if (!client_context.http_headers)
+	{
 		return NULL;
+	}
+
+	/* if pxf_isilon is false, ignore the port in the uri
+	 * and use pxf_service_port instead to access PXF.
+	 */
+	if (!pxf_isilon)
+	{
+		sprintf(gphd_uri->port, "%d", pxf_service_port);
+	}
+
+
 
 	/*
 	 * Enrich the curl HTTP header
@@ -303,7 +315,7 @@ PxfServer* get_pxf_server(GPHDUri* gphd_uri, const Relation rel)
 	add_delegation_token(&inputData);
 	build_http_header(&inputData);
 
-	int port = pxf_service_port;
+	int port = atoi(gphd_uri->port);
 
 	if (!pxf_isilon)
 	{
@@ -342,7 +354,7 @@ PxfServer* get_pxf_server(GPHDUri* gphd_uri, const Relation rel)
 	}
 	else /* Isilon */
 	{
-		ret_server->host = pstrdup("localhost");
+		ret_server->host = pstrdup("localhost"); /* TODO: should it always be localhost? */
 		ret_server->port = port;
 		elog(DEBUG2, "get_pxf_server: writing data to an Isilon target storage system");
 	}


### PR DESCRIPTION
When parsing PXF URI, change the port to pxf_service_port only if pxf_isilon is ON.
The parsed port is always used (both Isilon and regular cases), which makes the code simpler.
In case of HA, the port is not specified in the URI, so we use pxf_service_port instead.
