### PR TITLE
HAWQ-357. Track how many times a segment can not get expected contain…

### DIFF
--- a/src/backend/resourcemanager/include/resourcebroker/resourcebroker_API.h
+++ b/src/backend/resourcemanager/include/resourcebroker/resourcebroker_API.h
@@ -94,6 +94,9 @@ bool isCleanGRMResourceStatus(void);
 
 void RB_clearResource(List **ctnl);
 
+void RB_freePreferedHostsForGRMContainers(void);
+void RB_updateSegmentsHavingNoExpectedGRMContainers(HASHTABLE segments);
+
 /* Error message */
 extern bool				ResourceManagerIsForked;
 #endif /* HAWQ_RESOURCE_MANAGER_RESOURCE_BROKER_API_H */

--- a/src/backend/resourcemanager/include/resourcepool.h
+++ b/src/backend/resourcemanager/include/resourcepool.h
@@ -281,6 +281,7 @@ struct SegResourceData {
 
 	/* Total GRM container size. */
 	int				GRMContainerCount;
+	int				GRMContainerFailAllocCount;
 
 	/*
 	 * When resource manager has resource allocated from resource broker, the
@@ -632,6 +633,8 @@ int getOrderedResourceAvailTreeIndexByRatio(uint32_t ratio, BBST *tree);
 int getOrderedResourceAllocTreeIndexByRatio(uint32_t ratio, BBST *tree);
 
 void setAllSegResourceGRMUnavailable(void);
+
+void resetAllSegmentsGRMContainerFailAllocCount(void);
 
 struct RB_GRMContainerStatData
 {

--- a/src/backend/resourcemanager/resourcebroker/resourcebroker_API.c
+++ b/src/backend/resourcemanager/resourcebroker/resourcebroker_API.c
@@ -263,7 +263,7 @@ void RB_updateSegmentsHavingNoExpectedGRMContainers(HASHTABLE segments)
 			segres->GRMContainerFailAllocCount++;
 
 			elog(WARNING, "Resource manager detects segment %s hasn't gotten "
-						  "expected global quantity of resource containers for "
+						  "expected quantity of global resource containers for "
 						  "%d times.",
 						  GET_SEGRESOURCE_HOSTNAME(segres),
 						  segres->GRMContainerFailAllocCount);

--- a/src/backend/resourcemanager/resourcebroker/resourcebroker_API.c
+++ b/src/backend/resourcemanager/resourcebroker/resourcebroker_API.c
@@ -22,8 +22,9 @@
 #include "resourcebroker/resourcebroker_NONE.h"
 #include "resourcebroker/resourcebroker_LIBYARN.h"
 
-bool					 ResourceManagerIsForked;
-RB_FunctionEntriesData 	 CurrentRBImp;
+bool					ResourceManagerIsForked;
+RB_FunctionEntriesData	CurrentRBImp;
+List				   *PreferedHostsForGRMContainers;
 
 void RB_prepareImplementation(enum RB_IMP_TYPE imptype)
 {
@@ -36,6 +37,8 @@ void RB_prepareImplementation(enum RB_IMP_TYPE imptype)
 	CurrentRBImp.returnResource     = NULL;
 	CurrentRBImp.start				= NULL;
 	CurrentRBImp.stop				= NULL;
+
+	PreferedHostsForGRMContainers	= NULL;
 
 	switch(imptype) {
 	case NONE_HAWQ2:
@@ -77,7 +80,20 @@ int RB_getClusterReport(const char *queuename, List **machines, double *maxcapac
 int RB_acquireResource(uint32_t memorymb, uint32_t core, List *preferred)
 {
 	Assert(CurrentRBImp.acquireResource != NULL);
-	return CurrentRBImp.acquireResource(memorymb, core, preferred);
+	int res = CurrentRBImp.acquireResource(memorymb, core, preferred);
+
+	/*--------------------------------------------------------------------------
+	 * We hold preferred host list here, when resource broker gets the resource
+	 * allocation result, this is the reference for updating the counter in each
+	 * segment for failing of getting GRM containers from GRM.
+	 *--------------------------------------------------------------------------
+	 */
+	if ( PreferedHostsForGRMContainers != NULL )
+	{
+		RB_freePreferedHostsForGRMContainers();
+	}
+	PreferedHostsForGRMContainers = preferred;
+	return res;
 }
 
 int RB_returnResource(List **containers)
@@ -173,7 +189,9 @@ void RB_clearResource(List **ctnl)
 
 		if ( ctn->CalcDecPending )
 		{
-			minusResourceBundleData(&(ctn->Resource->DecPending), ctn->MemoryMB, ctn->Core);
+			minusResourceBundleData(&(ctn->Resource->DecPending),
+									ctn->MemoryMB,
+									ctn->Core);
 			Assert( ctn->Resource->DecPending.Core >= 0 );
 			Assert( ctn->Resource->DecPending.MemoryMB >= 0 );
 		}
@@ -181,5 +199,78 @@ void RB_clearResource(List **ctnl)
 		/* Destroy resource container. */
 		freeGRMContainer(ctn);
 		PRESPOOL->RetPendingContainerCount--;
