### PR TITLE
HAWQ-419. Failed to MemoryAccounting_SaveToLog in resource negotiator.

### DIFF
--- a/src/backend/utils/mmgr/memaccounting.c
+++ b/src/backend/utils/mmgr/memaccounting.c
@@ -420,7 +420,10 @@ MemoryAccounting_GetAccountName(MemoryAccount *memoryAccount)
 			return "X_BitmapTableScan";
 		case MEMORY_OWNER_TYPE_Exec_PartitionSelector:
 			return "X_PartitionSelector";
+		case MEMORY_OWNER_TYPE_Resource_Negotiator:
+			return "X_ResourceNegotiator";
 		default:
+			elog(LOG,"missing account ownerType number is %d",memoryAccount->ownerType);
 			Assert(false);
 			break;
 	}


### PR DESCRIPTION
add MEMORY_OWNER_TYPE_Resource_Negotiator in MemoryAccounting_GetAccountName()