### PR TITLE
HAWQ-535. hawqextract column context does not exist error

### DIFF
--- a/tools/bin/hawqextract
+++ b/tools/bin/hawqextract
@@ -152,12 +152,12 @@ class GpMetadataAccessor:
 
         Example:
         >>> accessor.get_aoseg_files(35709)
-        >>> [{'content':'0', 'fileno':'1', 'filesize':'320'},
-        ...  {'content':'1', 'fileno':'1', 'filesize':'880'},
-        ...  {'content':'1', 'fileno':'2', 'filesize':'160'}]
+        >>> [{'fileno':'1', 'filesize':'320'},
+        ...  {'fileno':'2', 'filesize':'880'},
+        ...  {'fileno':'3', 'filesize':'160'}]
         '''
         qry = """
-        SELECT content, segno as fileno, eof as filesize 
+        SELECT segno as fileno, eof as filesize 
         FROM pg_aoseg.pg_aoseg_%d
         ORDER by fileno;
         """ % oid
@@ -170,14 +170,14 @@ class GpMetadataAccessor:
 
         Example:
         >>> accessor.get_paqseg_files(35709)
-        >>> [{'content':'0', 'fileno':'1', 'filesize':'320'},
-        ...  {'content':'1', 'fileno':'1', 'filesize':'880'},
-        ...  {'content':'1', 'fileno':'2', 'filesize':'160'}]
+        >>> [{'fileno':'1', 'filesize':'320'},
+        ...  {'fileno':'2', 'filesize':'880'},
+        ...  {'fileno':'3', 'filesize':'160'}]
         '''
         qry = """
-        SELECT content, segno as fileno, eof as filesize 
+        SELECT segno as fileno, eof as filesize 
         FROM pg_aoseg.pg_paqseg_%d
-        WHERE content >= 0 ORDER by content, fileno;
+        ORDER by fileno;
         """ % oid
         return self.exec_query(qry)
 
@@ -306,17 +306,17 @@ def extract_metadata(conn, tbname):
 
         Example:
         >>> segment_localtions
-        >>> ['hdfs://127.0.0.1:9000/gpseg0', 'hdfs://127.0.0.1:9000/gpseg1']
+        >>> ['hdfs://127.0.0.1:9000/hawq_default', 'hdfs://127.0.0.1:9000/hawq_default']
         >>> tablespace_oid, database_oid, relfilenode, oid
         >>> (16385, 35469, 35470, 35488)
         >>> accessor.get_aoseg_files(35488)
-        >>> [{'content': '0', 'fileno': '1', 'filesize': '180'},
-        ...  {'content': '0', 'fileno': '2', 'filesize': '150'},
-        ...  {'content': '1', 'fileno': '1', 'filesize': '320'}]
+        >>> [{'fileno': '1', 'filesize': '180'},
+        ...  {'fileno': '2', 'filesize': '150'},
+        ...  {'fileno': '3', 'filesize': '320'}]
         >>> get_ao_table_files(35488, 35470)
-        >>> [{'path' :'/gpseg0/16385/35469/35470.1', 'size': 180},
-        ...  {'path' :'/gpseg0/16385/35469/35470.2', 'size': 150},
-        ...  {'path' :'/gpseg1/16385/35469/35470.1', 'size': 320}]
+        >>> [{'path' :'/hawq_default/16385/35469/1', 'size': 180},
+        ...  {'path' :'/hawq_default/16385/35469/2', 'size': 150},
+        ...  {'path' :'/hawq_default/16385/35469/3', 'size': 320}]
         '''
         files = []
         for f in accessor.get_aoseg_files(oid):


### PR DESCRIPTION
When running hawq extract python stack trace is returned because pg_aoseg no longer has a column called content

`[gpadmin@node2 ~]$ hawq extract -o rank_table.yaml foo
20160129:23:21:41:004538 hawqextract:node2:gpadmin-[INFO]:-try to connect database localhost:5432 gpadmin
20160129:23:21:41:004538 hawqextract:node2:gpadmin-[INFO]:-try to extract metadata of table 'foo'
20160129:23:21:41:004538 hawqextract:node2:gpadmin-[INFO]:--- detect FileFormat: AO
20160129:23:21:41:004538 hawqextract:node2:gpadmin-[INFO]:--- extract AO_FileLocations
Traceback (most recent call last):
  File "/usr/local/hawq-master/bin/hawqextract", line 551, in <module>
    sys.exit(main())
  File "/usr/local/hawq-master/bin/hawqextract", line 528, in main
    metadata = extract_metadata(conn, args[0])
  File "/usr/local/hawq-master/bin/hawqextract", line 444, in extract_metadata
    cases[file_format]()
  File "/usr/local/hawq-master/bin/hawqextract", line 363, in extract_AO_metadata
    'Files': get_ao_table_files(rel_pgclass['oid'], rel_pgclass['relfilenode'])
  File "/usr/local/hawq-master/bin/hawqextract", line 322, in get_ao_table_files
    for f in accessor.get_aoseg_files(oid):
  File "/usr/local/hawq-master/bin/hawqextract", line 164, in get_aoseg_files
    return self.exec_query(qry)
  File "/usr/local/hawq-master/bin/hawqextract", line 129, in exec_query
    return self.conn.query(sql).dictresult()
pg.ProgrammingError: ERROR:  column "content" does not exist
LINE 2:         SELECT content, segno as fileno, eof as filesize`