### PR TITLE
HAWQ-278. Add min_cost for each query.

### DIFF
--- a/src/backend/cdb/cdbdatalocality.c
+++ b/src/backend/cdb/cdbdatalocality.c
@@ -4111,8 +4111,13 @@ calculate_planner_segment_num(Query *query, QueryResourceLife resourceLife,
 			minTargetSegmentNumber = enforce_virtual_segment_number;
 		}
 		uint64_t before_rm_allocate_resource = gettime_microsec();
+
+		/* cost is use by RM to balance workload between hosts. the cost is at least one block size*/
+		int64 mincost = min_cost_for_each_query;
+		mincost <<= 20;
+		int64 queryCost = context.total_size < mincost ? mincost : context.total_size;
 		if (QRL_NONE != resourceLife) {
-			resource = AllocateResource(QRL_ONCE, sliceNum, context.total_size,
+			resource = AllocateResource(QRL_ONCE, sliceNum, queryCost,
 					maxTargetSegmentNumber, minTargetSegmentNumber,
 					context.host_context.hostnameVolInfos, context.host_context.size);
 		}

--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -267,6 +267,7 @@ int max_filecount_notto_split_segment;
 int min_datasize_to_combine_segment;
 int datalocality_algorithm_version;
 int hash_to_random_flag;
+int min_cost_for_each_query;
 bool metadata_cache_enable;
 int metadata_cache_block_capacity;
 

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -6273,6 +6273,16 @@ static struct config_int ConfigureNamesInt[] =
 	},
 
 	{
+			{"min_cost_for_each_query", PGC_USERSET, DEVELOPER_OPTIONS,
+				gettext_noop("Sets min cost(MB) for each query which is utilized by RM"),
+				NULL,
+				GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			},
+			&min_cost_for_each_query,
+			128, 1, 1024 ,NULL, NULL
+	},
+
+	{
 			{"datalocality_algorithm_version", PGC_USERSET, DEVELOPER_OPTIONS,
 				gettext_noop("Sets dalocality algorithm version default is 1(For DEBUG)"),
 				NULL,

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -1219,6 +1219,7 @@ extern int     rm_nresqueue_limit;
 extern int max_filecount_notto_split_segment;
 extern int min_datasize_to_combine_segment;
 extern int datalocality_algorithm_version;
+extern int min_cost_for_each_query;
 
 typedef enum
 {


### PR DESCRIPTION
When we run 50 concurrancy insert into values(3) on 16 hosts.
They will run on only one host, not balanced.
This is caused by we pass cost zero to RM for "insert into values" like query.
We need to assign a min_cost for each query. 
One block size(128M) is by default