### PR TITLE
HAWQ-442. Fix bug that wrong results in rollup which contains the same expr targetlist.

### DIFF
--- a/src/backend/optimizer/util/tlist.c
+++ b/src/backend/optimizer/util/tlist.c
@@ -77,6 +77,27 @@ tlist_member(Node *node, List *targetlist)
 }
 
 /*
+ * tlist_member_with_ressortgroupref
+ *    Compared with tlist_member, there is an additional check on ressortgroupref
+ */
+TargetEntry *
+tlist_member_with_ressortgroupref(Node *node, List *targetlist, int ressortgroupref) {
+	ListCell   *temp;
+
+	foreach(temp, targetlist)
+	{
+		TargetEntry *tlentry = (TargetEntry *) lfirst(temp);
+
+		Assert(IsA(tlentry, TargetEntry));
+
+		if (equal(node, tlentry->expr) && (ressortgroupref == 0 ||
+										   ressortgroupref == tlentry->ressortgroupref) )
+			return tlentry;
+	}
+	return NULL;
+}
+
+/*
  * tlist_members
  *	  Finds all members of the given tlist whose expression is
  *	  equal() to the given expression.	Result is NIL if no such member.

--- a/src/include/optimizer/tlist.h
+++ b/src/include/optimizer/tlist.h
@@ -38,6 +38,10 @@
 // return the first target entries that match the node expression
 extern TargetEntry *tlist_member(Node *node, List *targetlist);
 
+// return the TargetEntry that match both the node expression and ressortgroupref
+extern TargetEntry *tlist_member_with_ressortgroupref(Node *node, List *targetlist,
+													  int ressortgroupref);
+
 // return a list a target entries that match the node expression
 extern List *tlist_members(Node *node, List *targetlist);
 


### PR DESCRIPTION
Reproduce steps:
```
create table sale
(
    cn int not null,
    vn int not null,
    pn int not null,
    dt date not null,
    qty int not null,
    prc float not null
) WITH (appendonly=true, orientation = parquet) distributed by (cn,vn,pn);

insert into sale values
( 2, 40, 100, '1401-1-1', 1100, 2400);

taoz=# explain SELECT sale.qty as newalias1,sale.qty as newalias2 FROM sale GROUP BY ROLLUP(newalias2,newalias1);
                                                                   QUERY PLAN
------------------------------------------------------------------------------------------------------------------------------------------------
 Gather Motion 8:1  (slice2; segments: 8)  (cost=1.06..1.09 rows=3 width=8)
   ->  HashAggregate  (cost=1.06..1.09 rows=1 width=8)
         Group By: partial_aggregation.newalias1, partial_aggregation.newalias1, partial_aggregation."grouping", partial_aggregation."group_id"
         ->  Subquery Scan partial_aggregation  (cost=1.02..1.06 rows=0 width=20)
               ->  Redistribute Motion 8:8  (slice1; segments: 8)  (cost=1.02..1.06 rows=0 width=20)
                     Hash Key: "rollup".newalias1, "rollup".newalias1
                     ->  GroupAggregate  (cost=1.02..1.06 rows=0 width=20)
                           Group By: "rollup"."grouping", "rollup"."group_id"
                           ->  Subquery Scan "rollup"  (cost=1.02..1.06 rows=0 width=20)
                                 ->  GroupAggregate  (cost=1.02..1.06 rows=0 width=20)
                                       Group By: "rollup".newalias1, "rollup"."grouping", "rollup"."group_id"
                                       ->  Subquery Scan "rollup"  (cost=1.02..1.05 rows=1 width=20)
                                             ->  GroupAggregate  (cost=1.02..1.04 rows=1 width=20)
                                                   Group By: sale.qty, sale.qty
                                                   ->  Sort  (cost=1.02..1.02 rows=1 width=4)
                                                         Sort Key: sale.qty, sale.qty
                                                         ->  Parquet table Scan on sale  (cost=0.00..1.01 rows=1 width=4)
 Settings:  optimizer=off
 Optimizer status: legacy query optimizer
(19 rows)
```
Wrongly used the name newalias1 and newalias2