### PR TITLE
No need to use ksh and add an extra runtime dep

### DIFF
--- a/tools/bin/diskqual.ksh
+++ b/tools/bin/diskqual.ksh
@@ -1,4 +1,4 @@
-#!/bin/ksh
+#!/bin/bash
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file


### PR DESCRIPTION
Why a single file in the whole project will be using ksh without any ksh specific functionality it might need?
