### PR TITLE
HAWQ-301. Use combined value to measure segment workload to improve t…

### DIFF
--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -360,7 +360,7 @@ char	*rm_enforce_cgrp_mnt_pnt;
 char	*rm_enforce_cgrp_hier_name;
 double	rm_enforce_cpu_weight;
 double	rm_enforce_core_vpratio;
-int	rm_enforce_cleanup_period;
+int		rm_enforce_cleanup_period;
 
 int	rm_allocation_policy;
 
@@ -369,6 +369,14 @@ char   *rm_seg_tmp_dirs;
 
 int     rm_log_level;
 int     rm_nresqueue_limit;
+
+double	rm_regularize_io_max;
+double	rm_regularize_nvseg_max;
+double	rm_regularize_io_factor;
+double	rm_regularize_usage_factor;
+double	rm_regularize_nvseg_factor;
+
+int		rm_nvseg_variance_among_seg_respool_limit;
 
 /* Greenplum Database Experimental Feature GUCs */
 int         gp_distinct_grouping_sets_threshold = 32;

--- a/src/backend/resourcemanager/include/resourcepool.h
+++ b/src/backend/resourcemanager/include/resourcepool.h
@@ -263,6 +263,7 @@ struct SegResourceData {
 
 	int64_t			IOBytesWorkload; /* Accumulated io bytes number.      	  */
 	int				SliceWorkload;	 /* Accumulated slice number.             */
+	int				NVSeg;			 /* Accumulated vseg number.			  */
 
 	uint64_t        LastUpdateTime;  /* Update it when master receives IMAlive
 										message from segment,                 */
@@ -410,7 +411,7 @@ struct ResourcePoolData {
 	/*
 	 * The index to help finding the nodes having fewest io bytes number accumulated.
 	 */
-	BBSTData		OrderedIOBytesWorkload;
+	BBSTData		OrderedCombinedWorkload;
 
 	/*
 	 * This is for caching all resolved hdfs hostnames which are mapped to one
@@ -561,21 +562,6 @@ typedef struct VSegmentCounterInternalData  VSegmentCounterInternalData;
 typedef struct VSegmentCounterInternalData *VSegmentCounterInternal;
 
 void freeVSegmentConterList(List **list);
-
-int allocateResourceFromResourcePoolIOBytes(int32_t 	nodecount,
-										    int32_t		minnodecount,
-										    uint32_t 	memory,
-										    double 		core,
-										    int64_t		iobytes,
-										    int32_t   	slicesize,
-											int32_t		vseglimitpseg,
-										    int 		preferredcount,
-										    char 	  **preferredhostname,
-										    int64_t    *preferredscansize,
-										    bool		fixnodecount,
-										    List 	  **vsegcounters,
-										    int32_t    *totalvsegcount,
-										    int64_t    *vsegiobytes);
 
 int allocateResourceFromResourcePoolIOBytes2(int32_t 	 nodecount,
 										     int32_t	 minnodecount,

--- a/src/backend/resourcemanager/resourcepool.c
+++ b/src/backend/resourcemanager/resourcepool.c
@@ -158,7 +158,9 @@ int __DRM_NODERESPOOL_comp_combine(void *arg, void *val1, void *val2)
 					   (1.0 * node1->IOBytesWorkload / rm_regularize_io_max);
 		double fact2 = 1.0 -
 					   1.0 * node1->Available.MemoryMB / node1->Allocated.MemoryMB;
-		double fact3 = 1.0 * node1->NVSeg / rm_regularize_nvseg_max;
+		double fact3 = node1->NVSeg > rm_regularize_nvseg_max ?
+					   1.0 :
+					   1.0 * node1->NVSeg / rm_regularize_nvseg_max;
 
 		v1 = fact1 * rm_regularize_io_factor +
 			 fact2 * rm_regularize_usage_factor +
@@ -172,7 +174,9 @@ int __DRM_NODERESPOOL_comp_combine(void *arg, void *val1, void *val2)
 					   (1.0 * node2->IOBytesWorkload / rm_regularize_io_max);
 		double fact2 = 1.0 -
 					   1.0 * node2->Available.MemoryMB / node2->Allocated.MemoryMB;
-		double fact3 = 1.0 * node2->NVSeg / rm_regularize_nvseg_max;
+		double fact3 = node2->NVSeg > rm_regularize_nvseg_max ?
+					   1.0 :
+					   1.0 * node2->NVSeg / rm_regularize_nvseg_max;
 
 		v2 = fact1 * rm_regularize_io_factor +
 			 fact2 * rm_regularize_usage_factor +

--- a/src/backend/resourcemanager/resourcepool.c
+++ b/src/backend/resourcemanager/resourcepool.c
@@ -1993,16 +1993,16 @@ int allocateResourceFromResourcePoolIOBytes2(int32_t 	 nodecount,
 		freePAIRRefList(&(PRESPOOL->Segments), &ressegl);
 		Assert(minnvseg <= maxnvseg);
 
-		//if ( maxnvseg - minnvseg > rm_nvseg_variance_among_seg_respool_limit )
+		if ( maxnvseg - minnvseg > rm_nvseg_variance_among_seg_respool_limit )
 		{
-			elog(WARNING, "Reject virtual segment allocation based on data "
-						  "locality information. After tentative allocation "
-						  "maximum number of virtual segments in one segment is "
-						  "%d minimum number of virtual segments in one segment "
-						  "is %d, tolerated difference limit is %d.",
-						  maxnvseg,
-						  minnvseg,
-						  rm_nvseg_variance_among_seg_respool_limit);
+			elog(LOG, "Reject virtual segment allocation based on data "
+					  "locality information. After tentative allocation "
+					  "maximum number of virtual segments in one segment is "
+					  "%d minimum number of virtual segments in one segment "
+					  "is %d, tolerated difference limit is %d.",
+					  maxnvseg,
+					  minnvseg,
+					  rm_nvseg_variance_among_seg_respool_limit);
 
 			/* Return the allocated resource. */
 			List 	 *vsegcntlist = NULL;
@@ -2035,6 +2035,9 @@ int allocateResourceFromResourcePoolIOBytes2(int32_t 	 nodecount,
 
 			/* Clear the content in the virtual segment counter hashtable. */
 			clearHASHTABLE(&vsegcnttbl);
+
+			/* Restore nodecount. */
+			nodecountleft = nodecount;
 		}
 	}
 

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -6339,7 +6339,7 @@ static struct config_int ConfigureNamesInt[] =
 			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&rm_allocation_policy,
-		1, 0, 10, NULL, NULL
+		0, 0, 0, NULL, NULL
 	},
 
     {
@@ -6476,6 +6476,17 @@ static struct config_int ConfigureNamesInt[] =
 		},
 		&rm_nvseg_variance_among_seg_limit,
 		1, 0, 65535, NULL, NULL
