### PR TITLE
HAWQ-407. Fix memory leak in parquet metadata processing for reading table with data

### DIFF
--- a/src/backend/access/parquet/parquetam.c
+++ b/src/backend/access/parquet/parquetam.c
@@ -583,10 +583,6 @@ ParquetInsertDesc parquet_insert_init(Relation rel, ResultRelSegFileInfo *segfil
 	parquetInsertDesc->aoEntry = aoentry;
 	parquetInsertDesc->insertCount = 0;
 
-//	parquetInsertDesc->parquetMetadata = (struct ParquetMetadata_4C *)
-//			palloc0(sizeof(struct ParquetMetadata_4C));
-	/*SHOULD CALL OPEN METADATA FILE HERE, AND GET parquetMetadata INFO*/
-
 	initStringInfo(&titleBuf);
 	appendStringInfo(&titleBuf, "Write of Parquet relation '%s'",
 			RelationGetRelationName(parquetInsertDesc->parquet_rel));

--- a/src/backend/access/parquet/parquetam.c
+++ b/src/backend/access/parquet/parquetam.c
@@ -583,8 +583,8 @@ ParquetInsertDesc parquet_insert_init(Relation rel, ResultRelSegFileInfo *segfil
 	parquetInsertDesc->aoEntry = aoentry;
 	parquetInsertDesc->insertCount = 0;
 
-	parquetInsertDesc->parquetMetadata = (struct ParquetMetadata_4C *)
-			palloc0(sizeof(struct ParquetMetadata_4C));
+//	parquetInsertDesc->parquetMetadata = (struct ParquetMetadata_4C *)
+//			palloc0(sizeof(struct ParquetMetadata_4C));
 	/*SHOULD CALL OPEN METADATA FILE HERE, AND GET parquetMetadata INFO*/
 
 	initStringInfo(&titleBuf);

--- a/src/backend/cdb/cdbparquetfooterprocessor.c
+++ b/src/backend/cdb/cdbparquetfooterprocessor.c
@@ -111,6 +111,9 @@ bool readParquetFooter(File fileHandler, ParquetMetadata *parquetMetadata,
 
 	DetectHostEndian();
 
+  *parquetMetadata = (struct ParquetMetadata_4C *)
+      palloc0(sizeof(struct ParquetMetadata_4C));
+
 	/* if file size is 0, means there's no data in file, return false*/
 	if (eof == 0)
 		return false;

--- a/src/backend/cdb/cdbparquetfooterserializer.c
+++ b/src/backend/cdb/cdbparquetfooterserializer.c
@@ -167,9 +167,6 @@ void initDeserializeFooter(
 
 	initCompactProtocol(*footerProtocol, file, fileName, footerLength, PARQUET_FOOTER_BUFFERMODE_READ);
 
-//	*parquetMetadata =
-//			(struct ParquetMetadata_4C*) palloc0(sizeof(struct ParquetMetadata_4C));
-
 	readParquetFileMetadata(parquetMetadata, *footerProtocol);
 }
 

--- a/src/backend/cdb/cdbparquetfooterserializer.c
+++ b/src/backend/cdb/cdbparquetfooterserializer.c
@@ -167,8 +167,8 @@ void initDeserializeFooter(
 
 	initCompactProtocol(*footerProtocol, file, fileName, footerLength, PARQUET_FOOTER_BUFFERMODE_READ);
 
-	*parquetMetadata =
-			(struct ParquetMetadata_4C*) palloc0(sizeof(struct ParquetMetadata_4C));
+//	*parquetMetadata =
+//			(struct ParquetMetadata_4C*) palloc0(sizeof(struct ParquetMetadata_4C));
 
 	readParquetFileMetadata(parquetMetadata, *footerProtocol);
 }


### PR DESCRIPTION
Move the parquetMeta struct construction from two callers to one place, and avoid memory leak.