### PR TITLE
HAWQ-360. Fixed Data loss when alter partition table by add two column in one time.

### DIFF
--- a/src/backend/cdb/cdbfilesplit.c
+++ b/src/backend/cdb/cdbfilesplit.c
@@ -89,12 +89,12 @@ AssignSingleAOSegFileSplitToSegment(Oid relid, List *segment_infos, bool keep_ha
 	 */
 	if (RELSTORAGE_AOROWS == storageChar)
 	{
-		splits = AOGetAllSegFileSplits(aoEntry, ActiveSnapshot);
+		splits = AOGetAllSegFileSplits(aoEntry, SnapshotSelf);
 	}
 	else
 	{
 		Assert(RELSTORAGE_PARQUET == storageChar);
-		splits = ParquetGetAllSegFileSplits(aoEntry, ActiveSnapshot);
+		splits = ParquetGetAllSegFileSplits(aoEntry, SnapshotSelf);
 	}
 
 	/*


### PR DESCRIPTION
When executing the sql "alter table part_1 add column p int default 3,add column q int default 4;" , the executing process has tow phases. 
Phase 1:
create a pg_tmp_1 table
create pg_temp_1's aoseg table
copy every column in origin table with adding a column p to pg_temp_1 table
update its aoseg table

Phase 2:
create a pg_temp_2 table
create its pg_temp_2's aoseg table
copy every column in pg_temp_1 with adding a column q to pg_temp_2 table.
update its aoseg table

However, with using previous code, by the 3rd step in phase2 it use ActiveSnapshot, which means it can't get the latest aoseg table of pg_temp_1.  As a result, it cause data loss.
So I modify it by using SnapshotSelf.