### PR TITLE
HAWQ-155. Fix bug for out of range access to the hdfs file as scan a …

### DIFF
--- a/src/backend/cdb/cdbappendonlystorageread.c
+++ b/src/backend/cdb/cdbappendonlystorageread.c
@@ -728,8 +728,11 @@ AppendOnlyStorageRead_PositionToNextBlock(
 	 * Determine the maximum boundary of the block.
 	 * UNDONE: When we have a block directory, we will tighten the limit down.
 	 */
-	fileRemainderLen = storageRead->bufferedRead.fileLen -
-		               *headerOffsetInFile;
+	if (isUseSplitLen)
+		fileRemainderLen = storageRead->bufferedRead.splitLen - *headerOffsetInFile;
+	else
+		fileRemainderLen = storageRead->bufferedRead.fileLen - *headerOffsetInFile;
+
 	if (storageRead->maxBufferLen > fileRemainderLen)
 		*blockLimitLen = (int32)fileRemainderLen;
 	else


### PR DESCRIPTION
The fileRemainderLen was calculated incorrectly before. 
If the isUseSplitLen is true, it should be the bufferedRead.splitLen-*headerOffsetInFile, 
So the bug will cause the out of range read.