### PR TITLE
HAWQ-340. Make getVersion API return JSON format.

### DIFF
--- a/pxf/build.gradle
+++ b/pxf/build.gradle
@@ -17,6 +17,8 @@
  * under the License.
  */
 
+import org.apache.tools.ant.filters.ReplaceTokens
+
 buildscript {
     repositories {
         // mavenCentral without https:
@@ -122,6 +124,47 @@ subprojects { subProject ->
 }
 
 project('pxf-service') {
+
+// Copy existing sources and replace any occurrences of @tokenName@ with desired values
+    task generateSources {
+        doFirst {
+            copy {
+                from('src/main/java') {
+                    include '**/*.java'
+                    filter(ReplaceTokens,
+                        tokens:['pxfProtocolVersion': project.pxfProtocolVersion ])}
+                into "tmp/generatedSources"
+            }
+        }
+    }
+
+// Call cleanup taskAfter Java code compilation
+    compileJava.doLast {
+        tasks.cleanGeneratedSources.execute()
+    }
+
+// Delete "tmp" directory under current project directory
+// rm -r pxf-service/tmp
+    task cleanGeneratedSources() {
+        doFirst {
+            delete "tmp"
+        }
+    }
+
+// Call generateSources task before Java compilation
+    gradle.projectsEvaluated {
+        compileJava.dependsOn(generateSources)
+    }
+
+// Use custom sources directory with generated sources
+    sourceSets {
+        main {
+            java {
+                srcDirs = ["tmp/generatedSources"]
+            }
+        }
+    }
+
     apply plugin: 'war'
     tasks.war {
         archiveName = 'pxf.war'
@@ -137,7 +180,6 @@ project('pxf-service') {
             }
         }
     }
-
     dependencies {
         compile(project(':pxf-api'))
         compile 'com.sun.jersey:jersey-core:1.9'

--- a/pxf/gradle.properties
+++ b/pxf/gradle.properties
@@ -23,3 +23,4 @@ hiveVersion=1.2.1
 hbaseVersionJar=1.1.2
 hbaseVersionRPM=1.1.2
 tomcatVersion=7.0.62
+pxfProtocolVersion=v14

--- a/pxf/pxf-service/src/main/java/org/apache/hawq/pxf/service/rest/VersionResource.java
+++ b/pxf/pxf-service/src/main/java/org/apache/hawq/pxf/service/rest/VersionResource.java
@@ -21,6 +21,7 @@ package org.apache.hawq.pxf.service.rest;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.ResponseBuilder;
@@ -33,7 +34,25 @@ import org.apache.commons.logging.LogFactory;
  * version e.g. {@code ...pxf/v14/Bridge}
  */
 class Version {
-    final static String PXF_PROTOCOL_VERSION = "v14";
+    /**
+     * Constant which holds current protocol version. Getting replaced with
+     * actual value on build stage, using pxfProtocolVersion parameter from
+     * gradle.properties
+     */
+    final static String PXF_PROTOCOL_VERSION = "@pxfProtocolVersion@";
+
+    public Version() {
+    }
+
+    public String version;
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
 }
 
 /**
@@ -58,11 +77,12 @@ public class VersionResource {
      * @return response with the PXF protocol version
      */
     @GET
+    @Produces("application/json")
     public Response getProtocolVersion() {
 
         ResponseBuilder b = Response.ok();
-        b.entity("PXF protocol version " + Version.PXF_PROTOCOL_VERSION);
-        b.type(MediaType.TEXT_PLAIN_TYPE);
+        b.entity("{ \"version\": \"" + Version.PXF_PROTOCOL_VERSION + "\"}");
+        b.type(MediaType.APPLICATION_JSON_TYPE);
         return b.build();
     }
 }

--- a/pxf/pxf-service/src/test/java/org/apache/hawq/pxf/service/rest/VersionResourceTest.java
+++ b/pxf/pxf-service/src/test/java/org/apache/hawq/pxf/service/rest/VersionResourceTest.java
@@ -22,6 +22,8 @@ package org.apache.hawq.pxf.service.rest;
 
 import static org.junit.Assert.assertEquals;
 
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import org.junit.Test;
@@ -36,7 +38,10 @@ public class VersionResourceTest {
 
         assertEquals(Response.Status.OK,
                 Response.Status.fromStatusCode(result.getStatus()));
-        assertEquals("PXF protocol version " + Version.PXF_PROTOCOL_VERSION,
+        assertEquals(
+                "{ \"version\": \"" + Version.PXF_PROTOCOL_VERSION + "\"}",
                 result.getEntity().toString());
+        assertEquals(result.getMetadata().get(HttpHeaders.CONTENT_TYPE).get(0),
+                MediaType.APPLICATION_JSON_TYPE);
     }
 }


### PR DESCRIPTION
$ curl -i http://localhost:51200/pxf/ProtocolVersion
HTTP/1.1 200 OK
Server: Apache-Coyote/1.1
Content-Type: application/json
Transfer-Encoding: chunked
Date: Sat, 23 Jan 2016 00:01:31 GMT

{ "version": "v14"}