### PR TITLE
HAWQ-412. Allocate query resource for multiple EXECUTIONs in explicit and implicit prepared statement

### DIFF
--- a/src/backend/cdb/cdbdatalocality.c
+++ b/src/backend/cdb/cdbdatalocality.c
@@ -4004,12 +4004,20 @@ calculate_planner_segment_num(Query *query, QueryResourceLife resourceLife,
 	/*
 	 * Initialize QueryResourceParameters in QD
 	 *
-	 * We use TopMemoryContext here so that the QueryResourceParameter
-	 * can be available in the session. Thus, it can be used in multiple
-	 * "EXECUTION"s of the prepared statement (i.e., "PREPARE", "BIND",
-	 * "EXECUTION"
+	 * We use CacheMemoryContext/TopMemoryContext here so that the
+	 * QueryResourceParameter can be available in the session. Thus,
+	 * it can be used in multiple "EXECUTION"s of the prepared
+	 * statement (i.e., "PREPARE", "BIND", "EXECUTION").
 	 */
-	MemoryContext oldcontext = MemoryContextSwitchTo(TopMemoryContext);
+	MemoryContext oldcontext = NULL;
+	if ( CacheMemoryContext != NULL )
+	{
+		oldcontext = MemoryContextSwitchTo(CacheMemoryContext);
+	}
+	else
+	{
+		oldcontext = MemoryContextSwitchTo(TopMemoryContext);
+	}
 	resource_parameters = (QueryResourceParameters *)palloc(sizeof(QueryResourceParameters));
 	MemoryContextSwitchTo(oldcontext);
 

--- a/src/backend/cdb/cdbdatalocality.c
+++ b/src/backend/cdb/cdbdatalocality.c
@@ -454,6 +454,33 @@ static Relation_File** change_file_order_based_on_continuity(
 
 static int64 set_maximum_segment_volumn_parameter(Relation_Data *rel_data,
 		int host_num, double* maxSizePerSegment);
+
+/*
+ * saveQueryResourceParameters: save QueryResourceParameters
+ * in prepare statement along with query plan so that the query
+ * resource can be re-allocated during multiple executions of
+ * the plan
+ */
+void saveQueryResourceParameters(
+		QueryResourceParameters	*resource_parameters,
+		QueryResourceLife       life,
+		int32                   slice_size,
+		int64_t                 iobytes,
+		int                     max_target_segment_num,
+		int                     min_target_segment_num,
+		HostnameVolumnInfo      *vol_info,
+		int                     vol_info_size)
+
+{
+	resource_parameters->life = life;
+	resource_parameters->slice_size = slice_size;
+	resource_parameters->iobytes = iobytes;
+	resource_parameters->max_target_segment_num = max_target_segment_num;
+	resource_parameters->min_target_segment_num = min_target_segment_num;
+	resource_parameters->vol_info = vol_info;
+	resource_parameters->vol_info_size = vol_info_size;
+}
+
 /*
  * Setup /cleanup the memory context for this run
  * of data locality algorithm.
@@ -1892,7 +1919,7 @@ search_map_node(List *result, Oid rel_oid, int host_num,
 
 static List *
 post_process_assign_result(Split_Assignment_Result *assign_result) {
-	List *final_result = NULL;
+	List *final_result = NIL;
 	int i;
 
 	for (i = 0; i < assign_result->host_num; i++) {
@@ -3934,16 +3961,22 @@ static void cleanup_allocation_algorithm(
 SplitAllocResult *
 calculate_planner_segment_num(Query *query, QueryResourceLife resourceLife,
 		List *fullRangeTable, GpPolicy *intoPolicy, int sliceNum) {
-	SplitAllocResult *result;
+	SplitAllocResult *result = NULL;
 	QueryResource *resource = NULL;
-	List *virtual_segments;
-	List *alloc_result;
+	QueryResourceParameters *resource_parameters = NULL;
+
+	List *virtual_segments = NIL;
+	List *alloc_result = NIL;
 	split_to_segment_mapping_context context;
 
 	int planner_segments = -1; /*virtual segments number for explain statement */
 
 	result = (SplitAllocResult *) palloc(sizeof(SplitAllocResult));
+	result->resource = NULL;
+	result->resource_parameters = NULL;
+	result->alloc_results = NIL;
 	result->relsType = NIL;
+	result->planner_segments = -1;
 	result->datalocalityInfo = makeStringInfo();
 
 	/* fake data locality */
@@ -3955,8 +3988,9 @@ calculate_planner_segment_num(Query *query, QueryResourceLife resourceLife,
 		}
 	}
 
-	if ((Gp_role != GP_ROLE_DISPATCH)) {
+	if (Gp_role != GP_ROLE_DISPATCH) {
 		result->resource = NULL;
+		result->resource_parameters = NULL;
 		result->alloc_results = NIL;
 		result->relsType = NIL;
 		result->planner_segments = -1;
@@ -3966,6 +4000,18 @@ calculate_planner_segment_num(Query *query, QueryResourceLife resourceLife,
 	init_datalocality_memory_context();
 
 	init_datalocality_context(&context);
+
+	/*
+	 * Initialize QueryResourceParameters in QD
+	 *
+	 * We use TopMemoryContext here so that the QueryResourceParameter
+	 * can be available in the session. Thus, it can be used in multiple
+	 * "EXECUTION"s of the prepared statement (i.e., "PREPARE", "BIND",
+	 * "EXECUTION"
+	 */
+	MemoryContext oldcontext = MemoryContextSwitchTo(TopMemoryContext);
+	resource_parameters = (QueryResourceParameters *)palloc(sizeof(QueryResourceParameters));
+	MemoryContextSwitchTo(oldcontext);
 
 	collect_range_tables(query, fullRangeTable, &(context.rtc_context));
 
@@ -4007,6 +4053,18 @@ calculate_planner_segment_num(Query *query, QueryResourceLife resourceLife,
 	/*use inherit resource*/
 	if (resourceLife == QRL_INHERIT) {
 		resource = AllocateResource(resourceLife, sliceNum, 0, 0, 0, NULL, 0);
+
+		saveQueryResourceParameters(
+		        resource_parameters,  /* resource_parameters */
+		        resourceLife,         /* life */
+		        sliceNum,             /* slice_size */
+		        0,                    /* iobytes */
+		        0,                    /* max_target_segment_num */
+		        0,                    /* min_target_segment_num */
+		        NULL,                 /* vol_info */
+		        0                     /* vol_info_size */ 
+		        );
+
 		if (resource != NULL) {
 			if ((context.keep_hash)
 					&& (list_length(resource->segments) != context.hashSegNum)) {
@@ -4155,6 +4213,18 @@ calculate_planner_segment_num(Query *query, QueryResourceLife resourceLife,
 			resource = AllocateResource(QRL_ONCE, sliceNum, queryCost,
 					maxTargetSegmentNumber, minTargetSegmentNumber,
 					context.host_context.hostnameVolInfos, context.host_context.size);
+
+			saveQueryResourceParameters(
+			        resource_parameters,                   /* resource_parameters */
+			        QRL_ONCE,                              /* life */
+			        sliceNum,                              /* slice_size */
+			        queryCost,                             /* iobytes */
+			        maxTargetSegmentNumber,                /* max_target_segment_num */
+			        minTargetSegmentNumber,                /* min_target_segment_num */
+			        context.host_context.hostnameVolInfos, /* vol_info */
+			        context.host_context.size              /* vol_info_size */
+			        );
+			
 		}
 		/* for explain statement, we doesn't allocate resource physically*/
 		else {
@@ -4172,7 +4242,9 @@ calculate_planner_segment_num(Query *query, QueryResourceLife resourceLife,
 
 		if (resource == NULL) {
 			result->resource = NULL;
+			result->resource_parameters = NULL;
 			result->alloc_results = NIL;
+			result->relsType = NIL;
 			result->planner_segments = planner_segments;
 			return result;
 		}
@@ -4209,6 +4281,7 @@ calculate_planner_segment_num(Query *query, QueryResourceLife resourceLife,
 	alloc_result = run_allocation_algorithm(result, virtual_segments, &resource, &context);
 
 	result->resource = resource;
+	result->resource_parameters = resource_parameters;
 	result->alloc_results = alloc_result;
 	result->planner_segments = list_length(resource->segments);
 

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -216,7 +216,13 @@ _copyPlannedStmt(PlannedStmt *from)
 	COPY_SCALAR_FIELD(backoff_weight);
 	COPY_SCALAR_FIELD(query_mem);
 
-	COPY_SCALAR_FIELD(resource); // ?? What does this mean?
+	/*
+	 * A shallow copy of PlannedStmt that only copies the
+	 * reference of query resource and its parameters
+	 */
+	COPY_SCALAR_FIELD(resource);
+	COPY_SCALAR_FIELD(resource_parameters);
+
 	COPY_SCALAR_FIELD(planner_segments);
 
 	return newnode;

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -285,12 +285,12 @@ planner(Query *parse, int cursorOptions,
 	PlannedStmt *result = NULL;
 	instr_time	starttime, endtime;
 	ResourceNegotiatorResult *ppResult = (ResourceNegotiatorResult *) palloc(sizeof(ResourceNegotiatorResult));
-  SplitAllocResult initResult={NULL, NULL, -1};
-  ppResult->saResult = initResult;
-  ppResult->stmt =NULL;
+	SplitAllocResult initResult = {NULL, NULL, NIL, -1, NIL, NULL};
+	ppResult->saResult = initResult;
+	ppResult->stmt = NULL;
 	static int plannerLevel = 0;
 	bool resourceNegotiateDone = false;
-	QueryResource *savedQueryResource = GetActiveQueryResource();;
+	QueryResource *savedQueryResource = GetActiveQueryResource();
 	SetActiveRelType(NIL);
 
 	bool isDispatchParallel = false;
@@ -455,6 +455,7 @@ planner(Query *parse, int cursorOptions,
 		SetActiveQueryResource(savedQueryResource);
 
 		result->resource = ppResult->saResult.resource;
+		result->resource_parameters = ppResult->saResult.resource_parameters;
 		result->scantable_splits = ppResult->saResult.alloc_results;
 		result->planner_segments = ppResult->saResult.planner_segments;
 		result->datalocalityInfo = ppResult->saResult.datalocalityInfo;

--- a/src/include/cdb/cdbdatalocality.h
+++ b/src/include/cdb/cdbdatalocality.h
@@ -41,6 +41,7 @@
 typedef struct SplitAllocResult
 {
   QueryResource *resource;
+  QueryResourceParameters *resource_parameters;
   List *alloc_results;
   int planner_segments;
   List *relsType;// relation type after datalocality changing
@@ -63,6 +64,22 @@ typedef struct VirtualSegmentNode
 	NodeTag type;
 	char *hostname;
 } VirtualSegmentNode;
+
+/*
+ * saveQueryResourceParameters: save QueryResourceParameters
+ * in prepare statement along with query plan so that the query
+ * resource can be re-allocated during multiple executions of
+ * the plan
+ */
+void saveQueryResourceParameters(
+		QueryResourceParameters	*resource_parameters,
+		QueryResourceLife       life,
+		int32                   slice_size,
+		int64_t                 iobytes,
+		int                     max_target_segment_num,
+		int                     min_target_segment_num,
+		HostnameVolumnInfo      *vol_info,
+		int                     vol_info_size);
 
 /*
  * calculate_planner_segment_num: based on the parse tree,

--- a/src/include/executor/execdesc.h
+++ b/src/include/executor/execdesc.h
@@ -77,6 +77,20 @@ typedef struct HostnameVolumnInfo
 	int64 datavolumn;
 } HostnameVolumnInfo;
 
+/*
+ * structure for query resource parameters
+ */
+typedef struct QueryResourceParameters
+{
+	QueryResourceLife  life;
+	int32              slice_size;
+	int64_t            iobytes;
+	int                max_target_segment_num;
+	int                min_target_segment_num;
+	HostnameVolumnInfo *vol_info;
+	int                vol_info_size;
+} QueryResourceParameters;
+
 /* ----------------
  *		query descriptor:
  *

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -197,6 +197,7 @@ typedef struct PlannedStmt
 		QueryContextInfo * contextdisp; /* query context for dispatching */
 
 		struct QueryResource *resource;
+		struct QueryResourceParameters *resource_parameters;
 		int	planner_segments;
 
     /* The overall memory consumption account (i.e., outside of an operator) */


### PR DESCRIPTION
The resolution is to:
1. during planning phase, store the parameters that were used to allocate the query resource along with query resource itself in planned statement
2. in multiple EXECUTIONs, use the stored parameters to allocate query resource in the runtime

The query resource parameter includes:
1. Query resource life (i.e., QRL_ONCE, QRL_INHERIT)
2. Slice number
3. Query cost (i.e., iobytes)
4. Maximum target segment number
5. Minimum target segment number
6. Hostname volume information
7. Hostname volume information size