### PR TITLE
HAWQ-430. HAWQ resource manager prunes those registered segments having different memory to core ratio

### DIFF
--- a/src/backend/resourcemanager/include/envswitch.h
+++ b/src/backend/resourcemanager/include/envswitch.h
@@ -85,4 +85,9 @@
 #include "utils/memutilities.h"	/* Memory context and manipulation wrapper   */
 
 #define RMLOG rm_log_level
+
+#ifndef UINT32_MAX
+#define UINT32_MAX             (4294967295U)
+#endif
+
 #endif //ENVIRONMENT_SWITCH_H

--- a/src/backend/resourcemanager/include/resourcepool.h
+++ b/src/backend/resourcemanager/include/resourcepool.h
@@ -435,9 +435,8 @@ struct ResourcePoolData {
 	 */
 	HASHTABLEData	GRMHostNameIndexed;
 
-	/* The cluster level memory/core ratio. */
-	uint32_t		MemCoreRatio;
-	uint32_t		MemCoreRatioMajorityCounter;
+	/* The fixed cluster level memory to core ratio. */
+	uint32_t		ClusterMemoryCoreRatio;
 
 	/*
 	 * GRM Container life-cycle management.
@@ -655,6 +654,14 @@ int getClusterGRMContainerSize(void);
 void refreshAvailableNodeCount(void);
 
 void checkSlavesFile(void);
+
+void fixClusterMemoryCoreRatio(void);
+void adjustSegmentCapacity(SegResource segres);
+void adjustSegmentStatFTSCapacity(SegStat segstat);
+void adjustSegmentStatGRMCapacity(SegStat segstat);
+void adjustSegmentCapacityForNone(SegResource segres);
+void adjustSegmentCapacityForGRM(SegResource segres);
+void adjustMemoryCoreValue(uint32_t *memorymb, uint32_t *core);
 
 /*
  *------------------------------------------------------------------------------

--- a/src/backend/resourcemanager/requesthandler.c
+++ b/src/backend/resourcemanager/requesthandler.c
@@ -344,6 +344,17 @@ bool handleRMRequestAcquireResource(void **arg)
 		return false;
 	}
 
+	/*
+	 * If resource queue has no concrete capacity set yet, no need to handle
+	 * the request.
+	 */
+	if ( PQUEMGR->RootTrack->QueueInfo->ClusterMemoryMB <= 0 )
+	{
+		elog(DEBUG3, "Resource manager defers the resource request because the "
+					 "resource queues have no valid resource capacities yet.");
+		return false;
+	}
+
 	RPCRequestHeadAcquireResourceFromRM request =
 		SMBUFF_HEAD(RPCRequestHeadAcquireResourceFromRM,
 					&((*conntrack)->MessageBuff));

--- a/src/backend/resourcemanager/requesthandler_ddl.c
+++ b/src/backend/resourcemanager/requesthandler_ddl.c
@@ -429,7 +429,10 @@ bool handleRMDDLRequestManipulateResourceQueue(void **arg)
 			 * Refresh actual capacity of the resource queue, the change is
 			 * expected to be updated in the shadow instances.
 			 */
-			refreshResourceQueuePercentageCapacity(true);
+			if ( PRESPOOL->ClusterMemoryCoreRatio > 0 )
+			{
+				refreshResourceQueuePercentageCapacity(true);
+			}
 
 			/*------------------------------------------------------------------
 			 * Till now, we expect the input for altering a resource queue is

--- a/src/backend/resourcemanager/resourcemanager.c
+++ b/src/backend/resourcemanager/resourcemanager.c
@@ -497,6 +497,9 @@ int ResManagerMainServer2ndPhase(void)
 
 	elog(DEBUG5, "HAWQ RM :: passed loading queue and user definition.");
 
+	/* Check slaves file firstly to ensure we have expected cluster size. */
+	checkSlavesFile();
+
 	if ( rm_resourcepool_test_filename != NULL &&
 		 rm_resourcepool_test_filename[0] != '\0' ) {
 		loadHostInformationIntoResourcePool();
@@ -504,9 +507,6 @@ int ResManagerMainServer2ndPhase(void)
 
 	/******* TILL NOW, resource manager starts providing services *******/
 	elog(LOG, "HAWQ RM process works now.");
-
-	/* Check slaves file firstly to ensure we have expected cluster size. */
-	checkSlavesFile();
 
     /* Start request handler to provide services. */
     res = MainHandlerLoop();


### PR DESCRIPTION

1) When there are different ratio machines registered, HAWQ resource manager will choose a ratio having least memory wast as cluster level memory to core ratio;
2) All registered segments having different ratios will be pruned to ensure each segment in HAWQ cluster has the same resource memory to core ratio.