### PR TITLE
HAWQ-426. Fix memory leak for query and prepared statement due to introduction of query resource parameters

### DIFF
--- a/src/backend/cdb/cdbdatalocality.c
+++ b/src/backend/cdb/cdbdatalocality.c
@@ -4005,25 +4005,7 @@ calculate_planner_segment_num(Query *query, QueryResourceLife resourceLife,
 
 		init_datalocality_context(&context);
 
-		/*
-		 * Initialize QueryResourceParameters in QD
-		 *
-		 * We use CacheMemoryContext/TopMemoryContext here so that the
-		 * QueryResourceParameter can be available in the session. Thus,
-		 * it can be used in multiple "EXECUTION"s of the prepared
-		 * statement (i.e., "PREPARE", "BIND", "EXECUTION").
-		 */
-		MemoryContext oldcontext = NULL;
-		if ( CacheMemoryContext != NULL )
-		{
-			oldcontext = MemoryContextSwitchTo(CacheMemoryContext);
-		}
-		else
-		{
-			oldcontext = MemoryContextSwitchTo(TopMemoryContext);
-		}
-		resource_parameters = (QueryResourceParameters *)palloc(sizeof(QueryResourceParameters));
-		MemoryContextSwitchTo(oldcontext);
+		resource_parameters = makeNode(QueryResourceParameters);
 
 		collect_range_tables(query, fullRangeTable, &(context.rtc_context));
 

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -52,6 +52,7 @@
 #include "cdb/cdbgang.h"
 #include "cdb/cdbdatalocality.h"
 #include "nodes/nodeFuncs.h"
+#include "executor/execdesc.h"
 
 /*
  * Macros to simplify copying of different kinds of fields.  Use these
@@ -168,6 +169,32 @@ CopyLogicalIndexInfo(const LogicalIndexInfo *from, LogicalIndexInfo *newnode)
 }
 
 /*
+ * _copyQueryResourceParameters
+ */
+static QueryResourceParameters *
+_copyQueryResourceParameters(QueryResourceParameters *from)
+{
+	QueryResourceParameters *newnode = makeNode(QueryResourceParameters);
+
+	COPY_SCALAR_FIELD(life);
+	COPY_SCALAR_FIELD(slice_size);
+	COPY_SCALAR_FIELD(iobytes);
+	COPY_SCALAR_FIELD(max_target_segment_num);
+	COPY_SCALAR_FIELD(min_target_segment_num);
+	if (from->vol_info_size > 0)
+	{
+		COPY_POINTER_FIELD(vol_info, sizeof(HostnameVolumnInfo) * (from->vol_info_size));
+	}
+	else
+	{
+		newnode->vol_info = NULL;
+	}
+	COPY_SCALAR_FIELD(vol_info_size);
+
+	return newnode;
+}
+
+/*
  * _copyPlannedStmt 
  */
 static PlannedStmt *
@@ -217,11 +244,27 @@ _copyPlannedStmt(PlannedStmt *from)
 	COPY_SCALAR_FIELD(query_mem);
 
 	/*
-	 * A shallow copy of PlannedStmt that only copies the
-	 * reference of query resource and its parameters
+	 * Query resource is allocated every time a query/plan is
+	 * executed. So, here we only do a shallow copy of query
+	 * resource in planned statement.
 	 */
 	COPY_SCALAR_FIELD(resource);
-	COPY_SCALAR_FIELD(resource_parameters);
+	/*
+	 * A (prepared) plan might be executed multiple times. To
+	 * prevent memory leakage, here we do a deep copy of query
+	 * resource parameters so that its lifetime is exactly the
+	 * same as planned statement. Thus, we can re-allocate query
+	 * resource for each of the multiple executions of the (prepared)
+	 * plan.
+	 */
+	if (from->resource_parameters)
+	{
+		newnode->resource_parameters = _copyQueryResourceParameters(from->resource_parameters);
+	}
+	else
+	{
+		newnode->resource_parameters = NULL;
+	}
 
 	COPY_SCALAR_FIELD(planner_segments);
 
@@ -5166,6 +5209,10 @@ copyObject(void *from)
 			break;
 		case T_DenyLoginPoint:
 			retval = _copyDenyLoginPoint(from);
+			break;
+
+		case T_QueryResourceParameters:
+			retval = _copyQueryResourceParameters(from);
 			break;
 
 		case T_CaQLSelect:

--- a/src/include/executor/execdesc.h
+++ b/src/include/executor/execdesc.h
@@ -82,6 +82,8 @@ typedef struct HostnameVolumnInfo
  */
 typedef struct QueryResourceParameters
 {
+	NodeTag            type;
+
 	QueryResourceLife  life;
 	int32              slice_size;
 	int64_t            iobytes;

--- a/src/include/nodes/nodes.h
+++ b/src/include/nodes/nodes.h
@@ -515,19 +515,20 @@ typedef enum NodeTag
 	T_FileSystemFunctionData,   /* in storage/filesystem.h */
 	T_PartitionConstraints,     /* in executor/nodePartitionSelector.h */
 	T_SelectedParts,            /* in executor/nodePartitionSelector.h */
-	
-    	/* CDB: tags for random other stuff */
-    	T_CdbExplain_StatHdr = 950,             /* in cdb/cdbexplain.c */
 
-    	/* gpsql: tags for query context dispatching */
-    	T_QueryContextInfo = 1000,
+	/* CDB: tags for random other stuff */
+	T_CdbExplain_StatHdr = 950,             /* in cdb/cdbexplain.c */
 
-    	/* tags for describing the query resource should occupied in segment*/
-    	T_QueryResource = 1050,
+	/* gpsql: tags for query context dispatching */
+	T_QueryContextInfo = 1000,
 
-    	/*
-    	 * TAGS FOR CAQL PARSER
-     	*/
+	/* tags for describing the query resource should occupied in segment*/
+	T_QueryResource = 1050,
+	T_QueryResourceParameters,
+
+	/*
+	 * TAGS FOR CAQL PARSER
+	 */
 	T_CaQLSelect = 2000,
 	T_CaQLInsert,
 	T_CaQLDelete,


### PR DESCRIPTION
The query resource parameters is kept in planned statement. So, the resolution is to make query resource parameters using the same memory context as planned statement. Thus, they can be freed at the same time.

From implementation standpoint, we do a deep copy of query resource parameters in copy function of plannedstmt so that they use the same memory context.