### PR TITLE
HAWQ-366. Analyse data locality ratio for TPCH query in SFO.

### DIFF
--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -6955,7 +6955,7 @@ static struct config_real ConfigureNamesReal[] =
 			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&net_disk_ratio,
-		1.0, 1.0, 100.0, NULL, NULL
+		1.01, 1.0, 100.0, NULL, NULL
 	},
 
 	{


### PR DESCRIPTION
Data locality ratio for TPCH query(such as Q2) in SFO is low when some machines are down.
The reason for this is that we change net_disk_ratio to 1.0 which leads to we prefer the virtual segment with minimum allocated size plus current split size, but not LOCAL!
To prevent this happens we need to enlarge net_disk_ratio to 1.01. Then if the current size of two vsegs are almost the same, we can choose the LOCAL one.