### PR TITLE
HAWQ-272. Quit resource manager process on segment if postmaster is n…

### DIFF
--- a/src/backend/resourcemanager/resourcemanager_RMSEG.c
+++ b/src/backend/resourcemanager/resourcemanager_RMSEG.c
@@ -160,6 +160,12 @@ int MainHandlerLoop_RMSEG(void)
 
 	while( DRMGlobalInstance->ResManagerMainKeepRun ) {
 
+		if (!PostmasterIsAlive(true)) {
+			DRMGlobalInstance->ResManagerMainKeepRun = false;
+			elog(LOG, "Postmaster is not alive, resource manager exits");
+			break;
+		}
+
 		/* PART1. Handle socket server inputs. */
 		res = processAllCommFileDescs();
 		if ( res != FUNC_RETURN_OK ) {


### PR DESCRIPTION
This commit is to fix the bug, segment's postmaster process is killed, but segment's resource manager still alive and send IMAlive message to master resource manager. But actually, this segment can't work.
Please review. Thanks!
