### PR TITLE
HAWQ-268. Start standby node before master node  while doing hawq init standby

### DIFF
--- a/tools/bin/lib/hawqinit.sh
+++ b/tools/bin/lib/hawqinit.sh
@@ -352,16 +352,7 @@ standby_init() {
     else
         LOG_MSG "[INFO]:-HAWQ master stopped" verbose
     fi
-    
-    ${SSH} -o 'StrictHostKeyChecking no' ${hawqUser}@${master_host_name} \
-        "${SOURCE_PATH}; hawq start master -a;" >> ${STANDBY_LOG_FILE}
-    if [ $? -ne 0 ] ; then
-        LOG_MSG "[ERROR]:-Start HAWQ master failed" verbose
-        exit 1
-    else
-        LOG_MSG "[INFO]:-HAWQ master started" verbose
-    fi
-
+ 
     ${SSH} -o 'StrictHostKeyChecking no' ${hawqUser}@${master_host_name} \
         "${SOURCE_PATH}; hawq start standby -a;" >> ${STANDBY_LOG_FILE}
     if [ $? -ne 0 ] ; then
@@ -369,6 +360,17 @@ standby_init() {
         exit 1
     else
         LOG_MSG "[INFO]:-HAWQ standby started" verbose
+    fi
+
+    sleep 5
+
+    ${SSH} -o 'StrictHostKeyChecking no' ${hawqUser}@${master_host_name} \
+        "${SOURCE_PATH}; hawq start master -a;" >> ${STANDBY_LOG_FILE}
+    if [ $? -ne 0 ] ; then
+        LOG_MSG "[ERROR]:-Start HAWQ master failed" verbose
+        exit 1
+    else
+        LOG_MSG "[INFO]:-HAWQ master started" verbose
     fi
 
     ${SSH} -o 'StrictHostKeyChecking no' ${hawqUser}@${master_host_name} \


### PR DESCRIPTION
If hawq master start before standby, in some cases standby will do recovery, this will cause master can't connect to standby to do "Synchronized" check. So we will start standby first and sleep 5 seconds, then start master. This should avoid most of the "Synchronized" failues.

Error message is:
[' Not Synchronized | Connection error | 2015-12-23 20:52:20-08 | Master mirroring connect failed for entry db. Master unable to connect to test5 with options host=test5 port=20000 : FATAL:  the database system is in recovery mode \n',