### PR TITLE
HAWQ-274. Make function CheckTmpDirAvailable more simple

### DIFF
--- a/src/backend/cdb/cdbtmpdir.c
+++ b/src/backend/cdb/cdbtmpdir.c
@@ -45,7 +45,7 @@ List *initTmpDirList(List *list, char *szTmpDir)
                 tmpdir = (char *)palloc0(i-idx);
                 strncpy(tmpdir, szTmpDir+idx+1, i-idx-1);
                 tmpDirNum++;
-                elog(LOG, "Get a temporary directory:%s", tmpdir);
+                elog(DEBUG5, "Get a temporary directory:%s", tmpdir);
                 list = lappend(list, tmpdir);
             }
             idx = i;

--- a/src/backend/resourcemanager/resourcemanager_RMSEG.c
+++ b/src/backend/resourcemanager/resourcemanager_RMSEG.c
@@ -247,7 +247,7 @@ bool CheckTmpDirAvailable(char *path)
 	char* fname = NULL;
 	char* testfile = "/checktmpdir.log";
 
-	/* write some bytes to a file to check if
+	/* open a file to check if
 	 * this temporary directory is OK.
 	 */
 	fname = palloc0(strlen(path) + strlen(testfile) + 1);
@@ -258,24 +258,8 @@ bool CheckTmpDirAvailable(char *path)
 	{
 		elog(LOG, "Can't open file:%s when check temporary directory", fname);
 		ret = false;
-		goto _exit;
 	}
 
-	if (fseek(tmp, 0, SEEK_SET) != 0)
-	{
-		elog(LOG, "Can't seek file:%s when check temporary directory", fname);
-		ret = false;
-		goto _exit;
-	}
-
-	if (strlen("test") != fwrite("test", 1, strlen("test"), tmp))
-	{
-		elog(LOG, "Can't write file:%s when check temporary directory", fname);
-		ret = false;
-		goto _exit;
-	}
-
-	_exit:
 	pfree(fname);
 	if (tmp != NULL)
 		fclose(tmp);

--- a/src/backend/resourcemanager/resourcemanager_RMSEG.c
+++ b/src/backend/resourcemanager/resourcemanager_RMSEG.c
@@ -256,7 +256,9 @@ bool CheckTmpDirAvailable(char *path)
 	tmp = fopen(fname, "w");
 	if (tmp == NULL)
 	{
-		elog(LOG, "Can't open file:%s when check temporary directory", fname);
+		elog(LOG, "Can't open file:%s when check temporary directory: %s",
+				  fname,
+				  strerror(errno));
 		ret = false;
 	}
 


### PR DESCRIPTION
This fix is to simplify function CheckTmpDirAvailabl(). If can't open a file on this directory, we assume it is a failed dir. 
Please review.