### PR TITLE
HAWQ-283. Remove the content column from pg_aoseg_xxxxx

### DIFF
--- a/src/backend/access/appendonly/appendonlywriter.c
+++ b/src/backend/access/appendonly/appendonlywriter.c
@@ -1768,7 +1768,6 @@ AORelLookupSegfileStatus(int segno, AORelHashEntry entry)
 
 struct SegFileMap
 {
-    int32	contentid;
     int64	eof;
     bool	ok;
 };
@@ -1801,7 +1800,6 @@ GetSegmentFileLengthMapping(Relation rel, Oid segrelid, int segno, int *totalseg
 
             for (i = 0; i < *totalsegs; ++i)
             {
-                retval[i].contentid = fsinfo[i]->content;
                 retval[i].eof = fsinfo[i]->eof;
                 retval[i].ok = false;
             }
@@ -1826,7 +1824,6 @@ GetSegmentFileLengthMapping(Relation rel, Oid segrelid, int segno, int *totalseg
 
             for (i = 0; i < *totalsegs; ++i)
             {
-                retval[i].contentid = fsinfo[i]->content;
                 retval[i].eof = fsinfo[i]->eof;
                 retval[i].ok = false;
             }

--- a/src/backend/catalog/aoseg.c
+++ b/src/backend/catalog/aoseg.c
@@ -157,8 +157,6 @@ create_aoseg_table(Relation rel, Oid aosegOid, Oid aosegIndexOid, Oid * comptype
 		TupleDescInitEntry(tupdesc,
 				(AttrNumber) Anum_pg_aoseg_eofuncompressed,
 				"eofuncompressed", FLOAT8OID, -1, 0);
-		TupleDescInitEntry(tupdesc, (AttrNumber) Anum_pg_aoseg_content,
-				"content", INT4OID, -1, 0);
 	}
 	else
 	{
@@ -183,8 +181,6 @@ create_aoseg_table(Relation rel, Oid aosegOid, Oid aosegIndexOid, Oid * comptype
 		TupleDescInitEntry(tupdesc,
 				(AttrNumber) Anum_pg_parquetseg_eofuncompressed,
 				"eofuncompressed", FLOAT8OID, -1, 0);
-		TupleDescInitEntry(tupdesc, (AttrNumber) Anum_pg_parquetseg_content,
-				"content", INT4OID, -1, 0);
 	}
 
 	/*
@@ -224,12 +220,8 @@ create_aoseg_table(Relation rel, Oid aosegOid, Oid aosegIndexOid, Oid * comptype
 	 * Create unique index on segno.
 	 */
 	indexInfo = makeNode(IndexInfo);
-	indexInfo->ii_NumIndexAttrs = 2;
+	indexInfo->ii_NumIndexAttrs = 1;
 	indexInfo->ii_KeyAttrNumbers[0] = 1;
-	if (RelationIsAoRows(rel))
-		indexInfo->ii_KeyAttrNumbers[1] = Anum_pg_aoseg_content;
-	else
-		indexInfo->ii_KeyAttrNumbers[1] = Anum_pg_parquetseg_content;
 	indexInfo->ii_Expressions = NIL;
 	indexInfo->ii_ExpressionsState = NIL;
 	indexInfo->ii_Predicate = NIL;

--- a/src/backend/cdb/cdbdatabaseinfo.c
+++ b/src/backend/cdb/cdbdatabaseinfo.c
@@ -491,7 +491,6 @@ static void DatabaseInfo_AddExtraSegmentFile(
 
 static void DatabaseInfo_AddAppendOnlyCatalogSegmentInfo(
 	DbInfoRel 				*dbInfoRel,
-	int4					contentid,
 	int32 					segmentFileNum,
 	int64					logicalEof)
 {
@@ -1103,7 +1102,6 @@ DatabaseInfo_HandleAppendOnly(
 				{
 					DatabaseInfo_AddAppendOnlyCatalogSegmentInfo(
 															dbInfoRel,
-															aoSegfileArray[i]->content,
 															aoSegfileArray[i]->segno,
 															aoSegfileArray[i]->eof);
 				}

--- a/src/include/access/aosegfiles.h
+++ b/src/include/access/aosegfiles.h
@@ -14,13 +14,12 @@
 #include "utils/tqual.h"
 #include "catalog/pg_appendonly.h"
 
-#define Natts_pg_aoseg					6
+#define Natts_pg_aoseg					5
 #define Anum_pg_aoseg_segno				1
 #define Anum_pg_aoseg_eof				2
 #define Anum_pg_aoseg_tupcount			3
 #define Anum_pg_aoseg_varblockcount		4
 #define Anum_pg_aoseg_eofuncompressed	5
-#define Anum_pg_aoseg_content			6
 
 #define InvalidFileSegNumber			-1
 #define InvalidUncompressedEof			-1
@@ -38,8 +37,7 @@
 { -1, {"eof"},					701, -1, 8, 2, 0, -1, -1, true, 'p', 'd', false, false, false, true, 0 }, \
 { -1, {"tupcount"},				701, -1, 8, 3, 0, -1, -1, true, 'p', 'd', false, false, false, true, 0 }, \
 { -1, {"varblockcount"},		701, -1, 8, 4, 0, -1, -1, true, 'p', 'd', false, false, false, true, 0 }, \
-{ -1, {"eofuncompressed"},		701, -1, 8, 5, 0, -1, -1, true, 'p', 'd', false, false, false, true, 0 }, \
-{ -1, {"contentid"},			23, -1, 4, 21, 0, -1, -1, true, 'p', 'i', true, false, false, true, 0 }
+{ -1, {"eofuncompressed"},		701, -1, 8, 5, 0, -1, -1, true, 'p', 'd', false, false, false, true, 0 }
 
 /*
  * pg_aoseg_nnnnnn table values for FormData_pg_class.
@@ -64,7 +62,6 @@ typedef struct FileSegInfo
 	TupleVisibilitySummary	tupleVisibilitySummary;
 
 	int			segno;			/* the file segment number */
-	int			content;		/* content id of this tuple */
 	int64		tupcount;		/* total number of tuples in this fileseg */
 	int64		varblockcount;	/* total number of varblocks in this fileseg */	
 	ItemPointerData  sequence_tid;     /* tid for the unique sequence number for this fileseg */

--- a/src/include/access/parquetsegfiles.h
+++ b/src/include/access/parquetsegfiles.h
@@ -30,12 +30,11 @@
 #include "utils/rel.h"
 #include "utils/tqual.h"
 
-#define Natts_pg_parquetseg					5
+#define Natts_pg_parquetseg					4
 #define Anum_pg_parquetseg_segno			1
 #define Anum_pg_parquetseg_eof				2
 #define Anum_pg_parquetseg_tupcount			3
 #define Anum_pg_parquetseg_eofuncompressed	4
-#define Anum_pg_parquetseg_content			5
 
 #define InvalidFileSegNumber			-1
 #define InvalidUncompressedEof			-1
@@ -50,8 +49,7 @@
 { -1, {"segno"}, 				23, -1, 4, 1, 0, -1, -1, true, 'p', 'i', false, false, false, true, 0 }, \
 { -1, {"eof"},					701, -1, 8, 2, 0, -1, -1, true, 'p', 'd', false, false, false, true, 0 }, \
 { -1, {"tupcount"},				701, -1, 8, 3, 0, -1, -1, true, 'p', 'd', false, false, false, true, 0 }, \
-{ -1, {"eofuncompressed"},		701, -1, 8, 5, 0, -1, -1, true, 'p', 'd', false, false, false, true, 0 }, \
-{ -1, {"contentid"},			23, -1, 4, 21, 0, -1, -1, true, 'p', 'i', true, false, false, true, 0 }
+{ -1, {"eofuncompressed"},		701, -1, 8, 5, 0, -1, -1, true, 'p', 'd', false, false, false, true, 0 }
 
 /*
  * pg_parquetseg_nnnnnn table values for FormData_pg_class.
@@ -69,7 +67,6 @@ typedef struct ParquetFileSegInfo {
 	TupleVisibilitySummary tupleVisibilitySummary;
 
 	int segno; /* the file segment number */
-	int content; /* content id of this tuple */
 	int64 tupcount; /* total number of tuples in this fileseg */
 	ItemPointerData sequence_tid; /* tid for the unique sequence number for this fileseg */
 


### PR DESCRIPTION
In HAWQ 2.0, the content column inside the table pg_aoseg.pg_aoseg_xxxxx is meaningless now. We need to remove it.