### PR TITLE
HAWQ-427. Fix bug of wrong results in mdqa+rollup.

### DIFF
--- a/src/backend/optimizer/util/tlist.c
+++ b/src/backend/optimizer/util/tlist.c
@@ -323,6 +323,14 @@ get_sortgrouplist_exprs(List *sortClauses, List *targetList)
 		 */
 		if (sortcl == NULL) continue;
 
+		/*
+		 * tleSortGroupRef in SortClause and ressortgroupref in TargetEntry
+		 * may be zero at the sametime, which means no reference by
+		 * sort/group clause. Should avoid calling get_sortgroupclause_expr
+		 * in this situation.
+		 */
+		if (sortcl->tleSortGroupRef == 0) continue;
+
 		sortexpr = get_sortgroupclause_expr(sortcl, targetList);
 		result = lappend(result, sortexpr);
 	}


### PR DESCRIPTION
In mdqa join motion, dqa agg TargetEntry appears as the Hash Key of Redistribute Motion for HashJoin, which is wrong. The wrong plan is simplified as below:
```
->  Hash Join 
    Hash Cond: NOT dqa_coplan_1.vn IS DISTINCT FROM dqa_coplan_2.vn
    ->  Redistribute Motion 2:2
       Hash Key: dqa_coplan_1.vn,  dqa_coplan_1.max
    ->  Hash  
       ->  Redistribute Motion 2:2
            Hash Key: dqa_coplan_2.vn, dqa_coplan_2.max
```
Here dqa_coplan_1.max and dqa_coplan_2.max should not be the key.

Root cause is that tleSortGroupRef in SortClause for Rollup is zero, while ressortgroupref in TargetEntry for dqa agg is also zero. In get_sortgrouplist_exprs, we tried to build the referenced targetlist for SortGroupClause. However we don't consider they are both zero when checking if tleSortGroupRef equals to ressortgroupref. 