### PR TITLE
HAWQ-329. Remove statement_mem and deprecated resource queue policy s…

### DIFF
--- a/src/backend/cdb/cdbexplain.c
+++ b/src/backend/cdb/cdbexplain.c
@@ -2194,19 +2194,17 @@ cdbexplain_showExecStatsEnd(struct PlannedStmt *stmt,
        appendStringInfoChar(str, '\n');
     }
     
-    if (gp_resqueue_memory_policy != RESQUEUE_MEMORY_POLICY_NONE)
-    {
-        appendStringInfoString(str, "Statement statistics:\n");
-        appendStringInfo(str, "  Memory used: %.0fK bytes", ceil((double) stmt->query_mem / 1024.0));
+    appendStringInfoString(str, "Statement statistics:\n");
+    appendStringInfo(str, "  Memory used: %.0fK bytes", ceil((double) stmt->query_mem / 1024.0));
         
-        if (showstatctx->workmemwanted_max > 0)
-        {
-            appendStringInfo(str, "\n  Memory wanted: %.0fK bytes", 
-            		(double) PolicyAutoStatementMemForNoSpillKB(stmt, (uint64) showstatctx->workmemwanted_max / 1024L));        	
-        }
-        
-        appendStringInfoChar(str, '\n');
-    }
+    if (showstatctx->workmemwanted_max > 0)
+	{
+		appendStringInfo(str, "\n  Memory wanted: %.0fK bytes",
+				(double) StatementMemForNoSpillKB(stmt, (uint64) showstatctx->workmemwanted_max / 1024L));
+	}
+
+	appendStringInfoChar(str, '\n');
+
 }                               /* cdbexplain_showExecStatsEnd */
 
 static int

--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -1204,59 +1204,11 @@ gpvars_assign_gp_hash_index(bool newval, bool doit, GucSource source)
 }
 
 /*
- * gpvars_assign_gp_resqueue_memory_policy
- * gpvars_show_gp_resqueue_memory_policy
- */
-const char *
-gpvars_assign_gp_resqueue_memory_policy(const char *newval, bool doit, GucSource source __attribute__((unused)) )
-{
-	ResQueueMemoryPolicy newtype = RESQUEUE_MEMORY_POLICY_NONE;
-
-	if (newval == NULL || newval[0] == 0 ||
-		!pg_strcasecmp("none", newval))
-		newtype = RESQUEUE_MEMORY_POLICY_NONE;
-	else if (!pg_strcasecmp("auto", newval))
-		newtype = RESQUEUE_MEMORY_POLICY_AUTO;
-	else if (!pg_strcasecmp("eager_free", newval))
-		newtype = RESQUEUE_MEMORY_POLICY_EAGER_FREE;
-	else
-		elog(ERROR, "unknown resource queue memory policy: current policy is '%s'", gpvars_show_gp_resqueue_memory_policy());
-
-	if (doit)
-	{
-		gp_resqueue_memory_policy = newtype;
-	}
-
-	return newval;
-}
-
-const char *
-gpvars_show_gp_resqueue_memory_policy(void)
-{
-	switch(gp_resqueue_memory_policy)
-	{
-		case RESQUEUE_MEMORY_POLICY_NONE:
-			return "none";
-		case RESQUEUE_MEMORY_POLICY_AUTO:
-			return "auto";
-		case RESQUEUE_MEMORY_POLICY_EAGER_FREE:
-			return "eager_free";
-		default:
-			return "none";
-	}
-}
-
-/*
  * gpvars_assign_statement_mem
  */
 bool
 gpvars_assign_statement_mem(int newval, bool doit, GucSource source __attribute__((unused)) )
 {
-	if (newval >= max_statement_mem)
-	{
-		elog(ERROR, "Invalid input for statement_mem. Must be less than max_statement_mem (%d kB).", max_statement_mem);
-	}
-
 	if (doit)
 	{
 		statement_mem = newval;

--- a/src/backend/commands/explain.c
+++ b/src/backend/commands/explain.c
@@ -500,17 +500,15 @@ ExplainOnePlan_internal(PlannedStmt *plannedstmt,
 	else
 		eflags = EXEC_FLAG_EXPLAIN_ONLY;
 
-    if (gp_resqueue_memory_policy != RESQUEUE_MEMORY_POLICY_NONE)
-    {
-		if (superuser())
-		{
-			queryDesc->plannedstmt->query_mem = ResourceQueueGetSuperuserQueryMemoryLimit();			
-		}
-		else
-		{
-			queryDesc->plannedstmt->query_mem = ResourceQueueGetSuperuserQueryMemoryLimit();
-		}
-    }
+	if ( queryDesc->resource != NULL )
+	{
+		queryDesc->plannedstmt->query_mem = queryDesc->resource->segment_memory_mb;
+		queryDesc->plannedstmt->query_mem *= 1024L * 1024L;
+	}
+	else
+	{
+		queryDesc->plannedstmt->query_mem = statement_mem * 1024;
+	}
 
 	/* call ExecutorStart to prepare the plan for execution */
 	ExecutorStart(queryDesc, eflags);

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -456,9 +456,7 @@ ExecutorStart(QueryDesc *queryDesc, int eflags)
                     memAvailableBytes = queryDesc->plannedstmt->query_mem * hawq_re_memory_quota_allocation_ratio;
                 }
 
-                PolicyEagerFreeAssignOperatorMemoryKB(queryDesc->plannedstmt,
-                                                      memAvailableBytes);
-
+                AssignOperatorMemoryKB(queryDesc->plannedstmt, memAvailableBytes);
             }
         }
         

