### PR TITLE
HAWQ-325. In 3-node cluster HAWQ RM does not allocate resource to que…

### DIFF
--- a/src/backend/resourcemanager/resourcemanager.c
+++ b/src/backend/resourcemanager/resourcemanager.c
@@ -646,7 +646,6 @@ int MainHandlerLoop(void)
         if ( PRESPOOL->Segments.NodeCount > 0 && PQUEMGR->RatioCount > 0 &&
 			 PQUEMGR->toRunQueryDispatch &&
 			 PQUEMGR->ForcedReturnGRMContainerCount == 0 &&
-			 PRESPOOL->AddPendingContainerCount == 0 &&
 			 PRESPOOL->SlavesHostCount > 0 )
         {
     		dispatchResourceToQueries();


### PR DESCRIPTION
…ries if two nodes have no resource allocated from YARN

This fix is to avoid waiting for pending YARN containers when allocating resource to query resource requests.