### PR TITLE
HAWQ-363. Add guc variables for controlling FTS heartbeat interval an…

### DIFF
--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -346,7 +346,21 @@ int		rm_session_lease_heartbeat_interval;/* How many seconds to wait before
 int		rm_nocluster_timeout;				/* How many seconds to wait before
 											   getting enough number of available
 											   segments registered. */
-
+int		rm_segment_heartbeat_interval;		/* How many seconds to wait before
+											   sending another heart-beat to
+											   from a segment to resource
+											   manager. */
+int		rm_segment_heartbeat_timeout;		/* How many seconds to wait before
+											   setting down a segment that does
+											   not have heart-beat sent
+											   successfully to resource
+											   manager. */
+int		rm_segment_config_refresh_interval; /* How many seconds to wait before
+ 	 	 	 	 	 	 	 	 	 	 	   another refreshing local segment
+ 	 	 	 	 	 	 	 	 	 	 	   configuration. */
+int		rm_segment_tmpdir_detect_interval;	/* How many seconds to wait before
+											   another detecting local temporary
+											   directories. */
 int		rm_tolerate_nseg_limit;
 int		rm_rejectrequest_nseg_limit;
 int		rm_nvseg_variance_among_seg_limit;

--- a/src/backend/resourcemanager/communication/rmcomm_AsyncComm.c
+++ b/src/backend/resourcemanager/communication/rmcomm_AsyncComm.c
@@ -713,6 +713,7 @@ int registerAsyncConnectionFileDesc(const char				*sockpath,
 				   fd,
 				   errno);
 		 close(fd);
+		 res = UTIL_NETWORK_FAIL_CONNECT;
 	}
 
 exit:

--- a/src/backend/resourcemanager/include/dynrm.h
+++ b/src/backend/resourcemanager/include/dynrm.h
@@ -337,4 +337,5 @@ int  initializeSocketServer_RMSEG(void);
 int  MainHandlerLoop_RMSEG(void);
 int  MainHandler_RMSEGDummyLoop(void);
 
+void checkAndBuildFailedTmpDirList(void);
 #endif //DYNAMIC_RESOURCE_MANAGEMENT_H

--- a/src/backend/resourcemanager/resourcemanager.c
+++ b/src/backend/resourcemanager/resourcemanager.c
@@ -613,7 +613,8 @@ int MainHandlerLoop(void)
         uint64_t curtime = gettime_microsec();
 		if ((rm_resourcepool_test_filename == NULL ||
 			rm_resourcepool_test_filename[0] == '\0') &&
-			(curtime - PRESPOOL->LastCheckTime > 10LL * SEGMENT_HEARTBEAT_INTERVAL))
+			(curtime - PRESPOOL->LastCheckTime >
+        	 1000000LL * rm_segment_heartbeat_timeout))
 		{
 			updateStatusOfAllNodes();
 			PRESPOOL->LastCheckTime = curtime;
@@ -2605,17 +2606,21 @@ void sendResponseToClients(void)
  * Check and set the nodes down that are not updated by IMAlive heart-beat for a
  * long time.
  */
-void updateStatusOfAllNodes() {
+void updateStatusOfAllNodes()
+{
 	SegResource node = NULL;
 	uint64_t curtime = 0;
 
 	bool changedstatus = false;
 	curtime = gettime_microsec();
-	for(uint32_t idx = 0; idx < PRESPOOL->SegmentIDCounter; idx++) {
+	for(uint32_t idx = 0; idx < PRESPOOL->SegmentIDCounter; idx++)
+	{
 	    node = getSegResource(idx);
         if (node != NULL &&
-            curtime - node->LastUpdateTime > 10LL * SEGMENT_HEARTBEAT_INTERVAL &&
-			IS_SEGSTAT_FTSAVAILABLE(node->Stat) ) {
+            (curtime - node->LastUpdateTime >
+			 1000000LL * rm_segment_heartbeat_timeout) &&
+			IS_SEGSTAT_FTSAVAILABLE(node->Stat) )
+        {
         	/*
         	 * This call makes resource manager able to adjust queue and mem/core
         	 * trackers' capacity.

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -6393,6 +6393,16 @@ static struct config_int ConfigureNamesInt[] =
 	},
 
 	{
+		{"hawq_rm_segment_heartbeat_timeout", PGC_POSTMASTER, RESOURCES_MGM,
+			gettext_noop("timeout for setting one segment down that having no heart-beat "
+						 "successfully received by resource manager."),
+			NULL
+		},
+		&rm_segment_heartbeat_timeout,
+		300, 1, 65535, NULL, NULL
+	},
+
+	{
 		{"hawq_rm_session_lease_heartbeat_interval", PGC_POSTMASTER, RESOURCES_MGM,
 			gettext_noop("interval for sending heart-beat to resource manager to keep "
 						 "resource context alive."),
@@ -6410,6 +6420,34 @@ static struct config_int ConfigureNamesInt[] =
 		},
 		&rm_request_timeoutcheck_interval,
 		1, 1, 65535, NULL, NULL
+	},
+
+	{
+		{"hawq_rm_segment_heartbeat_interval", PGC_POSTMASTER, RESOURCES_MGM,
+			gettext_noop("interval for sending heart-beat to resource manager to keep "
+						 "segment alive and to present latest segment status."),
+			NULL
+		},
+		&rm_segment_heartbeat_interval,
+		30, 1, 65535, NULL, NULL
+	},
+
+	{
+		{"hawq_rm_segment_tmpdir_detect_interval", PGC_POSTMASTER, RESOURCES_MGM,
+			gettext_noop("interval for detecting segment local temporary directories."),
+			NULL
+		},
+		&rm_segment_tmpdir_detect_interval,
+		300, 60, 65535, NULL, NULL
+	},
+
+	{
+		{"hawq_rm_segment_config_refresh_interval", PGC_POSTMASTER, RESOURCES_MGM,
+			gettext_noop("interval for refreshing segment local host config."),
+			NULL
+		},
+		&rm_segment_config_refresh_interval,
+		30, 5, 65535, NULL, NULL
 	},
 
 	{

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -1183,8 +1183,13 @@ extern bool    rm_session_lease_heartbeat_enable;
 
 extern int 	   rm_resource_allocation_timeout;
 extern int	   rm_resource_timeout;
+extern int	   rm_segment_heartbeat_timeout;
 extern int	   rm_request_timeoutcheck_interval;
 extern int	   rm_session_lease_heartbeat_interval;
+extern int	   rm_segment_heartbeat_interval;
+extern int	   rm_segment_config_refresh_interval;
+extern int	   rm_segment_tmpdir_detect_interval;
+
 extern int	   rm_nocluster_timeout;
 extern int	   rm_tolerate_nseg_limit;
 extern int	   rm_rejectrequest_nseg_limit;


### PR DESCRIPTION
hawq_rm_segment_heartbeat_interval, control interval of sending heart-beat in a HAWQ segment. default 30s
hawq_rm_segment_timeout, HAWQ RM sets one segment down if its heart-beat is not received for more than hawq_rm_segment_timeout seconds. default 300s
hawq_rm_segment_config_refresh_interval, the interval for periodically checking local host configuration. default 30s
hawq_rm_segment_tmpdir_detect_interval, the interval for periodically checking temporary directories. default 300s