--- a/src/backend/executor/execUtils.c
+++ b/src/backend/executor/execUtils.c
@@ -2290,10 +2290,7 @@ void mppExecutorCleanup(QueryDesc *queryDesc)
 	/**
 	 * Since there was an error, clean up the function scan stack.
 	 */
-	if (gp_resqueue_memory_policy != RESQUEUE_MEMORY_POLICY_NONE)
-	{
-		SPI_InitMemoryReservation();
-	}
+	SPI_InitMemoryReservation();
 }
 
 void

--- a/src/backend/executor/functions.c
+++ b/src/backend/executor/functions.c
@@ -484,8 +484,7 @@ postquel_start(execution_state *es, SQLFunctionCachePtr fcache)
 			AfterTriggerBeginQuery();
 		
 		
-    	if (gp_resqueue_memory_policy != RESQUEUE_MEMORY_POLICY_NONE
-    			&& SPI_IsMemoryReserved())
+    	if (SPI_IsMemoryReserved())
     	{
     		es->qd->plannedstmt->query_mem = SPI_GetMemoryReservation();                		
     	}

--- a/src/backend/executor/nodeFunctionscan.c
+++ b/src/backend/executor/nodeFunctionscan.c
@@ -271,10 +271,7 @@ ExecInitFunctionScan(FunctionScan *node, EState *estate, int eflags)
 
 	initGpmonPktForFunctionScan((Plan *)node, &scanstate->ss.ps.gpmon_pkt, estate);
 	
-	if (gp_resqueue_memory_policy != RESQUEUE_MEMORY_POLICY_NONE)
-	{
-		SPI_ReserveMemory(((Plan *)node)->operatorMemKB * 1024L);
-	}
+	SPI_ReserveMemory(((Plan *)node)->operatorMemKB * 1024L);
 
 	return scanstate;
 }

--- a/src/backend/executor/nodeResult.c
+++ b/src/backend/executor/nodeResult.c
@@ -422,8 +422,7 @@ ExecInitResult(Result *node, EState *estate, int eflags)
 	ExecAssignResultTypeFromTL(&resstate->ps);
 	ExecAssignProjectionInfo(&resstate->ps, NULL);
 
-	if (gp_resqueue_memory_policy != RESQUEUE_MEMORY_POLICY_NONE
-			&& IsResultMemoryIntesive(node))
+	if (IsResultMemoryIntesive(node))
 	{
 		SPI_ReserveMemory(((Plan *)node)->operatorMemKB * 1024L);
 	}

--- a/src/backend/executor/spi.c
+++ b/src/backend/executor/spi.c
@@ -2134,12 +2134,11 @@ _SPI_pquery(QueryDesc * queryDesc, bool fire_triggers, long tcount)
 		ResetUsage();
 #endif
 	
