### PR TITLE
HAWQ-219. Rebuild gp_persistent_relation_node when rebuilding persistent tables

### DIFF
--- a/src/backend/cdb/cdbpersistentbuild.c
+++ b/src/backend/cdb/cdbpersistentbuild.c
@@ -303,6 +303,13 @@ static void PersistentBuild_PopulateGpRelationNode(
 				     dbInfoRel->relname);
 			}*/
 
+            //rebuild gp_persistent_relation_node for AO tables
+            PersistentRelation_AddCreated(
+                &relFileNode,
+                &persistentTid,
+                &persistentSerialNum,
+                false);
+
 			/*
 			 * Merge physical file existence and ao[cs]seg catalog logical EOFs .
 			 */


### PR DESCRIPTION
Fixed bug:  Built-in function gp_persistent_build_all doesn't reshape gp_persistent_relation_node table. No need to add info for heap tables.
