### PR TITLE
HAWQ-253. Separate pxf-service from pxf plugins

### DIFF
--- a/pxf/build.gradle
+++ b/pxf/build.gradle
@@ -237,9 +237,11 @@ project('pxf-service') {
 
 project('pxf-hdfs') {
     dependencies {
-        compile(project(':pxf-service'))
+        compile(project(':pxf-api'))
         compile 'org.apache.avro:avro-mapred:1.7.4'
         compile "org.apache.hadoop:hadoop-mapreduce-client-core:$hadoopVersion"
+        compile "org.apache.hadoop:hadoop-common:$hadoopVersion"
+        compile "org.apache.hadoop:hadoop-hdfs:$hadoopVersion"
     }
 
     ospackage {

--- a/pxf/pxf-api/src/main/java/org/apache/hawq/pxf/api/utilities/Utilities.java
+++ b/pxf/pxf-api/src/main/java/org/apache/hawq/pxf/api/utilities/Utilities.java
@@ -1,4 +1,4 @@
-package org.apache.hawq.pxf.service.utilities;
+package org.apache.hawq.pxf.api.utilities;
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
@@ -25,7 +25,6 @@ import java.lang.reflect.InvocationTargetException;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.hawq.pxf.api.utilities.InputData;
 
 /**
  * Utilities class exposes helper method for PXF classes

--- a/pxf/pxf-api/src/test/java/org/apache/hawq/pxf/api/utilities/UtilitiesTest.java
+++ b/pxf/pxf-api/src/test/java/org/apache/hawq/pxf/api/utilities/UtilitiesTest.java
@@ -1,4 +1,4 @@
-package org.apache.hawq.pxf.service.utilities;
+package org.apache.hawq.pxf.api.utilities;
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import org.apache.hawq.pxf.api.utilities.InputData;
+import org.apache.hawq.pxf.api.utilities.Utilities;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.api.mockito.PowerMockito;

--- a/pxf/pxf-hdfs/src/main/java/org/apache/hawq/pxf/plugins/hdfs/StringPassResolver.java
+++ b/pxf/pxf-hdfs/src/main/java/org/apache/hawq/pxf/plugins/hdfs/StringPassResolver.java
@@ -8,9 +8,9 @@ package org.apache.hawq.pxf.plugins.hdfs;
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -35,8 +35,8 @@ import static org.apache.hawq.pxf.api.io.DataType.VARCHAR;
 
 /**
  * StringPassResolver handles "deserialization" and serialization of
- * String records. StringPassResolver implements IReadResolver and
- * IWriteResolver interfaces. Returns strings as-is.
+ * String records. StringPassResolver implements {@link ReadResolver} and
+ * {@link WriteResolver} interfaces. Returns strings as-is.
  */
 public class StringPassResolver extends Plugin implements ReadResolver, WriteResolver {
     // for write

--- a/pxf/pxf-hdfs/src/main/java/org/apache/hawq/pxf/plugins/hdfs/WritableResolver.java
+++ b/pxf/pxf-hdfs/src/main/java/org/apache/hawq/pxf/plugins/hdfs/WritableResolver.java
@@ -24,9 +24,9 @@ import org.apache.hawq.pxf.api.*;
 import org.apache.hawq.pxf.api.io.DataType;
 import org.apache.hawq.pxf.api.utilities.InputData;
 import org.apache.hawq.pxf.api.utilities.Plugin;
+import org.apache.hawq.pxf.api.utilities.Utilities;
 import org.apache.hawq.pxf.plugins.hdfs.utilities.RecordkeyAdapter;
 import org.apache.hawq.pxf.plugins.hdfs.utilities.DataSchemaException;
-import org.apache.hawq.pxf.service.utilities.Utilities;
 
 import static org.apache.hawq.pxf.plugins.hdfs.utilities.DataSchemaException.MessageFmt.*;
 

--- a/pxf/pxf-hdfs/src/main/java/org/apache/hawq/pxf/plugins/hdfs/utilities/HdfsUtilities.java
+++ b/pxf/pxf-hdfs/src/main/java/org/apache/hawq/pxf/plugins/hdfs/utilities/HdfsUtilities.java
@@ -20,10 +20,10 @@ package org.apache.hawq.pxf.plugins.hdfs.utilities;
  */
 
 
-import org.apache.hawq.pxf.service.utilities.Utilities;
 import org.apache.hawq.pxf.api.io.DataType;
 import org.apache.hawq.pxf.api.OneField;
 import org.apache.hawq.pxf.api.utilities.InputData;
+import org.apache.hawq.pxf.api.utilities.Utilities;
 import org.apache.avro.Schema;
 import org.apache.avro.file.DataFileReader;
 import org.apache.avro.generic.GenericDatumReader;

--- a/pxf/pxf-hdfs/src/test/java/org/apache/hawq/pxf/plugins/hdfs/StringPassResolverTest.java
+++ b/pxf/pxf-hdfs/src/test/java/org/apache/hawq/pxf/plugins/hdfs/StringPassResolverTest.java
@@ -24,36 +24,22 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
-import java.io.ByteArrayInputStream;
-import java.io.DataInputStream;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
-import org.apache.commons.logging.LogFactory;
 import org.apache.hawq.pxf.api.OneField;
 import org.apache.hawq.pxf.api.OneRow;
-import org.apache.hawq.pxf.api.OutputFormat;
-import org.apache.hawq.pxf.service.BridgeInputBuilder;
-import org.apache.hawq.pxf.service.io.Text;
-import org.apache.hawq.pxf.service.utilities.ProtocolData;
+import org.apache.hawq.pxf.api.io.DataType;
+import org.apache.hawq.pxf.api.utilities.InputData;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({
-        Text.class,
-        BridgeInputBuilder.class,
-        ProtocolData.class,
-        LogFactory.class })
 public class StringPassResolverTest {
-    ProtocolData mockProtocolData;
+    InputData mockInputData;
 
     @Test
     /*
-     * Test the setFields method: small \n terminated input
+     * Test the setFields method: small input
      */
     public void testSetFields() throws Exception {
         StringPassResolver resolver = buildResolver();
@@ -68,84 +54,31 @@ public class StringPassResolverTest {
                 (int) 'o',
                 (int) '\n' };
 
-        DataInputStream inputStream = new DataInputStream(
-                new ByteArrayInputStream(data));
-        BridgeInputBuilder inputBuilder = new BridgeInputBuilder(
-                mockProtocolData);
-        List<OneField> record = inputBuilder.makeInput(inputStream);
+        List<OneField> record = Collections.singletonList(new OneField(DataType.BYTEA.getOID(),
+                Arrays.copyOfRange(data, 0, 5)));
 
         OneRow oneRow = resolver.setFields(record);
         verifyOneRow(oneRow, Arrays.copyOfRange(data, 0, 5));
 
-        record = inputBuilder.makeInput(inputStream);
+        record = Collections.singletonList(new OneField(DataType.BYTEA.getOID(),
+                Arrays.copyOfRange(data, 5, 8)));
+
         oneRow = resolver.setFields(record);
         verifyOneRow(oneRow, Arrays.copyOfRange(data, 5, 8));
     }
 
     @Test
     /*
-     * Test the setFields method: input > buffer size, \n terminated
+     * Test the setFields method: empty byte array
      */
-    public void testSetFieldsBigArray() throws Exception {
-
-        StringPassResolver resolver = buildResolver();
-
-        byte[] bigArray = new byte[2000];
-        for (int i = 0; i < 1999; ++i) {
-            bigArray[i] = (byte) (i % 10 + 30);
-        }
-        bigArray[1999] = (byte) '\n';
-
-        DataInputStream inputStream = new DataInputStream(
-                new ByteArrayInputStream(bigArray));
-        BridgeInputBuilder inputBuilder = new BridgeInputBuilder(
-                mockProtocolData);
-        List<OneField> record = inputBuilder.makeInput(inputStream);
-
-        OneRow oneRow = resolver.setFields(record);
-
-        verifyOneRow(oneRow, bigArray);
-    }
-
-    @Test
-    /*
-     * Test the setFields method: input > buffer size, no \n
-     */
-    public void testSetFieldsBigArrayNoNewLine() throws Exception {
-
-        StringPassResolver resolver = buildResolver();
-
-        byte[] bigArray = new byte[2000];
-        for (int i = 0; i < 2000; ++i) {
-            bigArray[i] = (byte) (i % 10 + 60);
-        }
-
-        DataInputStream inputStream = new DataInputStream(
-                new ByteArrayInputStream(bigArray));
-        BridgeInputBuilder inputBuilder = new BridgeInputBuilder(
-                mockProtocolData);
-        List<OneField> record = inputBuilder.makeInput(inputStream);
-
-        OneRow oneRow = resolver.setFields(record);
-
-        verifyOneRow(oneRow, bigArray);
-    }
-
-    @Test
-    /*
-     * Test the setFields method: empty stream (returns -1)
-     */
-    public void testSetFieldsEmptyStream() throws Exception {
+    public void testSetFieldsEmptyByteArray() throws Exception {
 
         StringPassResolver resolver = buildResolver();
 
         byte[] empty = new byte[0];
 
-        DataInputStream inputStream = new DataInputStream(
-                new ByteArrayInputStream(empty));
-        BridgeInputBuilder inputBuilder = new BridgeInputBuilder(
-                mockProtocolData);
-        List<OneField> record = inputBuilder.makeInput(inputStream);
+        List<OneField> record = Collections.singletonList(new OneField(DataType.BYTEA.getOID(),
+                                                          empty));
 
         OneRow oneRow = resolver.setFields(record);
 
@@ -156,12 +89,8 @@ public class StringPassResolverTest {
      * helpers functions
      */
     private StringPassResolver buildResolver() throws Exception {
-
-        mockProtocolData = mock(ProtocolData.class);
-        PowerMockito.when(mockProtocolData.outputFormat()).thenReturn(
-                OutputFormat.TEXT);
-
-        return new StringPassResolver(mockProtocolData);
+        mockInputData = mock(InputData.class);
+        return new StringPassResolver(mockInputData);
     }
 
     private void verifyOneRow(OneRow oneRow, byte[] expected) {

--- a/pxf/pxf-hive/src/main/java/org/apache/hawq/pxf/plugins/hive/HiveColumnarSerdeResolver.java
+++ b/pxf/pxf-hive/src/main/java/org/apache/hawq/pxf/plugins/hive/HiveColumnarSerdeResolver.java
@@ -27,8 +27,7 @@ import org.apache.hawq.pxf.api.UnsupportedTypeException;
 import org.apache.hawq.pxf.api.io.DataType;
 import org.apache.hawq.pxf.api.utilities.ColumnDescriptor;
 import org.apache.hawq.pxf.api.utilities.InputData;
-import org.apache.hawq.pxf.service.utilities.Utilities;
-
+import org.apache.hawq.pxf.api.utilities.Utilities;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;

--- a/pxf/pxf-hive/src/main/java/org/apache/hawq/pxf/plugins/hive/HiveResolver.java
+++ b/pxf/pxf-hive/src/main/java/org/apache/hawq/pxf/plugins/hive/HiveResolver.java
@@ -23,9 +23,8 @@ import org.apache.hawq.pxf.api.*;
 import org.apache.hawq.pxf.api.io.DataType;
 import org.apache.hawq.pxf.api.utilities.InputData;
 import org.apache.hawq.pxf.api.utilities.Plugin;
+import org.apache.hawq.pxf.api.utilities.Utilities;
 import org.apache.hawq.pxf.plugins.hdfs.utilities.HdfsUtilities;
-import org.apache.hawq.pxf.service.utilities.Utilities;
-
 import org.apache.commons.lang.CharUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/pxf/pxf-service/src/main/java/org/apache/hawq/pxf/service/FragmenterFactory.java
+++ b/pxf/pxf-service/src/main/java/org/apache/hawq/pxf/service/FragmenterFactory.java
@@ -22,7 +22,7 @@ package org.apache.hawq.pxf.service;
 
 import org.apache.hawq.pxf.api.Fragmenter;
 import org.apache.hawq.pxf.api.utilities.InputData;
-import org.apache.hawq.pxf.service.utilities.Utilities;
+import org.apache.hawq.pxf.api.utilities.Utilities;
 
 /**
  * Factory class for creation of {@link Fragmenter} objects. The actual {@link Fragmenter} object is "hidden" behind

--- a/pxf/pxf-service/src/main/java/org/apache/hawq/pxf/service/ReadBridge.java
+++ b/pxf/pxf-service/src/main/java/org/apache/hawq/pxf/service/ReadBridge.java
@@ -25,9 +25,9 @@ import org.apache.hawq.pxf.api.ReadAccessor;
 import org.apache.hawq.pxf.api.ReadResolver;
 import org.apache.hawq.pxf.api.utilities.InputData;
 import org.apache.hawq.pxf.api.utilities.Plugin;
+import org.apache.hawq.pxf.api.utilities.Utilities;
 import org.apache.hawq.pxf.service.io.Writable;
 import org.apache.hawq.pxf.service.utilities.ProtocolData;
-import org.apache.hawq.pxf.service.utilities.Utilities;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 

--- a/pxf/pxf-service/src/main/java/org/apache/hawq/pxf/service/WriteBridge.java
+++ b/pxf/pxf-service/src/main/java/org/apache/hawq/pxf/service/WriteBridge.java
@@ -23,9 +23,9 @@ package org.apache.hawq.pxf.service;
 import org.apache.hawq.pxf.api.*;
 import org.apache.hawq.pxf.api.utilities.InputData;
 import org.apache.hawq.pxf.api.utilities.Plugin;
+import org.apache.hawq.pxf.api.utilities.Utilities;
 import org.apache.hawq.pxf.service.io.Writable;
 import org.apache.hawq.pxf.service.utilities.ProtocolData;
-import org.apache.hawq.pxf.service.utilities.Utilities;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 

--- a/pxf/pxf-service/src/main/java/org/apache/hawq/pxf/service/rest/InvalidPathResource.java
+++ b/pxf/pxf-service/src/main/java/org/apache/hawq/pxf/service/rest/InvalidPathResource.java
@@ -22,9 +22,10 @@ package org.apache.hawq.pxf.service.rest;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.hawq.pxf.service.utilities.Utilities;
+import org.apache.hawq.pxf.api.utilities.Utilities;
 
 import com.google.common.collect.ImmutableSet;
+
 import java.util.Arrays;
 import java.util.List;
 

--- a/pxf/pxf-service/src/main/java/org/apache/hawq/pxf/service/rest/WritableResource.java
+++ b/pxf/pxf-service/src/main/java/org/apache/hawq/pxf/service/rest/WritableResource.java
@@ -150,11 +150,11 @@ public class WritableResource extends RestResource{
         // Open the output file
         bridge.beginIteration();
 
-        DataInputStream dataStream = new DataInputStream(inputStream);
-
         long totalWritten = 0;
 
-        try {
+        // dataStream will close automatically in the end of the try.
+        // inputStream is closed by dataStream.close().
+        try (DataInputStream dataStream = new DataInputStream(inputStream)) {
             while (bridge.setNext(dataStream)) {
                 ++totalWritten;
             }
@@ -163,8 +163,6 @@ public class WritableResource extends RestResource{
         } catch (Exception ex) {
             LOG.debug("totalWritten so far " + totalWritten + " to " + path);
             throw ex;
-        } finally {
-            inputStream.close();
         }
 
         String censuredPath = Utilities.maskNonPrintables(path);

--- a/pxf/pxf-service/src/main/java/org/apache/hawq/pxf/service/rest/WritableResource.java
+++ b/pxf/pxf-service/src/main/java/org/apache/hawq/pxf/service/rest/WritableResource.java
@@ -37,11 +37,11 @@ import javax.ws.rs.core.Response;
 import org.apache.catalina.connector.ClientAbortException;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.hawq.pxf.api.utilities.Utilities;
 import org.apache.hawq.pxf.service.Bridge;
 import org.apache.hawq.pxf.service.WriteBridge;
 import org.apache.hawq.pxf.service.utilities.ProtocolData;
 import org.apache.hawq.pxf.service.utilities.SecuredHDFS;
-import org.apache.hawq.pxf.service.utilities.Utilities;
 
 /*
  * Running this resource manually:

--- a/pxf/pxf-service/src/test/java/org/apache/hawq/pxf/service/BridgeInputBuilderTest.java
+++ b/pxf/pxf-service/src/test/java/org/apache/hawq/pxf/service/BridgeInputBuilderTest.java
@@ -1,0 +1,154 @@
+package org.apache.hawq.pxf.service;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.hawq.pxf.api.OneField;
+import org.apache.hawq.pxf.api.OutputFormat;
+import org.apache.hawq.pxf.api.io.DataType;
+import org.apache.hawq.pxf.service.utilities.ProtocolData;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+@RunWith(PowerMockRunner.class)
+public class BridgeInputBuilderTest {
+    ProtocolData mockProtocolData;
+
+    @Test
+    /*
+     * Test makeInput method: small \n terminated input
+     */
+    public void makeInput() throws Exception {
+
+        byte[] data = new byte[] {
+                (int) 'a',
+                (int) 'b',
+                (int) 'c',
+                (int) 'd',
+                (int) '\n',
+                (int) 'n',
+                (int) 'o',
+                (int) '\n' };
+
+        DataInputStream inputStream = new DataInputStream(
+                new ByteArrayInputStream(data));
+        BridgeInputBuilder inputBuilder = new BridgeInputBuilder(
+                mockProtocolData);
+        List<OneField> record = inputBuilder.makeInput(inputStream);
+
+        verifyRecord(record, Arrays.copyOfRange(data, 0, 5));
+
+        record = inputBuilder.makeInput(inputStream);
+        verifyRecord(record, Arrays.copyOfRange(data, 5, 8));
+    }
+
+    @Test
+    /*
+     * Test the makeInput method: input > buffer size, \n terminated
+     */
+    public void makeInputBigArray() throws Exception {
+
+        byte[] bigArray = new byte[2000];
+        for (int i = 0; i < 1999; ++i) {
+            bigArray[i] = (byte) (i % 10 + 30);
+        }
+        bigArray[1999] = (byte) '\n';
+
+        DataInputStream inputStream = new DataInputStream(
+                new ByteArrayInputStream(bigArray));
+        BridgeInputBuilder inputBuilder = new BridgeInputBuilder(
+                mockProtocolData);
+        List<OneField> record = inputBuilder.makeInput(inputStream);
+
+        verifyRecord(record, bigArray);
+    }
+
+    @Test
+    /*
+     * Test the makeInput method: input > buffer size, no \n
+     */
+    public void makeInputBigArrayNoNewLine() throws Exception {
+
+        byte[] bigArray = new byte[2000];
+        for (int i = 0; i < 2000; ++i) {
+            bigArray[i] = (byte) (i % 10 + 60);
+        }
+
+        DataInputStream inputStream = new DataInputStream(
+                new ByteArrayInputStream(bigArray));
+        BridgeInputBuilder inputBuilder = new BridgeInputBuilder(
+                mockProtocolData);
+        List<OneField> record = inputBuilder.makeInput(inputStream);
+
+        verifyRecord(record, bigArray);
+    }
+
+    @Test
+    /*
+     * Test the makeInput method: empty stream (returns -1)
+     */
+    public void makeInputEmptyStream() throws Exception {
+
+        byte[] empty = new byte[0];
+
+        DataInputStream inputStream = new DataInputStream(
+                new ByteArrayInputStream(empty));
+        BridgeInputBuilder inputBuilder = new BridgeInputBuilder(
+                mockProtocolData);
+        List<OneField> record = inputBuilder.makeInput(inputStream);
+
+        verifyRecord(record, empty);
+    }
+
+    /*
+     * helpers functions
+     */
+
+    @Before
+    public void mockProtocolData() {
+        mockProtocolData = mock(ProtocolData.class);
+        PowerMockito.when(mockProtocolData.outputFormat()).thenReturn(
+                OutputFormat.TEXT);
+    }
+
+    private void verifyRecord(List<OneField> record, byte[] expected) {
+        assertEquals(record.size(), 1);
+
+        OneField field = record.get(0);
+        assertEquals(field.type, DataType.BYTEA.getOID());
+
+        byte[] bytes = (byte[]) field.val;
+        byte[] result = Arrays.copyOfRange(bytes, 0, bytes.length);
+        assertEquals(result.length, expected.length);
+        assertTrue(Arrays.equals(result, expected));
+    }
+}


### PR DESCRIPTION
1. Move Utilities class from pxf-service to pxf-api package.
2. Split StringPassResolverTest to two unit test files - one testing functionality of StringPassResolver.setFields and the other testing the functionality of BridgeInputBuilder.makeInput.