-	if (gp_resqueue_memory_policy != RESQUEUE_MEMORY_POLICY_NONE
-			&& superuser())
+	if (superuser())
 	{
 		if (!SPI_IsMemoryReserved())
 		{
-			queryDesc->plannedstmt->query_mem = ResourceQueueGetSuperuserQueryMemoryLimit();                		
+			queryDesc->plannedstmt->query_mem = statement_mem * 1024L;
 		}
 		else
 		{
@@ -2446,7 +2445,6 @@ static uint64 SPIMemReserved = 0;
  */
 void SPI_InitMemoryReservation(void)
 {
-	Assert(gp_resqueue_memory_policy != RESQUEUE_MEMORY_POLICY_NONE);
 	SPIMemReserved = (uint64) statement_mem * 1024L;;
 }
 
@@ -2458,16 +2456,10 @@ void SPI_InitMemoryReservation(void)
  */
 void SPI_ReserveMemory(uint64 mem_reserved)
 {
-	Assert(gp_resqueue_memory_policy != RESQUEUE_MEMORY_POLICY_NONE);
 	if (mem_reserved > 0
-			&& (SPIMemReserved == 0 || mem_reserved < SPIMemReserved))
+		&& (SPIMemReserved == 0 || mem_reserved < SPIMemReserved))
 	{
 		SPIMemReserved = mem_reserved;
-	}
-
-	if (gp_log_resqueue_memory)
-	{
-		elog(gp_resqueue_memory_log_level, "SPI memory reservation %d", (int) SPIMemReserved);
 	}
 }
 
@@ -2477,7 +2469,6 @@ void SPI_ReserveMemory(uint64 mem_reserved)
  */
 uint64 SPI_GetMemoryReservation(void)
 {
-	Assert(gp_resqueue_memory_policy != RESQUEUE_MEMORY_POLICY_NONE);
 	return SPIMemReserved;
 }
 
@@ -2486,7 +2477,6 @@ uint64 SPI_GetMemoryReservation(void)
  */
 bool SPI_IsMemoryReserved(void)
 {
-	Assert(gp_resqueue_memory_policy != RESQUEUE_MEMORY_POLICY_NONE);
 	return (SPIMemReserved == 0);
 }
 

--- a/src/backend/storage/ipc/ipci.c
+++ b/src/backend/storage/ipc/ipci.c
@@ -389,10 +389,7 @@ CreateSharedMemoryAndSemaphores(bool makePrivate, int port)
 		ShmemBackendArrayAllocation();
 #endif
 	
-	if (gp_resqueue_memory_policy != RESQUEUE_MEMORY_POLICY_NONE)
-	{
-		SPI_InitMemoryReservation();
-	}
+	SPI_InitMemoryReservation();
 	
 	/*
 	 * Now give loadable modules a chance to set up their shmem allocations

--- a/src/backend/utils/init/globals.c
+++ b/src/backend/utils/init/globals.c
@@ -106,7 +106,6 @@ int			planner_work_mem = 32768;
 int			work_mem = 32768;
 int			max_work_mem = 1024000;
 int			statement_mem = 256000;
-int			max_statement_mem = 2048000;
 /*
  * gp_vmem_limit_per_query set to 0 means we
  * do not enforce per-query memory limit

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -3332,17 +3332,6 @@ static struct config_bool ConfigureNamesBool[] =
 	},
 
 	{
-
-		{"gp_log_resqueue_memory", PGC_USERSET, LOGGING_WHAT,
-			gettext_noop("Prints out messages related to resource queue's memory management."),
-			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
-		},
-		&gp_log_resqueue_memory,
-		false, NULL, NULL
-	},
-
-	{
 		{"gp_resqueue_print_operator_memory_limits", PGC_USERSET, LOGGING_WHAT,
 			gettext_noop("Prints out the memory limit for operators (in explain) assigned by resource queue's "
 						 "memory management."),
@@ -4828,8 +4817,8 @@ static struct config_int ConfigureNamesInt[] =
 	},
 
 	{
-		{"statement_mem", PGC_USERSET, RESOURCES_MEM,
-			gettext_noop("Sets the memory to be reserved for a statement."),
+		{"default_statement_mem", PGC_USERSET, RESOURCES_MEM,
+			gettext_noop("Sets the default memory to be reserved for a statement."),
 			NULL,
 			GUC_UNIT_KB | GUC_GPDB_ADDOPT
 		},
@@ -4840,16 +4829,6 @@ static struct config_int ConfigureNamesInt[] =
 #else
 		128000, 1000, INT_MAX, gpvars_assign_statement_mem, NULL
 #endif
-	},
-
-	{
-		{"max_statement_mem", PGC_SUSET, RESOURCES_MEM,
-		 	gettext_noop("Sets the maximum value for statement_mem setting."),
-		 	NULL,
-			GUC_UNIT_KB | GUC_GPDB_ADDOPT
-		},
-		&max_statement_mem,
-		2048000, 32768, INT_MAX, NULL, NULL
 	},
 
 	{
@@ -7941,15 +7920,6 @@ static struct config_string ConfigureNamesString[] =
 		},
 		&pljava_classpath,
 		"", NULL, NULL
-	},
-
-	{
-		{"gp_resqueue_memory_policy", PGC_SUSET, RESOURCES_MGM,
-			gettext_noop("Sets the policy for memory allocation of queries."),
-			gettext_noop("Valid values are NONE, AUTO, EAGER_FREE.")
-		},
-		&gp_resqueue_memory_policy_str,
-		"none", gpvars_assign_gp_resqueue_memory_policy, gpvars_show_gp_resqueue_memory_policy
 	},
 
 	{

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -1098,9 +1098,6 @@ extern bool gpvars_assign_gp_hash_index(bool newval, bool doit, GucSource source
 /* wire off SET WITH() for alter table distributed by */
 extern bool gp_disable_atsdb_set_with;
 
-extern const char *gpvars_assign_gp_resqueue_memory_policy(const char *newval, bool doit, GucSource source __attribute__((unused)) );
-extern const char *gpvars_show_gp_resqueue_memory_policy(void);
-
 extern bool gpvars_assign_statement_mem(int newval, bool doit, GucSource source __attribute__((unused)) );
 
 extern void increment_command_count(void);

--- a/src/include/cdb/memquota.h
+++ b/src/include/cdb/memquota.h
@@ -30,32 +30,15 @@
 #include "nodes/plannodes.h"
 #include "cdb/cdbplan.h"
 
-typedef enum ResQueueMemoryPolicy
-{
-	RESQUEUE_MEMORY_POLICY_NONE,
-	RESQUEUE_MEMORY_POLICY_AUTO,
-	RESQUEUE_MEMORY_POLICY_EAGER_FREE
-} ResQueueMemoryPolicy;
+extern int 	gp_resqueue_memory_policy_auto_fixed_mem;
+extern bool	gp_resqueue_print_operator_memory_limits;
 
-extern char                		*gp_resqueue_memory_policy_str;
-extern ResQueueMemoryPolicy		gp_resqueue_memory_policy;
-extern bool						gp_log_resqueue_memory;
-extern int						gp_resqueue_memory_policy_auto_fixed_mem;
-extern const int				gp_resqueue_memory_log_level;
-extern bool						gp_resqueue_print_operator_memory_limits;
-
-extern void PolicyAutoAssignOperatorMemoryKB(PlannedStmt *stmt, uint64 memoryAvailable);
-extern void PolicyEagerFreeAssignOperatorMemoryKB(PlannedStmt *stmt, uint64 memoryAvailable);
-
-/**
- * What is the memory reservation for superuser queries?
- */
-extern uint64 ResourceQueueGetSuperuserQueryMemoryLimit(void);
+extern void AssignOperatorMemoryKB(PlannedStmt *stmt, uint64 memoryAvailable);
 
 /**
  * Inverse for explain analyze.
  */
-extern uint64 PolicyAutoStatementMemForNoSpillKB(PlannedStmt *stmt, uint64 minOperatorMemKB);
+extern uint64 StatementMemForNoSpillKB(PlannedStmt *stmt, uint64 minOperatorMemKB);
 
 /**
  * Is result node memory intensive?

--- a/src/include/miscadmin.h
+++ b/src/include/miscadmin.h
@@ -301,7 +301,6 @@ extern PGDLLIMPORT int work_mem;
 extern PGDLLIMPORT int max_work_mem;
 extern PGDLLIMPORT int maintenance_work_mem;
 extern PGDLLIMPORT int statement_mem;
-extern PGDLLIMPORT int max_statement_mem;
 extern PGDLLIMPORT int gp_vmem_limit_per_query;
 
 extern int	VacuumCostPageHit;

--- a/src/test/regress/expected/parquet_compression.out
+++ b/src/test/regress/expected/parquet_compression.out
@@ -27,7 +27,6 @@ ERROR:  table "parquet_snappy_part_unc" does not exist
 drop table parquet_gzip_2;
 ERROR:  table "parquet_gzip_2" does not exist
 alter resource queue pg_default with ( vseg_resource_quota='mem:4gb');
---set statement_mem='1999MB';
 --end_ignore
 --Datatypes covered: text,bytea,varchar,bit varying
 -- parquet table ,compresstype = gzip

--- a/src/test/regress/sql/parquet_compression.sql
+++ b/src/test/regress/sql/parquet_compression.sql
@@ -20,7 +20,6 @@ drop table parquet_snappy_part_unc;
 drop table parquet_gzip_2;
 
 alter resource queue pg_default with ( vseg_resource_quota='mem:4gb');
---set statement_mem='1999MB';
 --end_ignore
 
 --Datatypes covered: text,bytea,varchar,bit varying

--- a/src/test/regress/sql/parquet_subpartition.sql
+++ b/src/test/regress/sql/parquet_subpartition.sql
@@ -7,7 +7,6 @@ DROP TABLE if exists parquet_wt_subpartgzip7 cascade;
 
 DROP TABLE if exists parquet_wt_subpartgzip7_uncompr cascade;
 
-SET statement_mem='1999MB';
 --end_ignore
 --
 -- Create table

--- a/src/test/unit/mock/mock_info.json
+++ b/src/test/unit/mock/mock_info.json
@@ -11033,33 +11033,7 @@
                 "source"
             ], 
             "return": "char*"
-        }, 
-        "gpvars_assign_gp_resqueue_memory_policy": {
-            "filename": "src/backend/cdb/cdbvars.c", 
-            "header filename": "src/include/cdb/cdbvars.h", 
-            "parameter": [
-                "newval", 
-                "doit", 
-                "source"
-            ], 
-            "return": "char*"
-        }, 
-        "gpvars_assign_statement_mem": {
-            "filename": "src/backend/cdb/cdbvars.c", 
-            "header filename": "src/include/cdb/cdbvars.h", 
-            "parameter": [
-                "newval", 
-                "doit", 
-                "source"
-            ], 
-            "return": "bool"
-        }, 
-        "gpvars_show_gp_autostats_mode": {
-            "filename": "src/backend/cdb/cdbvars.c", 
-            "header filename": "src/include/cdb/cdbvars.h", 
-            "parameter": [], 
-            "return": "char*"
-        }, 
+        },  
         "gpvars_show_gp_autostats_mode_in_functions": {
             "filename": "src/backend/cdb/cdbvars.c", 
             "header filename": "src/include/cdb/cdbvars.h", 
@@ -14547,10 +14521,6 @@
         "max_prepared_xacts": {
             "filename": "src/backend/access/transam/twophase.c", 
             "header filename": "src/include/access/twophase.h"
-        }, 
-        "max_statement_mem": {
-            "filename": "src/backend/tcop/postgres.c", 
-            "header filename": "src/include/miscadmin.h"
         }, 
         "max_work_mem": {
             "filename": "src/backend/tcop/postgres.c", 


### PR DESCRIPTION
Remove statement_mem and deprecated resource queue policy setting

New guc names default_statement_mem is introduced for defining default resource quota for those queries not dispatched to segments.

HAWQ1.x resource queue policy settings are removed as well.