### PR TITLE
HAWQ-336. Set default net_disk_ratio to 1.0.

### DIFF
--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -6971,7 +6971,7 @@ static struct config_real ConfigureNamesReal[] =
 			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&net_disk_ratio,
-		3.0, 1.0, 100.0, NULL, NULL
+		1.0, 1.0, 100.0, NULL, NULL
 	},
 
 	{


### PR DESCRIPTION
After performance test, we decide to change default net_disk_ratio from 3.0 to 1.0. It'll reach better performance on large dataset or complex query.