### PR TITLE
HAWQ-342. Update copyright to 2016

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Apache HAWQ (incubating) 
-Copyright 2015 The Apache Software Foundation.
+Copyright 2016 The Apache Software Foundation.
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).


### PR DESCRIPTION
Based on feedback I saw on some other Apache Podling votes I noticed that our NOTICE file had not been updated for 2016.  

Note: this does *not* update copyright dates on some other components such as:
> HBase
> Apache HBase
> Copyright 2007-2015 The Apache Software Foundation

Because these copyrights are based on the versions of our dependencies and these should be updated when we update to newer versions that themselves have updated copyrights - I think.

It also does not update:
> Portions Copyright (c) 2014-2015, Pivotal Inc.

Because all changes since donating the code to Apache are under the Apache ICLA agreement and thus Copyright to Apache.