### PR TITLE
HAWQ-216. Fix bug for built-in function gp_update_global_sequence_entry

### DIFF
--- a/src/backend/utils/gp/persistentutil.c
+++ b/src/backend/utils/gp/persistentutil.c
@@ -212,7 +212,7 @@ Datum
 gp_update_global_sequence_entry(PG_FUNCTION_ARGS)
 {
 	ItemPointer			tid;
-	int8				sequenceVal;
+	int64				sequenceVal;
 	GpGlobalSequence    sequence;
 
 	/* Must be super user */


### PR DESCRIPTION
Parameter sequenceVal was defined as a int8 number. But it is should be a int64 number.
