### PR TITLE
HAWQ-314. Fix AO Read when a segment file larger than 4TB

### DIFF
--- a/src/backend/cdb/cdbbufferedread.c
+++ b/src/backend/cdb/cdbbufferedread.c
@@ -155,7 +155,7 @@ void BufferedReadSetFile(
 	bufferedRead->haveTemporaryLimitInEffect = false;
 	bufferedRead->temporaryLimitFileLen = 0;
 
-    int32 real_fileLen = fileLen - bufferedRead->largeReadPosition; 
+    int64 real_fileLen = fileLen - bufferedRead->largeReadPosition;
 	if (real_fileLen > 0)
 	{
 		/*


### PR DESCRIPTION
"real_fileLen" should be int64 as "fileLen" is a int64 number and "bufferedRead->largeReadPosition" is also a int64 number.
According to the code, a int64 number is changed to int32 which make the number wrong.
See more in https://issues.apache.org/jira/browse/HAWQ-314