### PR TITLE
HAWQ-347. Fixed dead lock between pg_filespace lock and PersistentObj…

### DIFF
--- a/src/backend/access/transam/xlog_mm.c
+++ b/src/backend/access/transam/xlog_mm.c
@@ -495,7 +495,7 @@ emit_mmxlog_fs_record(mm_fs_obj_type type, Oid filespace,
 	xlrec.database = database;
 	xlrec.relfilenode = relfilenode;
 	xlrec.segnum = segnum;
-	xlrec.shared = is_filespace_shared(filespace);
+	xlrec.shared = (SYSTEMFILESPACE_OID!=filespace); //cannot call is_filespace_shared(filespace); here, it will cause deadlock with PersistentObjLock
     xlrec.persistentTid = *persistentTid;
     xlrec.persistentSerialNum = persistentSerialNum;
 


### PR DESCRIPTION
…Lock

In hawq1.x, segment on master node will use local disk, segments on other segment nodes will use hdfs. However in hawq2.0 we make all segment use hdfs. So now only the pg_system file space use local hdfs.