### PR TITLE
HAWQ-375. Fixed Fixed hawq core dump at dispatch_free_result():1493 w…

### DIFF
--- a/src/backend/cdb/cdbcopy.c
+++ b/src/backend/cdb/cdbcopy.c
@@ -79,6 +79,7 @@ makeCdbCopy(bool is_copy_in, QueryResource *resource)
 	c->aotupcounts = NULL;
 
 	c->executors.segment_conns = NIL;
+	c->executors.errbuf.data = NULL;
 
 	/* Initialize the state of each segment database */
 	c->segdb_state = (SegDbState **) palloc((c->partition_num) * sizeof(SegDbState *));

--- a/src/backend/cdb/dispatcher.c
+++ b/src/backend/cdb/dispatcher.c
@@ -1490,7 +1490,11 @@ dispatch_free_result(DispatchDataResult *result)
 	if (!result)
 		return;
 
-	pfree(result->errbuf.data);
+	if(result->errbuf.data)
+	{
+		pfree(result->errbuf.data);
+		result->errbuf.data = NULL;
+	}
 	dispmgt_free_takeoved_segment_conns(result->segment_conns);
 }
 


### PR DESCRIPTION
…hen run stress test

Same as HAWQ-374, it crashed at different variable, we need to make sure initiate it with NULL, and free it when it is not NULL. 