### PR TITLE
HAWQ-290. Add faultinjector for test.

### DIFF
--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -2325,6 +2325,13 @@ CommitTransaction(void)
 	 * We don't need to worry about inconsistent states between them. So no
 	 * CHECKPOINT_START_LOCK any more.
 	 */
+#ifdef FAULT_INJECTOR
+	FaultInjector_InjectFaultIfSet(
+			Checkpoint,
+			DDLNotSpecified,
+			"",	// databaseName
+			""); // tableName
+#endif
 
 	/* Prevent cancel/die interrupt while cleaning up */
 	HOLD_INTERRUPTS();
@@ -2813,7 +2820,13 @@ AbortTransaction(void)
 	 * We don't need to worry about inconsistent states between them. So no
 	 * CHECKPOINT_START_LOCK any more.
 	 */
-
+#ifdef FAULT_INJECTOR
+	FaultInjector_InjectFaultIfSet(
+			Checkpoint,
+			DDLNotSpecified,
+			"",	// databaseName
+			""); // tableName
+#endif
 	/*
 	 * Advertise the fact that we aborted in pg_clog (assuming that we got as
 	 * far as assigning an XID to advertise).


### PR DESCRIPTION
As we removed CHECKPOINT_START_LOCK , we need to set fault_injector here, then we can test it.