### PR TITLE
HAWQ-428. ORDER/GROUP BY not found in target list error found in olap…

### DIFF
--- a/src/backend/cdb/cdbmetadatacache_process.c
+++ b/src/backend/cdb/cdbmetadatacache_process.c
@@ -392,6 +392,7 @@ GenerateMetadataCacheRefreshList()
             MetadataCacheRefreshList = lappend(MetadataCacheRefreshList, refresh_info);
             if (list_length(MetadataCacheRefreshList) >= metadata_cache_refresh_max_num)
             {
+                hash_seq_term(&hstat);
                 break;
             }
         }

--- a/src/backend/optimizer/plan/plangroupext.c
+++ b/src/backend/optimizer/plan/plangroupext.c
@@ -1867,7 +1867,12 @@ convert_gs_to_rollups(AttrNumber *grpColIdx,
 		 * resno.
 		 */
 		sc.tleSortGroupRef = no+1;
-		tle = get_sortgroupclause_tle(&sc, tlist);
+		tle = get_sortgroupclause_tle_internal(&sc, tlist);
+        if (NULL == tle) 
+        {
+            continue;
+        }
+
 		foreach (sub_lc, sub_tlist)
 		{
 			TargetEntry *sub_tle = (TargetEntry *)lfirst(sub_lc);

--- a/src/backend/optimizer/plan/plangroupext.c
+++ b/src/backend/optimizer/plan/plangroupext.c
@@ -1868,10 +1868,10 @@ convert_gs_to_rollups(AttrNumber *grpColIdx,
 		 */
 		sc.tleSortGroupRef = no+1;
 		tle = get_sortgroupclause_tle_internal(&sc, tlist);
-        if (NULL == tle) 
-        {
-            continue;
-        }
+        	if (NULL == tle) 
+        	{
+            		continue;
+        	}
 
 		foreach (sub_lc, sub_tlist)
 		{

--- a/src/backend/optimizer/util/tlist.c
+++ b/src/backend/optimizer/util/tlist.c
@@ -209,6 +209,18 @@ TargetEntry *
 get_sortgroupclause_tle(SortClause *sortClause,
 						List *targetList)
 {
+    TargetEntry *ret = get_sortgroupclause_tle_internal(sortClause, targetList);
+    if (NULL == ret) {
+	    elog(ERROR, "ORDER/GROUP BY expression not found in targetlist");
+    }
+	
+	return NULL;				/* keep compiler quiet */
+}
+
+TargetEntry *
+get_sortgroupclause_tle_internal(SortClause *sortClause,
+						List *targetList)
+{
 	Index		refnumber = sortClause->tleSortGroupRef;
 	ListCell   *l;
 
@@ -220,9 +232,9 @@ get_sortgroupclause_tle(SortClause *sortClause,
 			return tle;
 	}
 
-	elog(ERROR, "ORDER/GROUP BY expression not found in targetlist");
 	return NULL;				/* keep compiler quiet */
 }
+
 
 /*
  * get_sortgroupclauses_tles

--- a/src/include/optimizer/tlist.h
+++ b/src/include/optimizer/tlist.h
@@ -46,6 +46,8 @@ extern TargetEntry *tlist_member_ignoring_RelabelType(Expr *expr, List *targetli
 extern List *flatten_tlist(List *tlist);
 extern List *add_to_flat_tlist(List *tlist, List *vars, bool resjunk);
 
+extern TargetEntry *get_sortgroupclause_tle_internal(SortClause *sortClause,
+						List *targetList);
 extern TargetEntry *get_sortgroupclause_tle(SortClause *sortClause,
 						List *targetList);
 extern Node *get_sortgroupclause_expr(SortClause *sortClause,


### PR DESCRIPTION
ignore error if fail in get_sortgroupclause_tle function  when check targetentry in rollup. Because rollup clause only need groupkeys.