### PR TITLE
HAWQ-382. Adjust combined workload index in resource pool in different situations

### DIFF
--- a/src/backend/resourcemanager/include/resourcepool.h
+++ b/src/backend/resourcemanager/include/resourcepool.h
@@ -546,7 +546,6 @@ SegResource getSegResource(int32_t id);
 int  addGRMContainerToToBeAccepted(GRMContainer ctn);
 void GRMContainerToAccepted(GRMContainer ctn);
 void addGRMContainerToResPool(GRMContainer ctn);
-void dropGRMContainerFromResPool(GRMContainer ctn);
 
 void addGRMContainerToToBeKicked(GRMContainer ctn);
 void addGRMContainerToKicked(GRMContainer ctn);


### PR DESCRIPTION
This fix it to make combined workload index maintained well when consuming resource, mark segment up/down, etc.