### PR TITLE
HAWQ-300. Fix out of memory during loading large volume data on large cluster with YARN mode

### DIFF
--- a/src/backend/utils/init/globals.c
+++ b/src/backend/utils/init/globals.c
@@ -150,4 +150,5 @@ int hawq_re_memory_overcommit_max = 8192;
 #else
 int hawq_re_memory_overcommit_max = 8192;
 #endif
+double hawq_re_memory_quota_allocation_ratio = 0.5;
 int gp_vmem_protect_gang_cache_limit = 500;

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -6956,6 +6956,16 @@ static struct config_real ConfigureNamesReal[] =
 		3.0, 1.0, 100.0, NULL, NULL
 	},
 
+	{
+		{"hawq_re_memory_quota_allocation_ratio", PGC_USERSET, RESOURCES_MEM,
+			gettext_noop("Sets the ratio for memory quota allocation during query optimization."),
+			NULL,
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+		},
+		&hawq_re_memory_quota_allocation_ratio,
+		0.5, 0.0, 1.0, NULL, NULL
+	},
+
 /* End-of-list marker */
 	{
 		{NULL, 0, 0, NULL, NULL}, NULL, 0.0, 0.0, 0.0, NULL, NULL

--- a/src/include/miscadmin.h
+++ b/src/include/miscadmin.h
@@ -314,6 +314,7 @@ extern int	VacuumCostBalance;
 extern bool VacuumCostActive;
 
 extern int hawq_re_memory_overcommit_max;
+extern double hawq_re_memory_quota_allocation_ratio;
 extern int gp_vmem_protect_gang_cache_limit;
 
 /* in tcop/postgres.c */

--- a/src/test/regress/expected/parquet_compression.out
+++ b/src/test/regress/expected/parquet_compression.out
@@ -26,7 +26,7 @@ drop table parquet_snappy_part_unc;
 ERROR:  table "parquet_snappy_part_unc" does not exist
 drop table parquet_gzip_2;
 ERROR:  table "parquet_gzip_2" does not exist
-alter resource queue pg_default with ( vseg_resource_quota='mem:2gb');
+alter resource queue pg_default with ( vseg_resource_quota='mem:4gb');
 --set statement_mem='1999MB';
 --end_ignore
 --Datatypes covered: text,bytea,varchar,bit varying

--- a/src/test/regress/sql/parquet_compression.sql
+++ b/src/test/regress/sql/parquet_compression.sql
@@ -19,7 +19,7 @@ drop table parquet_snappy_part;
 drop table parquet_snappy_part_unc;
 drop table parquet_gzip_2;
 
-alter resource queue pg_default with ( vseg_resource_quota='mem:2gb');
+alter resource queue pg_default with ( vseg_resource_quota='mem:4gb');
 --set statement_mem='1999MB';
 --end_ignore
 


### PR DESCRIPTION
The fix tries to assign query memory quota to memory intensive operators in a conservative manner.
At present, we give GUC hawq_re_memory_quota_allocation_ratio a default value 0.5. This needs to be tuned later with more tests.