### PR TITLE
HAWQ-425. Add default value for hawq_rm_memory_limit_perseg and hawq_…

### DIFF
--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -6868,7 +6868,7 @@ static struct config_real ConfigureNamesReal[] =
 			NULL
 		},
 		&rm_seg_core_use,
-		1.0, 1.0, INT_MAX, NULL, NULL
+		16.0, 1.0, INT_MAX, NULL, NULL
 	},
 
 	{
@@ -8087,7 +8087,7 @@ static struct config_string ConfigureNamesString[] =
 			NULL
 		},
 		&rm_seg_memory_use,
-		"", NULL, NULL
+		"64GB", NULL, NULL
 	},
 
     {


### PR DESCRIPTION
Add default value for hawq_rm_memory_limit_perseg and hawq_rm_nvcore_limit_perseg, so that, segment can start without these two properties configured in yarn mode. If in NONE mode, these two properties should be configured in hawq-site.xml to overwrite the default value.