### PR TITLE
[HAWQ-19] Money type overflow fixed by back porting int64 support from Postgres commit 74a4019

### DIFF
--- a/src/backend/cdb/cdbparquetcolumn.c
+++ b/src/backend/cdb/cdbparquetcolumn.c
@@ -486,7 +486,7 @@ decodePlain(Datum *value, uint8_t **buffer, int hawqTypeID)
 			 * should be a pointer, see cash.c
 			 */
 			(*value) = PointerGetDatum(*buffer);
-			(*buffer) += 4;
+			(*buffer) += 8;
 			break;
 		}
 

--- a/src/backend/cdb/cdbparquetstoragewrite.c
+++ b/src/backend/cdb/cdbparquetstoragewrite.c
@@ -653,7 +653,6 @@ mappingHAWQType(int hawqTypeID)
 
 	case HAWQ_TYPE_INT2:
 	case HAWQ_TYPE_INT4:
-	case HAWQ_TYPE_MONEY:
 	case HAWQ_TYPE_DATE:
 		return INT32;
 
@@ -661,6 +660,7 @@ mappingHAWQType(int hawqTypeID)
 	case HAWQ_TYPE_TIME:
 	case HAWQ_TYPE_TIMESTAMPTZ:
 	case HAWQ_TYPE_TIMESTAMP:
+	case HAWQ_TYPE_MONEY:
 		return INT64;
 
 	case HAWQ_TYPE_FLOAT4:
@@ -1274,13 +1274,18 @@ encodePlain(Datum data,
 		memcpy(dst_ptr, &val, len);
 		return len;
 	}
