### PR TITLE
HAWQ-273. Need re-fetch snapshot at planning stage

### DIFF
--- a/src/backend/commands/prepare.c
+++ b/src/backend/commands/prepare.c
@@ -131,7 +131,7 @@ PrepareQuery(PrepareStmt *stmt, const char *queryString)
 	query_list_copy = copyObject(query_list); /* planner scribbles on query tree */
 	
 	/* Generate plans for queries.	Snapshot is already set. */
-	plan_list = pg_plan_queries(query_list, NULL, false, QRL_NONE);
+	plan_list = pg_plan_queries(query_list, NULL, true, QRL_NONE);
 	
 	/*
 	 * Save the results.  We don't have the query string for this PREPARE, but
@@ -202,7 +202,7 @@ ExecuteQuery(ExecuteStmt *stmt, const char *queryString,
 			query->intoClause = copyObject(stmt->into);
 		}
 		
-		stmt_list = pg_plan_queries(query_list, paramLI, false, QRL_ONCE);
+		stmt_list = pg_plan_queries(query_list, paramLI, true, QRL_ONCE);
 	}
 
 	/*
@@ -668,7 +668,7 @@ ExplainExecuteQuery(ExecuteStmt *execstmt, ExplainStmt *stmt, const char * query
 	
 	
 	query_list = copyObject(entry->query_list); /* planner scribbles on query tree */
-	stmt_list = pg_plan_queries(query_list, paramLI, false, QRL_ONCE);
+	stmt_list = pg_plan_queries(query_list, paramLI, true, QRL_ONCE);
 	
 	Assert(list_length(query_list) == list_length(stmt_list));
 

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -1645,7 +1645,7 @@ exec_simple_query(const char *query_string, const char *seqServerHost, int seqSe
 		querytree_list = pg_analyze_and_rewrite(parsetree, query_string,
 												NULL, 0);
 
-		plantree_list = pg_plan_queries(querytree_list, NULL, false, QRL_ONCE);
+		plantree_list = pg_plan_queries(querytree_list, NULL, true, QRL_ONCE);
 
 		/* Done with the snapshot used for parsing/planning */
 		ActiveSnapshot = NULL;

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -850,14 +850,6 @@ pg_plan_query(Query *querytree, ParamListInfo boundParams, QueryResourceLife res
 /*
  * Generate plans for a list of already-rewritten queries.
  *
- * If needSnapshot is TRUE, we haven't yet set a snapshot for the current
- * query.  A snapshot must be set before invoking the planner, since it
- * might try to evaluate user-defined functions.  But we must not set a
- * snapshot if the list contains only utility statements, because some
- * utility statements depend on not having frozen the snapshot yet.
- * (We assume that such statements cannot appear together with plannable
- * statements in the rewriter's output.)
- *
  * Normal optimizable statements generate PlannedStmt entries in the result
  * list.  Utility statements are simply represented by their statement nodes.
  */
@@ -873,6 +865,15 @@ pg_plan_queries(List *querytrees, ParamListInfo boundParams,
 		Query	   *query = (Query *) lfirst(query_list);
 		Node *stmt;
 
+		/*
+		 * If needSnapshot is TRUE, we haven't yet set a snapshot for the current
+		 * query.  A snapshot must be set before invoking the planner, since it
+		 * might try to evaluate user-defined functions.  But we must not set a
+		 * snapshot if the list contains only utility statements, because some
+		 * utility statements depend on not having frozen the snapshot yet.
+		 * (We assume that such statements cannot appear together with plannable
+		 * statements in the rewriter's output.)
+		 */
 		if (query->commandType == CMD_UTILITY)
 		{
 			/* Utility commands have no plans. */


### PR DESCRIPTION
Because data locality and hdfs metadata cache will fetch pg_aoseg meta data when planning, we need to re-fetch the latest snapshot.