### PR TITLE
HAWQ-374. Fixed hawq core dump at dispatch_free_result() when run str…

### DIFF
--- a/src/backend/cdb/cdbcopy.c
+++ b/src/backend/cdb/cdbcopy.c
@@ -78,6 +78,8 @@ makeCdbCopy(bool is_copy_in, QueryResource *resource)
 	/* init gangs */
 	c->aotupcounts = NULL;
 
+	c->executors.segment_conns = NIL;
+
 	/* Initialize the state of each segment database */
 	c->segdb_state = (SegDbState **) palloc((c->partition_num) * sizeof(SegDbState *));
 


### PR DESCRIPTION
…ess test

The root cause is:
The copy error may occurs after  c->executors initiated at cdbCopyEnd(), but before 
c->executors.segment_conns initiated line 1432 at dispatch_statement() .