+
+
+	/*----------------------------------------------------------------
+	 * Type mapped to 8-bytes INT64/DOUBLE in Parquet
+	 *----------------------------------------------------------------*/
 	case HAWQ_TYPE_MONEY:
 	{
 		/*
-		 * Although money is represented as int32 internally,
+		 * Although money is represented as int64 internally,
 		 * it's passed by reference.
 		 */
-		len = 4;
+		len = 8;
 		if (!ensureBufferCapacity(current_page, len, pageSizeLimit))
 		{
 			return ENCODE_OUTOF_PAGE;
@@ -1293,11 +1298,7 @@ encodePlain(Datum data,
 		memcpy(dst_ptr, cash_p, len);
 		return len;
 	}
-
-
-	/*----------------------------------------------------------------
-	 * Type mapped to 8-bytes INT64/DOUBLE in Parquet
-	 *----------------------------------------------------------------*/
+	
 	case HAWQ_TYPE_INT8:
 	{
 		len = 8;

--- a/src/backend/utils/adt/cash.c
+++ b/src/backend/utils/adt/cash.c
@@ -1,13 +1,17 @@
 /*
  * cash.c
  * Written by D'Arcy J.M. Cain
+ * darcy@druid.net
+ * http://www.druid.net/darcy/
  *
  * Functions to allow input and output of money normally but store
- * and handle it as int4s
+ * and handle it as 64 bit ints
  *
  * A slightly modified version of this file and a discussion of the
  * workings can be found in the book "Software Solutions in C" by
- * Dale Schumacher, Academic Press, ISBN: 0-12-632360-7.
+ * Dale Schumacher, Academic Press, ISBN: 0-12-632360-7 except that
+ * this version handles 64 bit numbers and so can hold values up to
+ * $92,233,720,368,547,758.07.
  *
  * $PostgreSQL: pgsql/src/backend/utils/adt/cash.c,v 1.69 2007/01/03 01:19:50 darcy Exp $
  */
@@ -23,16 +27,11 @@
 #include "utils/cash.h"
 #include "utils/pg_locale.h"
 
-
-static const char *num_word(Cash value);
-
-/* when we go to 64 bit values we will have to modify this */
-#define CASH_BUFSZ		24
+#define CASH_BUFSZ		36
 
 #define TERMINATOR		(CASH_BUFSZ - 1)
 #define LAST_PAREN		(TERMINATOR - 1)
 #define LAST_DIGIT		(LAST_PAREN - 1)
-
 
 /*
  * Cash is a pass-by-ref SQL type, so we must pass and return pointers.
@@ -40,6 +39,65 @@ static const char *num_word(Cash value);
  */
 #define PG_GETARG_CASH(n)  (* ((Cash *) PG_GETARG_POINTER(n)))
 #define PG_RETURN_CASH(x)  return CashGetDatum(x)
+
+
+
+/*************************************************************************
+ * Private routines
+ ************************************************************************/
+
+static const char *
+num_word(Cash value)
+{
+	static char buf[128];
+	static const char *small[] = {
+		"zero", "one", "two", "three", "four", "five", "six", "seven",
+		"eight", "nine", "ten", "eleven", "twelve", "thirteen", "fourteen",
+		"fifteen", "sixteen", "seventeen", "eighteen", "nineteen", "twenty",
+		"thirty", "forty", "fifty", "sixty", "seventy", "eighty", "ninety"
+	};
+	const char **big = small + 18;
+	int			tu = value % 100;
+
+	/* deal with the simple cases first */
+	if (value <= 20)
+		return small[value];
+
+	/* is it an even multiple of 100? */
+	if (!tu)
+	{
+		sprintf(buf, "%s hundred", small[value / 100]);
+		return buf;
+	}
+
+	/* more than 99? */
+	if (value > 99)
+	{
+		/* is it an even multiple of 10 other than 10? */
+		if (value % 10 == 0 && tu > 10)
+			sprintf(buf, "%s hundred %s",
+					small[value / 100], big[tu / 10]);
+		else if (tu < 20)
+			sprintf(buf, "%s hundred and %s",
+					small[value / 100], small[tu]);
+		else
+			sprintf(buf, "%s hundred %s %s",
+					small[value / 100], big[tu / 10], small[tu % 10]);
+
+	}
+	else
+	{
+		/* is it an even multiple of 10 other than 10? */
+		if (value % 10 == 0 && tu > 10)
+			sprintf(buf, "%s", big[tu / 10]);
+		else if (tu < 20)
+			sprintf(buf, "%s", small[tu]);
+		else
+			sprintf(buf, "%s %s", big[tu / 10], small[tu % 10]);
+	}
+
+	return buf;
+}	/* num_word() */
 
 static Datum
 CashGetDatum(Cash value)
@@ -56,12 +114,6 @@ CashGetDatum(Cash value)
  * Format is [$]###[,]###[.##]
  * Examples: 123.45 $123.45 $123,456.78
  *
- * This is currently implemented as a 32-bit integer.
- * XXX HACK It looks as though some of the symbols for
- *	monetary values returned by localeconv() can be multiple
- *	bytes/characters. This code assumes one byte only. - tgl 97/04/14
- * XXX UNHACK Allow the currency symbol to be multibyte.
- *	- thomas 1998-03-01
  */
 Datum
 cash_in(PG_FUNCTION_ARGS)
@@ -74,11 +126,11 @@ cash_in(PG_FUNCTION_ARGS)
 	int			seen_dot = 0;
 	const char *s = str;
 	int			fpoint;
-	char	   *csymbol;
 	char		dsymbol,
 				ssymbol,
-				psymbol,
-			   *nsymbol;
+				psymbol;
+	const char *nsymbol,
+			   *csymbol;
 
 	struct lconv *lconvert = PGLC_localeconv();
 
@@ -120,6 +172,7 @@ cash_in(PG_FUNCTION_ARGS)
 
 	/* a leading minus or paren signifies a negative number */
 	/* again, better heuristics needed */
+	/* XXX - doesn't properly check for balanced parens - djmc */
 	if (strncmp(s, nsymbol, strlen(nsymbol)) == 0)
 	{
 		sgn = -1;
@@ -152,7 +205,7 @@ cash_in(PG_FUNCTION_ARGS)
 
 	for (;; s++)
 	{
-		/* we look for digits as int4 as we have less */
+		/* we look for digits as int8 as we have less */
 		/* than the required number of decimal places */
 		if (isdigit((unsigned char) *s) && dec < fpoint)
 		{
@@ -161,14 +214,14 @@ cash_in(PG_FUNCTION_ARGS)
 			if (seen_dot)
 				dec++;
 
-			/* decimal point? then start counting fractions... */
 		}
+		/* decimal point? then start counting fractions... */
 		else if (*s == dsymbol && !seen_dot)
 		{
 			seen_dot = 1;
 
-			/* "thousands" separator? then skip... */
 		}
+		/* "thousands" separator? then skip... */
 		else if (*s == ssymbol)
 		{
 
@@ -187,7 +240,9 @@ cash_in(PG_FUNCTION_ARGS)
 		}
 	}
 
-	while (isspace((unsigned char) *s) || *s == '0' || *s == ')')
+	/* should only be trailing digits followed by whitespace or closing paren */
+	while (isdigit(*s)) s++;
+	while (isspace((unsigned char) *s) || *s == ')')
 		s++;
 
 	if (*s != '\0')
@@ -223,9 +278,9 @@ cash_out(PG_FUNCTION_ARGS)
 	int			points,
 				mon_group;
 	char		comma;
-	char	   *csymbol,
-				dsymbol,
+	const char *csymbol,
 			   *nsymbol;
+	char		dsymbol;
 	char		convention;
 
 	struct lconv *lconvert = PGLC_localeconv();
@@ -276,8 +331,8 @@ cash_out(PG_FUNCTION_ARGS)
 		else if (comma && count % (mon_group + 1) == comma_position)
 			buf[count--] = comma;
 
-		buf[count--] = ((unsigned int) value % 10) + '0';
-		value = ((unsigned int) value) / 10;
+		buf[count--] = ((uint64) value % 10) + '0';
+		value = ((uint64) value) / 10;
 	}
 
 	strncpy((buf + count - strlen(csymbol) + 1), csymbol, strlen(csymbol));
@@ -470,9 +525,6 @@ flt8_mul_cash(PG_FUNCTION_ARGS)
 
 /* cash_div_flt8()
  * Divide cash by float8.
- *
- * XXX Don't know if rounding or truncating is correct behavior.
- * Round for now. - tgl 97/04/15
  */
 Datum
 cash_div_flt8(PG_FUNCTION_ARGS)
@@ -489,6 +541,7 @@ cash_div_flt8(PG_FUNCTION_ARGS)
 	result = rint(c / f);
 	PG_RETURN_CASH(result);
 }
+
 
 /* cash_mul_flt4()
  * Multiply cash by float4.
@@ -523,8 +576,6 @@ flt4_mul_cash(PG_FUNCTION_ARGS)
 /* cash_div_flt4()
  * Divide cash by float4.
  *
- * XXX Don't know if rounding or truncating is correct behavior.
- * Round for now. - tgl 97/04/15
  */
 Datum
 cash_div_flt4(PG_FUNCTION_ARGS)
@@ -543,6 +594,56 @@ cash_div_flt4(PG_FUNCTION_ARGS)
 }
 
 
+/* cash_mul_int8()
+ * Multiply cash by int8.
+ */
+Datum
+cash_mul_int8(PG_FUNCTION_ARGS)
+{
+	Cash		c = PG_GETARG_CASH(0);
+	int64		i = PG_GETARG_INT64(1);
+	Cash		result;
+
+	result = c * i;
+	PG_RETURN_CASH(result);
+}
+
+
+/* int8_mul_cash()
+ * Multiply int8 by cash.
+ */
+Datum
+int8_mul_cash(PG_FUNCTION_ARGS)
+{
+	int64		i = PG_GETARG_INT64(0);
+	Cash		c = PG_GETARG_CASH(1);
+	Cash		result;
+
+	result = i * c;
+	PG_RETURN_CASH(result);
+}
+
+/* cash_div_int8()
+ * Divide cash by 8-byte integer.
+ */
+Datum
+cash_div_int8(PG_FUNCTION_ARGS)
+{
+	Cash		c = PG_GETARG_CASH(0);
+	int64		i = PG_GETARG_INT64(1);
+	Cash		result;
+
+	if (i == 0)
+		ereport(ERROR,
+				(errcode(ERRCODE_DIVISION_BY_ZERO),
+				 errmsg("division by zero")));
+
+	result = rint(c / i);
+
+	PG_RETURN_CASH(result);
+}
+
+
 /* cash_mul_int4()
  * Multiply cash by int4.
  */
@@ -550,7 +651,7 @@ Datum
 cash_mul_int4(PG_FUNCTION_ARGS)
 {
 	Cash		c = PG_GETARG_CASH(0);
-	int32		i = PG_GETARG_INT32(1);
+	int64		i = PG_GETARG_INT64(1);
 	Cash		result;
 
 	result = c * i;
@@ -576,14 +677,12 @@ int4_mul_cash(PG_FUNCTION_ARGS)
 /* cash_div_int4()
  * Divide cash by 4-byte integer.
  *
- * XXX Don't know if rounding or truncating is correct behavior.
- * Round for now. - tgl 97/04/15
  */
 Datum
 cash_div_int4(PG_FUNCTION_ARGS)
 {
 	Cash		c = PG_GETARG_CASH(0);
-	int32		i = PG_GETARG_INT32(1);
+	int64		i = PG_GETARG_INT64(1);
 	Cash		result;
 
 	if (i == 0)
@@ -628,8 +727,6 @@ int2_mul_cash(PG_FUNCTION_ARGS)
 /* cash_div_int2()
  * Divide cash by int2.
  *
- * XXX Don't know if rounding or truncating is correct behavior.
- * Round for now. - tgl 97/04/15
  */
 Datum
 cash_div_int2(PG_FUNCTION_ARGS)
@@ -677,7 +774,6 @@ cashsmaller(PG_FUNCTION_ARGS)
 	PG_RETURN_CASH(result);
 }
 
-
 /* cash_words()
  * This converts a int4 as well but to a representation using words
  * Obviously way North American centric - sorry
@@ -686,13 +782,16 @@ Datum
 cash_words(PG_FUNCTION_ARGS)
 {
 	Cash		value = PG_GETARG_CASH(0);
-	unsigned int val;
+	uint64 val;
 	char		buf[256];
 	char	   *p = buf;
 	Cash		m0;
 	Cash		m1;
 	Cash		m2;
 	Cash		m3;
+	Cash		m4;
+	Cash		m5;
+	Cash		m6;
 	text	   *result;
 
 	/* work with positive numbers */
@@ -706,12 +805,33 @@ cash_words(PG_FUNCTION_ARGS)
 		buf[0] = '\0';
 
 	/* Now treat as unsigned, to avoid trouble at INT_MIN */
-	val = (unsigned int) value;
+	val = (uint64) value;
 
-	m0 = val % 100;				/* cents */
-	m1 = (val / 100) % 1000;	/* hundreds */
-	m2 = (val / 100000) % 1000; /* thousands */
-	m3 = val / 100000000 % 1000;	/* millions */
+	m0 = val % 100ll;				/* cents */
+	m1 = (val / 100ll) % 1000;	/* hundreds */
+	m2 = (val / 100000ll) % 1000; /* thousands */
+	m3 = val / 100000000ll % 1000;	/* millions */
+	m4 = val / 100000000000ll % 1000;	/* billions */
+	m5 = val / 100000000000000ll % 1000;	/* trillions */
+	m6 = val / 100000000000000000ll % 1000;	/* quadrillions */
+
+	if (m6)
+	{
+		strcat(buf, num_word(m6));
+		strcat(buf, " quadrillion ");
+	}
+
+	if (m5)
+	{
+		strcat(buf, num_word(m5));
+		strcat(buf, " trillion ");
+	}
+
+	if (m4)
+	{
+		strcat(buf, num_word(m4));
+		strcat(buf, " billion ");
+	}
 
 	if (m3)
 	{
@@ -745,61 +865,3 @@ cash_words(PG_FUNCTION_ARGS)
 
 	PG_RETURN_TEXT_P(result);
 }
-
-
-/*************************************************************************
- * Private routines
- ************************************************************************/
-
-static const char *
-num_word(Cash value)
-{
-	static char buf[128];
-	static const char *small[] = {
-		"zero", "one", "two", "three", "four", "five", "six", "seven",
-		"eight", "nine", "ten", "eleven", "twelve", "thirteen", "fourteen",
-		"fifteen", "sixteen", "seventeen", "eighteen", "nineteen", "twenty",
-		"thirty", "forty", "fifty", "sixty", "seventy", "eighty", "ninety"
-	};
-	const char **big = small + 18;
-	int			tu = value % 100;
-
-	/* deal with the simple cases first */
-	if (value <= 20)
-		return small[value];
-
-	/* is it an even multiple of 100? */
-	if (!tu)
-	{
-		sprintf(buf, "%s hundred", small[value / 100]);
-		return buf;
-	}
-
-	/* more than 99? */
-	if (value > 99)
-	{
-		/* is it an even multiple of 10 other than 10? */
-		if (value % 10 == 0 && tu > 10)
-			sprintf(buf, "%s hundred %s",
-					small[value / 100], big[tu / 10]);
-		else if (tu < 20)
-			sprintf(buf, "%s hundred and %s",
-					small[value / 100], small[tu]);
-		else
-			sprintf(buf, "%s hundred %s %s",
-					small[value / 100], big[tu / 10], small[tu % 10]);
-
-	}
-	else
-	{
-		/* is it an even multiple of 10 other than 10? */
-		if (value % 10 == 0 && tu > 10)
-			sprintf(buf, "%s", big[tu / 10]);
-		else if (tu < 20)
-			sprintf(buf, "%s", small[tu]);
-		else
-			sprintf(buf, "%s %s", big[tu / 10], small[tu % 10]);
-	}
-
-	return buf;
-}	/* num_word() */

--- a/src/include/catalog/pg_type.h
+++ b/src/include/catalog/pg_type.h
@@ -464,10 +464,10 @@ DESCR("geometric circle '(center,radius)'");
 #define CIRCLEOID		718
 DATA(insert OID = 719 (	_circle	   PGNSP PGUID -1 f b t \054 0	718 array_in array_out array_recv array_send - d x f 0 -1 0 _null_ _null_ ));
 
-DATA(insert OID = 790 (	money	   PGNSP PGUID 4 f b t \054 0	0 cash_in cash_out cash_recv cash_send - i p f 0 -1 0 _null_ _null_ ));
+DATA(insert OID = 790 (	money	   PGNSP PGUID 8 f b t \054 0	0 cash_in cash_out cash_recv cash_send - d p f 0 -1 0 _null_ _null_ ));
 DESCR("monetary amounts, $d,ddd.cc");
 #define CASHOID 790
-DATA(insert OID = 791 (	_money	   PGNSP PGUID -1 f b t \054 0	790 array_in array_out array_recv array_send - i x f 0 -1 0 _null_ _null_ ));
+DATA(insert OID = 791 (	_money	   PGNSP PGUID -1 f b t \054 0  790 array_in array_out array_recv array_send - d x f 0 -1 0 _null_ _null_ ));
 
 
 /*  OIDS 800 - 899  */

--- a/src/include/catalog/pg_type.sql
+++ b/src/include/catalog/pg_type.sql
@@ -388,9 +388,9 @@
    OUTPUT = cash_out,
    RECEIVE = cash_recv,
    SEND = cash_send,
-   INTERNALLENGTH = 4,
+   INTERNALLENGTH = 8,
    STORAGE = plain,
-   ALIGNMENT = int4
+   ALIGNMENT = double
  ) WITH (OID=790, ARRAYOID=791, DESCRIPTION="monetary amounts, $d,ddd.cc");
 -- #define CASHOID 790
 

--- a/src/include/utils/cash.h
+++ b/src/include/utils/cash.h
@@ -21,7 +21,7 @@
  * Written by D'Arcy J.M. Cain
  *
  * Functions to allow input and output of money normally but store
- *	and handle it as int4.
+ *	and handle it as 64 bit integer.
  */
 
 #ifndef CASH_H
@@ -29,8 +29,7 @@
 
 #include "fmgr.h"
 
-/* if we store this as 4 bytes, we better make it int, not long, bjm */
-typedef int32 Cash;
+typedef int64 Cash;
 
 extern Datum cash_in(PG_FUNCTION_ARGS);
 extern Datum cash_out(PG_FUNCTION_ARGS);
@@ -55,6 +54,10 @@ extern Datum flt8_mul_cash(PG_FUNCTION_ARGS);
 extern Datum cash_mul_flt4(PG_FUNCTION_ARGS);
 extern Datum cash_div_flt4(PG_FUNCTION_ARGS);
 extern Datum flt4_mul_cash(PG_FUNCTION_ARGS);
+
+extern Datum cash_mul_int8(PG_FUNCTION_ARGS);
+extern Datum int8_mul_cash(PG_FUNCTION_ARGS);
+extern Datum cash_div_int8(PG_FUNCTION_ARGS);
 
 extern Datum cash_mul_int4(PG_FUNCTION_ARGS);
 extern Datum cash_div_int4(PG_FUNCTION_ARGS);

--- a/src/test/regress/expected/money.out
+++ b/src/test/regress/expected/money.out
@@ -1,0 +1,158 @@
+--
+-- MONEY
+--
+CREATE TABLE MONEY_TBL (f1  money);
+INSERT INTO MONEY_TBL(f1) VALUES ('    0.0');
+INSERT INTO MONEY_TBL(f1) VALUES ('1004.30   ');
+INSERT INTO MONEY_TBL(f1) VALUES ('     -34.84    ');
+INSERT INTO MONEY_TBL(f1) VALUES ('123456789012345.67');
+-- test money over and under flow
+SELECT '12345678901234567890.12'::money = '-13639628150831692.60'::money as x;
+ x 
+---
+ t
+(1 row)
+
+SELECT '123.001'::money = '123'::money as x;
+ x 
+---
+ t
+(1 row)
+
+-- bad input
+INSERT INTO MONEY_TBL(f1) VALUES ('xyz');
+ERROR:  invalid input syntax for type money: "xyz"
+INSERT INTO MONEY_TBL(f1) VALUES ('5.0.0');
+ERROR:  invalid input syntax for type money: "5.0.0"
+INSERT INTO MONEY_TBL(f1) VALUES ('5 . 0');
+ERROR:  invalid input syntax for type money: "5 . 0"
+INSERT INTO MONEY_TBL(f1) VALUES ('5.   0');
+ERROR:  invalid input syntax for type money: "5.   0"
+INSERT INTO MONEY_TBL(f1) VALUES ('123            5');
+ERROR:  invalid input syntax for type money: "123            5"
+-- queries
+SELECT '' AS five, * FROM MONEY_TBL ORDER BY 2;
+ five |           f1            
+------+-------------------------
+      |                 -$34.84
+      |                   $0.00
+      |               $1,004.30
+      | $123,456,789,012,345.67
+(4 rows)
+
+SELECT '' AS four, f.* FROM MONEY_TBL f WHERE f.f1 <> '1004.3' ORDER BY 2;
+ four |           f1            
+------+-------------------------
+      |                 -$34.84
+      |                   $0.00
+      | $123,456,789,012,345.67
+(3 rows)
+
+SELECT '' AS one, f.* FROM MONEY_TBL f WHERE f.f1 = '1004.3' ORDER BY 2;
+ one |    f1     
+-----+-----------
+     | $1,004.30
+(1 row)
+
+SELECT '' AS three, f.* FROM MONEY_TBL f WHERE '1004.3' > f.f1 ORDER BY 2;
+ three |   f1    
+-------+---------
+       | -$34.84
+       |   $0.00
+(2 rows)
+
+SELECT '' AS three, f.* FROM MONEY_TBL f WHERE  f.f1 < '1004.3' ORDER BY 2;
+ three |   f1    
+-------+---------
+       | -$34.84
+       |   $0.00
+(2 rows)
+
+SELECT '' AS four, f.* FROM MONEY_TBL f WHERE '1004.3' >= f.f1 ORDER BY 2;
+ four |    f1     
+------+-----------
+      |   -$34.84
+      |     $0.00
+      | $1,004.30
+(3 rows)
+
+SELECT '' AS four, f.* FROM MONEY_TBL f WHERE  f.f1 <= '1004.3' ORDER BY 2;
+ four |    f1     
+------+-----------
+      |   -$34.84
+      |     $0.00
+      | $1,004.30
+(3 rows)
+
+SELECT '' AS three, f.f1, f.f1 * '-10' AS x FROM MONEY_TBL f
+   WHERE f.f1 > '0.0' ORDER BY 2;
+ three |           f1            |             x              
+-------+-------------------------+----------------------------
+       |               $1,004.30 |                -$10,043.00
+       | $123,456,789,012,345.67 | -$1,234,567,890,123,456.80
+(2 rows)
+
+SELECT '' AS three, f.f1, f.f1 + '-10' AS x FROM MONEY_TBL f
+   WHERE f.f1 > '0.0' ORDER BY 2;
+ three |           f1            |            x            
+-------+-------------------------+-------------------------
+       |               $1,004.30 |                 $994.30
+       | $123,456,789,012,345.67 | $123,456,789,012,335.67
+(2 rows)
+
+SELECT '' AS three, f.f1, f.f1 / '-10' AS x FROM MONEY_TBL f
+   WHERE f.f1 > '0.0' ORDER BY 2;
+ three |           f1            |            x            
+-------+-------------------------+-------------------------
+       |               $1,004.30 |                -$100.43
+       | $123,456,789,012,345.67 | -$12,345,678,901,234.57
+(2 rows)
+
+SELECT '' AS three, f.f1, f.f1 - '-10' AS x FROM MONEY_TBL f
+   WHERE f.f1 > '0.0' ORDER BY 2;
+ three |           f1            |            x            
+-------+-------------------------+-------------------------
+       |               $1,004.30 |               $1,014.30
+       | $123,456,789,012,345.67 | $123,456,789,012,355.67
+(2 rows)
+
+SELECT SUM(f.f1) AS x FROM MONEY_TBL f;
+            x            
+-------------------------
+ $123,456,789,013,315.13
+(1 row)
+
+-- test divide by zero
+SELECT '' AS bad, f.f1 / '0.0' from MONEY_TBL f;
+ERROR:  division by zero  (seg0 localhost:40000 pid=281608)
+SELECT '' AS five, * FROM MONEY_TBL ORDER BY 2;
+ five |           f1            
+------+-------------------------
+      |                 -$34.84
+      |                   $0.00
+      |               $1,004.30
+      | $123,456,789,012,345.67
+(4 rows)
+
+-- parquet table
+CREATE TABLE MONEY_TBL_P (f1 money) with (appendonly=true, orientation=parquet);
+INSERT INTO MONEY_TBL_P(f1) VALUES ('    0.0');
+INSERT INTO MONEY_TBL_P(f1) VALUES ('1004.30   ');
+INSERT INTO MONEY_TBL_P(f1) VALUES ('     -34.84    ');
+INSERT INTO MONEY_TBL_P(f1) VALUES ('123456789012345.67');
+SELECT f1 FROM MONEY_TBL_P f
+   ORDER BY f1;
+           f1            
+-------------------------
+                 -$34.84
+                   $0.00
+               $1,004.30
+ $123,456,789,012,345.67
+(4 rows)
+
+SELECT sum(f1) AS x, min(f1) as y, max(f1) as z FROM MONEY_TBL_P AS f;
+            x            |    y    |            z            
+-------------------------+---------+-------------------------
+ $123,456,789,013,315.13 | -$34.84 | $123,456,789,012,345.67
+(1 row)
+

--- a/src/test/regress/known_good_schedule
+++ b/src/test/regress/known_good_schedule
@@ -35,6 +35,7 @@ test: int8
 test: oid
 test: float4
 ignore: float8
+test: money
 ignore: bit
 ignore: numeric
 ignore: strings

--- a/src/test/regress/parallel_schedule
+++ b/src/test/regress/parallel_schedule
@@ -1,6 +1,6 @@
 # $PostgreSQL: pgsql/src/test/regress/serial_schedule,v 1.33 2006/08/30 23:34:22 tgl Exp $
 # This should probably be in an order similar to parallel_schedule.
-test: boolean char name varchar text int2 int4 int8 oid float4 float8 bit numeric
+test: boolean char name varchar text int2 int4 int8 oid float4 float8 money bit numeric
 
 test: strings
 test: numerology

--- a/src/test/regress/serial_schedule
+++ b/src/test/regress/serial_schedule
@@ -11,6 +11,7 @@ test: int8
 test: oid
 test: float4
 test: float8
+test: money
 test: bit
 test: numeric
 test: strings

--- a/src/test/regress/sql/money.sql
+++ b/src/test/regress/sql/money.sql
@@ -1,0 +1,68 @@
+--
+-- MONEY
+--
+
+CREATE TABLE MONEY_TBL (f1  money);
+
+INSERT INTO MONEY_TBL(f1) VALUES ('    0.0');
+INSERT INTO MONEY_TBL(f1) VALUES ('1004.30   ');
+INSERT INTO MONEY_TBL(f1) VALUES ('     -34.84    ');
+INSERT INTO MONEY_TBL(f1) VALUES ('123456789012345.67');
+
+-- test money over and under flow
+SELECT '12345678901234567890.12'::money = '-13639628150831692.60'::money as x;
+SELECT '123.001'::money = '123'::money as x;
+
+-- bad input
+INSERT INTO MONEY_TBL(f1) VALUES ('xyz');
+INSERT INTO MONEY_TBL(f1) VALUES ('5.0.0');
+INSERT INTO MONEY_TBL(f1) VALUES ('5 . 0');
+INSERT INTO MONEY_TBL(f1) VALUES ('5.   0');
+INSERT INTO MONEY_TBL(f1) VALUES ('123            5');
+
+-- queries
+SELECT '' AS five, * FROM MONEY_TBL ORDER BY 2;
+
+SELECT '' AS four, f.* FROM MONEY_TBL f WHERE f.f1 <> '1004.3' ORDER BY 2;
+
+SELECT '' AS one, f.* FROM MONEY_TBL f WHERE f.f1 = '1004.3' ORDER BY 2;
+
+SELECT '' AS three, f.* FROM MONEY_TBL f WHERE '1004.3' > f.f1 ORDER BY 2;
+
+SELECT '' AS three, f.* FROM MONEY_TBL f WHERE  f.f1 < '1004.3' ORDER BY 2;
+
+SELECT '' AS four, f.* FROM MONEY_TBL f WHERE '1004.3' >= f.f1 ORDER BY 2;
+
+SELECT '' AS four, f.* FROM MONEY_TBL f WHERE  f.f1 <= '1004.3' ORDER BY 2;
+
+SELECT '' AS three, f.f1, f.f1 * '-10' AS x FROM MONEY_TBL f
+   WHERE f.f1 > '0.0' ORDER BY 2;
+
+SELECT '' AS three, f.f1, f.f1 + '-10' AS x FROM MONEY_TBL f
+   WHERE f.f1 > '0.0' ORDER BY 2;
+
+SELECT '' AS three, f.f1, f.f1 / '-10' AS x FROM MONEY_TBL f
+   WHERE f.f1 > '0.0' ORDER BY 2;
+
+SELECT '' AS three, f.f1, f.f1 - '-10' AS x FROM MONEY_TBL f
+   WHERE f.f1 > '0.0' ORDER BY 2;
+
+SELECT SUM(f.f1) AS x FROM MONEY_TBL f;
+
+-- test divide by zero
+SELECT '' AS bad, f.f1 / '0.0' from MONEY_TBL f;
+
+SELECT '' AS five, * FROM MONEY_TBL ORDER BY 2;
+
+-- parquet table
+CREATE TABLE MONEY_TBL_P (f1 money) with (appendonly=true, orientation=parquet);
+
+INSERT INTO MONEY_TBL_P(f1) VALUES ('    0.0');
+INSERT INTO MONEY_TBL_P(f1) VALUES ('1004.30   ');
+INSERT INTO MONEY_TBL_P(f1) VALUES ('     -34.84    ');
+INSERT INTO MONEY_TBL_P(f1) VALUES ('123456789012345.67');
+
+SELECT f1 FROM MONEY_TBL_P f
+   ORDER BY f1;
+
+SELECT sum(f1) AS x, min(f1) as y, max(f1) as z FROM MONEY_TBL_P AS f;


### PR DESCRIPTION
This commit fixes the issue [HAWQ-19](https://issues.apache.org/jira/browse/HAWQ-19) "Money type overflow" by back porting commit [74a4019](https://github.com/postgres/postgres/commit/74a40190aabd27b052ea7a63e93f7ed47743755d#diff-7ddd78dd264f8cf2a62cf572baf90b84) to HAWQ. Changes internal representation of "money" datatype, input function, cash_words function, adds function to multiply/divide cash by int8. Also changes pg_type to accommodate new internal representation

Before this commit:
```
test=# select '$30000000'::money;
      money      
-----------------
 -$12,949,672.96
(1 row)
```
After this commit:
```
test=# select '$30000000'::money;
     money      
----------------
 $30,000,000.00
(1 row)
```