### PR TITLE
HAWQ-269. Change net_disk_ratio from int to double type.

### DIFF
--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -720,7 +720,7 @@ int			optimizer_log_failure;
 double		optimizer_cost_threshold;
 double		optimizer_nestloop_factor;
 double locality_upper_bound;
-int net_disk_ratio;
+double net_disk_ratio;
 bool		optimizer_cte_inlining;
 int		optimizer_cte_inlining_bound;
 double 	optimizer_damping_factor_filter;
@@ -6129,17 +6129,6 @@ static struct config_int ConfigureNamesInt[] =
 	},
 
 	{
-			{"net_disk_ratio", PGC_USERSET, DEVELOPER_OPTIONS,
-				gettext_noop("set the speed ratio of net against network"),
-	            NULL,
-				GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
-				},
-			&net_disk_ratio,
-			3, 1, 100, NULL, NULL
-	},
-
-
-	{
 		{"server_ticket_renew_interval", PGC_USERSET, CONN_AUTH,
 			gettext_noop("Set the kerberos renew interval"),
 			NULL,
@@ -6856,6 +6845,15 @@ static struct config_real ConfigureNamesReal[] =
 			},
 		&locality_upper_bound,
 		1.2, 1.0, 2.0, NULL, NULL
+	},
+	{
+		{"net_disk_ratio", PGC_USERSET, DEVELOPER_OPTIONS,
+			gettext_noop("set the scan volumn ratio of disk against network."),
+	        NULL,
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+		},
+		&net_disk_ratio,
+		3.0, 1.0, 100.0, NULL, NULL
 	},
 
 /* End-of-list marker */

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -715,12 +715,12 @@ bool		optimizer_enable_assert_maxonerow;
 bool		optimizer_enumerate_plans;
 bool		optimizer_sample_plans;
 int		optimizer_plan_id;
-int 		optimizer_samples_number;
-int			optimizer_log_failure;
-double		optimizer_cost_threshold;
-double		optimizer_nestloop_factor;
-double locality_upper_bound;
-double net_disk_ratio;
+int  optimizer_samples_number;
+int  optimizer_log_failure;
+double	  optimizer_cost_threshold;
+double  optimizer_nestloop_factor;
+double  locality_upper_bound;
+double  net_disk_ratio;
 bool		optimizer_cte_inlining;
 int		optimizer_cte_inlining_bound;
 double 	optimizer_damping_factor_filter;
@@ -6829,7 +6829,7 @@ static struct config_real ConfigureNamesReal[] =
 
 	{
 		{"optimizer_nestloop_factor",PGC_USERSET, DEVELOPER_OPTIONS,
-			gettext_noop("set the nestloop join cost factor in the optimizer"),
+			gettext_noop("Sets the nestloop join cost factor in the optimizer"),
 			NULL,
 			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
@@ -6839,7 +6839,7 @@ static struct config_real ConfigureNamesReal[] =
 
 	{
 		{"locality_upper_bound", PGC_USERSET, DEVELOPER_OPTIONS,
-			gettext_noop("set the ratio of upper bound of local read."),
+			gettext_noop("Sets the ratio of upper bound of local read."),
 	        NULL,
 			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 			},
@@ -6848,7 +6848,7 @@ static struct config_real ConfigureNamesReal[] =
 	},
 	{
 		{"net_disk_ratio", PGC_USERSET, DEVELOPER_OPTIONS,
-			gettext_noop("set the scan volumn ratio of disk against network."),
+			gettext_noop("Sets the scan volumn ratio of disk against network."),
 	        NULL,
 			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -391,7 +391,7 @@ extern double optimizer_cost_threshold;
 extern double optimizer_nestloop_factor;
 extern double locality_upper_bound;
 extern bool optimizer_cte_inlining;
-extern int net_disk_ratio;
+extern double net_disk_ratio;
 extern int optimizer_cte_inlining_bound;
 extern double optimizer_damping_factor_filter;
 extern double optimizer_damping_factor_join;


### PR DESCRIPTION
net_disk_ratio is the punishment factor of the size of remote read compared with local read.
we need to set it to be double type.