### PR TITLE
HAWQ-380. Wrongly validate resource pool status when index of allocated resources is not complete

### DIFF
--- a/src/backend/resourcemanager/resourcepool.c
+++ b/src/backend/resourcemanager/resourcepool.c
@@ -3449,7 +3449,6 @@ void timeoutIdleGRMResourceToRBByRatio(int 		 ratioindex,
 			elog(LOG, "Resource manager decides to return container "INT64_FORMAT" in host %s",
 					  retcont->ID,
 					  retcont->HostName);
-			validateResourcePoolStatus(false);
 		}
 		else
 		{
@@ -3472,6 +3471,8 @@ void timeoutIdleGRMResourceToRBByRatio(int 		 ratioindex,
 	{
 		insertBBSTNode(tree, (BBSTNode)removeDQueueHeadNode(&tempskipnodes));
 	}
+
+	validateResourcePoolStatus(false);
 }
 
 bool hasSegmentGRMCapacityNotUpdated(void)


### PR DESCRIPTION
When RM finds appropriate segments to remove GRM containers, the index node of allocated resource maybe partially removed, therefore, we can only validate the resource pool after restoring the index.