+	}
+}
+
+void RB_freePreferedHostsForGRMContainers(void)
+{
+	ListCell *cell = NULL;
+	foreach(cell, PreferedHostsForGRMContainers)
+	{
+		PAIR pair = (PAIR)lfirst(cell);
+		rm_pfree(PCONTEXT, pair->Value);
+		rm_pfree(PCONTEXT, pair);
+	}
+	MEMORY_CONTEXT_SWITCH_TO(PCONTEXT)
+	list_free(PreferedHostsForGRMContainers);
+	MEMORY_CONTEXT_SWITCH_BACK
+
+	PreferedHostsForGRMContainers = NULL;
+}
+
+void RB_updateSegmentsHavingNoExpectedGRMContainers(HASHTABLE segments)
+{
+	ListCell *cell = NULL;
+	foreach(cell, PreferedHostsForGRMContainers)
+	{
+		PAIR pair = (PAIR)lfirst(cell);
+		SegResource 	segres = (SegResource)(pair->Key);
+		ResourceBundle	expres = (ResourceBundle)(pair->Value);
+
+		bool failed = false;
+		/* Check if the segment exists in the hash table. */
+		PAIR pair2 = getHASHTABLENode(segments, segres);
+		if ( pair2 == NULL )
+		{
+			elog(RMLOG, "Resource manager finds segment %s has no resource "
+						"container allocated from global resource manager, "
+						"expected resource quota (%d MB, %lf CORE)",
+						GET_SEGRESOURCE_HOSTNAME(segres),
+						expres->MemoryMB,
+						expres->Core);
+			failed = true;
+		}
+		else
+		{
+			ResourceBundle allocres = (ResourceBundle)(pair->Value);
+			if ( allocres->MemoryMB < expres->MemoryMB )
+			{
+				elog(RMLOG, "Resource manager finds segment %s hasn't sufficient "
+							"resource containers allocated from global resource "
+							"manager, expected resource quota (%d MB, %lf CORE), "
+							"actual allocated resource (%d MB, %lf CORE)",
+							GET_SEGRESOURCE_HOSTNAME(segres),
+							expres->MemoryMB,
+							expres->Core,
+							allocres->MemoryMB,
+							allocres->Core);
+				failed = true;
+			}
+		}
+
+		if ( failed )
+		{
+			segres->GRMContainerFailAllocCount++;
+
+			elog(WARNING, "Resource manager detects segment %s hasn't gotten "
+						  "expected global quantity of resource containers for "
+						  "%d times.",
+						  GET_SEGRESOURCE_HOSTNAME(segres),
+						  segres->GRMContainerFailAllocCount);
+		}
+		else
+		{
+			segres->GRMContainerFailAllocCount = 0;
+		}
 	}
 }

--- a/src/backend/resourcemanager/resourcemanager.c
+++ b/src/backend/resourcemanager/resourcemanager.c
@@ -567,6 +567,8 @@ int MainHandlerLoop(void)
 			/* Refresh resource queue resource usage and request quota. */
 			refreshMemoryCoreRatioLevelUsage(gettime_microsec());
 
+			resetAllSegmentsGRMContainerFailAllocCount();
+
 			/* Check if can resume using new available global resource manager.*/
 			if ( cleanedAllGRMContainers() )
 			{
@@ -2268,15 +2270,6 @@ int generateAllocRequestToBroker(void)
 							reqcore);
 			}
 		}
-
-		/* Free preferred host list. */
-		foreach(cell, preferred)
-		{
-			PAIR pair = (PAIR)lfirst(cell);
-			rm_pfree(PCONTEXT, pair->Value);
-			rm_pfree(PCONTEXT, pair);
-		}
-		list_free(preferred);
 	}
 
 	return res;

--- a/src/backend/resourcemanager/resourcepool.c
+++ b/src/backend/resourcemanager/resourcepool.c
@@ -1311,6 +1311,20 @@ void setAllSegResourceGRMUnavailable(void)
 	freePAIRRefList(&(PRESPOOL->Segments), &allsegres);
 }
 
+void resetAllSegmentsGRMContainerFailAllocCount(void)
+{
+	List 	 *allsegres = NULL;
+	ListCell *cell		= NULL;
+	getAllPAIRRefIntoList(&(PRESPOOL->Segments), &allsegres);
+
+	foreach(cell, allsegres)
+	{
+		SegResource segres = (SegResource)(((PAIR)lfirst(cell))->Value);
+		segres->GRMContainerFailAllocCount = 0;
+	}
+	freePAIRRefList(&(PRESPOOL->Segments), &allsegres);
+}
+
 /*
  * Check index to get host id based on host name string.
  */
@@ -1379,8 +1393,8 @@ SegResource createSegResource(SegStat segstat)
 	resetResourceBundleData(&(res->DecPending), 0, 0.0, 0);
 	resetResourceBundleData(&(res->OldInuse)  , 0, 0.0, 0);
 
-	res->GRMContainerCount = 0;
-
+	res->GRMContainerCount 			= 0;
+	res->GRMContainerFailAllocCount	= 0;
 	return res;
 }
 


### PR DESCRIPTION
HAWQ RM will generate WARNING log for each segment that can not get expected quantity of YARN containers.

"Resource manager detects segment %s hasn't gotten expected quantity of resource containers for %d times."