### PR TITLE
HAWQ-293. Enable writable external table to support on number syntax.

### DIFF
--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -4597,13 +4597,6 @@ CreateExternalStmt:	CREATE OptWritable EXTERNAL OptWeb OptTemp TABLE qualified_n
 									extdesc->on_clause = lappend(extdesc->on_clause, 
 										   				   		 makeDefElem("all", (Node *)makeInteger(TRUE)));
 								}
-								else if(n->iswritable)
-								{
-									ereport(ERROR,
-											(errcode(ERRCODE_SYNTAX_ERROR),
-									 		 errmsg("ON clause may not be used with a writable external table"),
-									 		 errOmitLocation(true)));							
-								}
 							}
 
 							if(n->sreh && n->iswritable)

--- a/src/test/regress/output/exttab1_optimizer.source
+++ b/src/test/regress/output/exttab1_optimizer.source
@@ -669,7 +669,7 @@ HINT:  use the gpfdist protocol or COPY FROM instead
 create writable external table wet_neg1(a text, b text) location('gpfdist://@hostname@:7070/wet.out', 'gpfdist://@hostname@:7070/wet.out') format 'text';
 ERROR:  location uri "gpfdist://@hostname@:7070/wet.out" appears more than once
 create writable external web table wet_pos5(a text, b text) execute 'some command' on segment 0 format 'text';
-ERROR:  ON clause may not be used with a writable external table
+ERROR:  the ON segment syntax for writable        external tables is deprecated
 --
 -- SELECT from WET (negative)
 --


### PR DESCRIPTION
writable external table is used for export data in hawq to others.
In hawq1.x default is on all, which is deprecated in hawq2.x
we support this feature by using on number instread of on all.
