### PR TITLE
HAWQ-285. not freed connection track instance

### DIFF
--- a/src/backend/resourcemanager/resqueuemanager.c
+++ b/src/backend/resourcemanager/resqueuemanager.c
@@ -5201,6 +5201,7 @@ int rebuildResourceQueueTrackDynamicStatusInShadow(DynResourceQueueTrack  quetra
 							  "one queued query resource and new definition of "
 							  "resource queue %s",
 							  quetrack->QueueInfo->Name);
+				freeUsedConnectionTrack(newconn);
 				return RESQUEMGR_ALTERQUEUE_CONFILICT;
 			}
 		}


### PR DESCRIPTION
This is a bug, in case altering queue statement is canceled, temporary created connection track instance is not freed in rebuildResourceQueueTrackDynamicStatusInShadow()