+	},
+
+	{
+		{"hawq_rm_nvseg_variance_amon_seg_respool_limit", PGC_POSTMASTER, RESOURCES_MGM,
+			gettext_noop("the variance of vseg number in each segment that resource manager "
+						 "should tolerate at most in resource pool when choosing segments "
+						 "based on data locality reference."),
+			NULL
+		},
+		&rm_nvseg_variance_among_seg_respool_limit,
+		2, 0, 65535, NULL, NULL
 	},
 
 	{
@@ -6869,6 +6880,51 @@ static struct config_real ConfigureNamesReal[] =
 		},
 		&rm_enforce_core_vpratio,
 		1.0, 0.0, INT_MAX, NULL, NULL
+	},
+
+	{
+		{"hawq_rm_regularize_io_max",PGC_POSTMASTER, RESOURCES_MGM,
+			gettext_noop("Set the maximum io workload limit for regularize the workload of one segment."),
+			NULL
+		},
+		&rm_regularize_io_max,
+		137438953472.0 /* 128gb */, 0.0, DBL_MAX, NULL, NULL
+	},
+
+	{
+		{"hawq_rm_regularize_nvseg_max",PGC_POSTMASTER, RESOURCES_MGM,
+			gettext_noop("Set the maximum number of virtual segments for regularize the workload of one segment."),
+			NULL
+		},
+		&rm_regularize_nvseg_max,
+		300.0, 0.0, DBL_MAX, NULL, NULL
+	},
+
+	{
+		{"hawq_rm_regularize_io_factor",PGC_POSTMASTER, RESOURCES_MGM,
+			gettext_noop("Set the factor of io workload in combined workload of a segment."),
+			NULL
+		},
+		&rm_regularize_io_factor,
+		1.0, 0.0, DBL_MAX, NULL, NULL
+	},
+
+	{
+		{"hawq_rm_regularize_usage_factor",PGC_POSTMASTER, RESOURCES_MGM,
+			gettext_noop("Set the factor of resource usage in combined workload of a segment."),
+			NULL
+		},
+		&rm_regularize_usage_factor,
+		1.0, 0.0, DBL_MAX, NULL, NULL
+	},
+
+	{
+		{"hawq_rm_regularize_nvseg_factor",PGC_POSTMASTER, RESOURCES_MGM,
+			gettext_noop("Set the factor of number of virtual segments in combined workload of a segment."),
+			NULL
+		},
+		&rm_regularize_nvseg_factor,
+		1.0, 0.0, DBL_MAX, NULL, NULL
 	},
 
 	{

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -1217,6 +1217,14 @@ extern char   *rm_seg_tmp_dirs;
 extern int     rm_log_level;
 extern int     rm_nresqueue_limit;
 
+extern double  rm_regularize_io_max;
+extern double  rm_regularize_nvseg_max;
+extern double  rm_regularize_io_factor;
+extern double  rm_regularize_usage_factor;
+extern double  rm_regularize_nvseg_factor;
+
+extern int	   rm_nvseg_variance_among_seg_respool_limit;
+
 extern int max_filecount_notto_split_segment;
 extern int min_datasize_to_combine_segment;
 extern int datalocality_algorithm_version;


### PR DESCRIPTION
In one segment, the combined workload counts:
1) total number of virtual segments allocated;
2) resource usage rate ( used/allocated );
3) estimated accumulated IO workload;
The new vsegs are allocated in the segments having lower combined workload. If data loclaity information is provided when one client requests query resource, the unbalance of number of vsegs among segments are restricted.

double	rm_regularize_io_max; // maximum limit of accumulated estimated io workload in one segment for workload regularization.
double	rm_regularize_nvseg_max; // maximum limit of accumulated number of vsegs in one segment for workload regularization.
double	rm_regularize_io_factor; // factor of accumulated estimated io workload, 1 as default.
double	rm_regularize_usage_factor; // factor of resource usage, 1 as default.
double	rm_regularize_nvseg_factor; // factor of accumulated number of vsegs, 1 as default.

int		rm_nvseg_variance_among_seg_respool_limit; // the limit of unbalance of accumulated number of vsegs among segments after getting tentative vseg allocation based on data locality information.
