### PR TITLE
HAWQ-103. Build PXF RPMs with license and vendor parameters

### DIFF
--- a/pxf/Makefile
+++ b/pxf/Makefile
@@ -5,13 +5,23 @@ ifneq "$(HD)" ""
 BUILD_PARAMS= -Dhd=$(HD)
 endif
 
+ifneq "$(LICENSE)" ""
+BUILD_PARAMS+= -Plicense="$(LICENSE)"
+endif
+ifneq "$(VENDOR)" ""
+BUILD_PARAMS+= -Pvendor="$(VENDOR)"
+endif
+
 help:
 	@echo 
 	@echo	"help it is then"
 	@echo	"Possible targets"
 	@echo	"  - all (clean, build, unittest, jar, tar, rpm)"
 	@echo	"  -  -  HD=<phd|hdp> - set classpath to match hadoop distribution. default phd"
+	@echo	"  -  -  LICENSE=<license info> - add license info to created RPMs"
+	@echo	"  -  -  VENDOR=<vendor name> - add vendor name to created RPMs"
 	@echo	"  - tomcat - builds tomcat rpm from downloaded tarball"
+	@echo	"  -  -  LICENSE and VENDOR parameters can be used as well"
 
 all: 
 	./gradlew clean release $(BUILD_PARAMS)
@@ -33,5 +43,5 @@ clean:
 
 .PHONY: tomcat
 tomcat:
-	./gradlew tomcatRpm
+	./gradlew tomcatRpm $(BUILD_PARAMS)
 

--- a/pxf/build.gradle
+++ b/pxf/build.gradle
@@ -110,11 +110,11 @@ subprojects { subProject ->
     //buildRpm
     ospackage {
         summary = 'The PXF extensions library for HAWQ'
-        vendor = 'Pivotal'
+        vendor = project.vendor
         release = buildNumber()
         version = subProject.version.split('-')[0];
         os = LINUX
-        license = "ASL 2.0"
+        license = project.license
         obsoletes('gpxf')
         user = 'root'
         permissionGroup = 'root'
@@ -389,11 +389,11 @@ task tomcatRpm(type: Rpm) {
     ospackage {
         packageName 'apache-tomcat'
         summary = 'Apache Tomcat RPM'
-        vendor = 'Pivotal'
+        vendor = project.vendor
         release = buildNumber()
         version = tomcatVersion
         os = LINUX
-        license = "ASL 2.0"
+        license = project.license
         user = 'root'
         permissionGroup = 'root'
 

--- a/pxf/gradle.properties
+++ b/pxf/gradle.properties
@@ -17,7 +17,7 @@
 
 version=3.0.0
 license=ASL 2.0
-vendor=
+vendor=Apache HAWQ Incubating
 hadoopVersion=2.7.1
 hiveVersion=1.2.1
 hbaseVersionJar=1.1.2

--- a/pxf/gradle.properties
+++ b/pxf/gradle.properties
@@ -16,6 +16,8 @@
 # under the License.
 
 version=3.0.0
+license=ASL 2.0
+vendor=
 hadoopVersion=2.7.1
 hiveVersion=1.2.1
 hbaseVersionJar=1.1.2


### PR DESCRIPTION
By default the license is "ASL 2.0" and the vendor is left empty.
