### PR TITLE
HAWQ-413. Create_table_distribution sporadically fails.

### DIFF
--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -4502,7 +4502,7 @@ static struct config_int ConfigureNamesInt[] =
 			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&default_segment_num,
-		2, 1, INT_MAX, NULL, NULL
+		8, 1, INT_MAX, NULL, NULL
 	},
 	{
 		{"enforce_virtual_segment_number", PGC_USERSET, QUERY_TUNING_OTHER,


### PR DESCRIPTION
"create_table_distribution test in installcheck-good fails sporadically.
I was running it on my Mac with one segment - sometimes it fails and sometimes not."

The way I fix it is to change default_segment_num to 8. The recommend value of default_segment_num is 8* host_number