### PR TITLE
HAWQ-364. Make resource manager dynamically adjust minimum YARN conta…

### DIFF
--- a/src/backend/resourcemanager/communication/rmcomm_RM2RMSEG.c
+++ b/src/backend/resourcemanager/communication/rmcomm_RM2RMSEG.c
@@ -244,6 +244,7 @@ void receivedRUAliveResponse(AsyncCommMessageHandlerContext  context,
 					  GET_SEGRESOURCE_HOSTNAME(segres));
 
 			refreshResourceQueueCapacity(false);
+			refreshActualMinGRMContainerPerSeg();
 		}
 		else {
 			elog(DEBUG3, "Resource manager find host %s is down already.",
@@ -293,6 +294,7 @@ void sentRUAliveError(AsyncCommMessageHandlerContext context)
 				  GET_SEGRESOURCE_HOSTNAME(segres));
 
 		refreshResourceQueueCapacity(false);
+		refreshActualMinGRMContainerPerSeg();
 	}
 }
 

--- a/src/backend/resourcemanager/include/resourcepool.h
+++ b/src/backend/resourcemanager/include/resourcepool.h
@@ -390,6 +390,7 @@ struct ResourcePoolData {
 	 */
 	ResourceBundleData FTSTotal;
 	ResourceBundleData GRMTotal;
+	ResourceBundleData GRMTotalHavingNoHAWQNode;
 
     uint64_t LastUpdateTime; /* Last time the GRM cluster report is gotten.   */
     uint64_t LastRequestTime;/* Last time the GRM cluster report is sent.     */

--- a/src/backend/resourcemanager/include/resqueuemanager.h
+++ b/src/backend/resourcemanager/include/resqueuemanager.h
@@ -329,6 +329,8 @@ struct DynResourceQueueManagerData {
     int						 ForcedReturnGRMContainerCount;
     bool					 toRunQueryDispatch;
     bool	 				 hasResourceProblem[RESPROBLEM_COUNT];
+
+    int						 ActualMinGRMContainerPerSeg;
 };
 typedef struct DynResourceQueueManagerData *DynResourceQueueManager;
 typedef struct DynResourceQueueManagerData  DynResourceQueueManagerData;
@@ -344,8 +346,10 @@ typedef struct DynResourceQueueManagerData  DynResourceQueueManagerData;
 void initializeResourceQueueManager(void);
 /* collect resource queues' resource usage status from bottom up. */
 void refreshMemoryCoreRatioLevelUsage(uint64_t curmicrosec);
-/* Refresh reosurce queue resource capacity and adjusts all queued requests. */
+/* Refresh resource queue resource capacity and adjusts all queued requests. */
 void refreshResourceQueueCapacity(bool queuechanged);
+/* Refresh actual minimum GRM container water level. */
+void refreshActualMinGRMContainerPerSeg(void);
 /* Dispatch resource to the queuing queries. */
 void dispatchResourceToQueries(void);
 /* Time out the resource allocated whose QD owner does not have chance to return. */

--- a/src/backend/resourcemanager/requesthandler.c
+++ b/src/backend/resourcemanager/requesthandler.c
@@ -783,6 +783,7 @@ bool handleRMSEGRequestIMAlive(void **arg)
 	{
 		/* Refresh resource queue capacities. */
 		refreshResourceQueueCapacity(false);
+		refreshActualMinGRMContainerPerSeg();
 		/* Recalculate all memory/core ratio instances' limits. */
 		refreshMemoryCoreRatioLimits();
 		/* Refresh memory/core ratio level water mark. */
@@ -1049,6 +1050,7 @@ bool handleRMRequestSegmentIsDown(void **arg)
 	}
 
 	refreshResourceQueueCapacity(false);
+	refreshActualMinGRMContainerPerSeg();
 
 	RPCResponseSegmentIsDownData response;
 	response.Result   = res;

--- a/src/backend/resourcemanager/resourcemanager.c
+++ b/src/backend/resourcemanager/resourcemanager.c
@@ -2645,6 +2645,7 @@ void updateStatusOfAllNodes()
 	if ( changedstatus )
 	{
 		refreshResourceQueueCapacity(false);
+		refreshActualMinGRMContainerPerSeg();
 	}
 
 	validateResourcePoolStatus(true);
@@ -2808,6 +2809,7 @@ int  loadHostInformationIntoResourcePool(void)
 
 	/* Refresh resource queue capacities. */
     refreshResourceQueueCapacity(false);
+    refreshActualMinGRMContainerPerSeg();
 	/* Recalculate all memory/core ratio instances' limits. */
 	refreshMemoryCoreRatioLimits();
 	/* Refresh memory/core ratio level water mark. */

--- a/src/backend/resourcemanager/resqueuemanager.c
+++ b/src/backend/resourcemanager/resqueuemanager.c
@@ -258,6 +258,8 @@ void initializeResourceQueueManager(void)
     {
     	PQUEMGR->hasResourceProblem[i] = false;
     }
+
+    PQUEMGR->ActualMinGRMContainerPerSeg = rm_min_resource_perseg;
 }
 
 /*
@@ -2462,6 +2464,77 @@ int returnResourceToResQueMgr(ConnectionTrack conntrack)
 	return res;
 }
 
+void refreshActualMinGRMContainerPerSeg(void)
+{
+	/*--------------------------------------------------------------------------
+	 * There are 3 limits should be considered, the actual water level is the
+	 * least value of the 3 limits : resource queue normal capacity caused mean
+	 * GRM container number, minimum value of all segments' maximum GRM container
+	 * numbers, user setting saved in guc.
+	 *
+	 *--------------------------------------------------------------------------
+	 */
+
+	/* STEP 1. go through each segment to get segment maximum capacity. */
+	int minctncount = INT32_MAX;
+	int normalctncount = INT32_MAX;
+	if ( DRMGlobalInstance->ImpType != NONE_HAWQ2 )
+	{
+		List 	 *allsegres = NULL;
+		ListCell *cell		= NULL;
+		getAllPAIRRefIntoList(&(PRESPOOL->Segments), &allsegres);
+
+		foreach(cell, allsegres)
+		{
+			SegResource segres = (SegResource)(((PAIR)lfirst(cell))->Value);
+			if ( !IS_SEGSTAT_FTSAVAILABLE(segres->Stat) ||
+				 !IS_SEGSTAT_GRMAVAILABLE(segres->Stat) )
+			{
+				continue;
+			}
+
+			if ( segres->Stat->GRMTotalCore < minctncount )
+			{
+				minctncount = segres->Stat->GRMTotalCore;
+			}
+		}
+		freePAIRRefList(&(PRESPOOL->Segments), &allsegres);
+
+		elog(RMLOG, "Resource manager finds minimum global resource manager "
+					"container count can contained by all segments is %d",
+					minctncount);
+
+		/* STEP 2. check the queue normal capacity introduced water level. */
+		if ( PRESPOOL->AvailNodeCount > 0 &&
+			 PQUEMGR->GRMQueueCapacity > 0 &&
+			 PRESPOOL->GRMTotalHavingNoHAWQNode.Core > 0 )
+		{
+			normalctncount = trunc(PRESPOOL->GRMTotalHavingNoHAWQNode.Core *
+								   PQUEMGR->GRMQueueCapacity /
+								   PRESPOOL->AvailNodeCount);
+
+			elog(RMLOG, "Resource manager calculates normal global resource "
+						"manager container count based on target queue capacity "
+						"is %d",
+						normalctncount);
+		}
+	}
+
+	/* STEP 3. Get final water level result. */
+	int oldval = PQUEMGR->ActualMinGRMContainerPerSeg;
+	int newval = minctncount < normalctncount ? minctncount : normalctncount;
+	newval = newval < rm_min_resource_perseg ? newval : rm_min_resource_perseg;
+
+	if ( newval != oldval )
+	{
+		elog(WARNING, "Resource manager adjusts minimum global resource manager "
+					  "container count in each segment from %d to %d.",
+					  oldval,
+					  newval);
+	}
+	PQUEMGR->ActualMinGRMContainerPerSeg = newval;
+}
+
 void refreshResourceQueueCapacity(bool queuechanged)
 {
 	static char errorbuf[ERRORMESSAGE_SIZE];
@@ -2500,8 +2573,10 @@ void refreshResourceQueuePercentageCapacity(bool queuechanged)
 	{
 		if ( DRMGlobalInstance->ImpType == YARN_LIBYARN )
 		{
-			mem  = PRESPOOL->GRMTotal.MemoryMB * PQUEMGR->GRMQueueMaxCapacity;
-			core = PRESPOOL->GRMTotal.Core     * PQUEMGR->GRMQueueMaxCapacity;
+			mem  = PRESPOOL->GRMTotalHavingNoHAWQNode.MemoryMB *
+				   PQUEMGR->GRMQueueMaxCapacity;
+			core = PRESPOOL->GRMTotalHavingNoHAWQNode.Core     *
+				   PQUEMGR->GRMQueueMaxCapacity;
 		}
 		else if ( DRMGlobalInstance->ImpType == NONE_HAWQ2 )
 		{


### PR DESCRIPTION
user can set the minimum YARN container water level through guc hawq_rm_min_resource_perseg. 
1) If the segment capacity is smaller than expected level, this water level is lowered down;
2) If the queue capacity can not make each segment have at least hawq_rm_min_resource_perseg YARN containers, this water level is lowered down.
This improvement can make HAWQ able to dynamically fit the changing YARN cluster and avoid user wrong config caused unexpected behaviors.

If the setting is adjusted by hawq rm, one WARNING log is generated for issue tracking.

"WARNING","01000","Resource manager adjusts minimum global resource manager container count in each segment from 100 to 8.",,,,,,,0,,"resqueuemanager.c",2530,