### PR TITLE
HAWQ-445. Support large strings (up to a GB) in text_to_array()

### DIFF
--- a/src/backend/utils/adt/test/Makefile
+++ b/src/backend/utils/adt/test/Makefile
@@ -1,0 +1,42 @@
+top_builddir=../../../../..
+subdir=src/backend/utils/adt
+
+TARGETS=varlena
+
+# Objects from backend, which don't need to be mocked but need to be linked.
+common_REAL_OBJS=\
+    $(top_srcdir)/src/backend/access/hash/hashfunc.o \
+    $(top_srcdir)/src/backend/bootstrap/bootparse.o \
+    $(top_srcdir)/src/backend/lib/stringinfo.o \
+    $(top_srcdir)/src/backend/nodes/bitmapset.o \
+    $(top_srcdir)/src/backend/nodes/equalfuncs.o \
+    $(top_srcdir)/src/backend/nodes/list.o \
+    $(top_srcdir)/src/backend/parser/gram.o \
+    $(top_srcdir)/src/backend/regex/regcomp.o \
+    $(top_srcdir)/src/backend/regex/regerror.o \
+    $(top_srcdir)/src/backend/regex/regexec.o \
+    $(top_srcdir)/src/backend/regex/regfree.o \
+    $(top_srcdir)/src/backend/storage/page/itemptr.o \
+    $(top_srcdir)/src/backend/utils/adt/datum.o \
+    $(top_srcdir)/src/backend/utils/adt/like.o \
+    $(top_srcdir)/src/backend/utils/hash/dynahash.o \
+    $(top_srcdir)/src/backend/utils/hash/hashfn.o \
+    $(top_srcdir)/src/backend/utils/misc/guc.o \
+    $(top_srcdir)/src/backend/utils/init/globals.o \
+    $(top_srcdir)/src/backend/utils/mmgr/mcxt.o \
+    $(top_srcdir)/src/backend/utils/mmgr/aset.o \
+    $(top_srcdir)/src/backend/utils/mmgr/memprot.o \
+    $(top_srcdir)/src/port/exec.o \
+    $(top_srcdir)/src/port/path.o \
+    $(top_srcdir)/src/port/pgsleep.o \
+    $(top_srcdir)/src/port/pgstrcasecmp.o \
+    $(top_srcdir)/src/port/qsort.o \
+    $(top_srcdir)/src/port/strlcpy.o \
+    $(top_srcdir)/src/port/thread.o \
+    $(top_srcdir)/src/timezone/localtime.o \
+    $(top_srcdir)/src/timezone/pgtz.o    
+
+varlena_REAL_OBJS=$(common_REAL_OBJS)
+
+include ../../../../Makefile.mock
+

--- a/src/backend/utils/adt/test/varlena_test.c
+++ b/src/backend/utils/adt/test/varlena_test.c
@@ -1,0 +1,251 @@
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include "cmockery.h"
+
+#include "c.h"
+#include "postgres.h"
+#include "nodes/nodes.h"
+#include "../varlena.c"
+
+#define MEMORY_LIMIT 8 /* 8 bytes memory limit */
+
+#ifdef USE_ASSERT_CHECKING
+void
+_ExceptionalCondition( )
+{
+     PG_RE_THROW();
+}
+#endif
+
+/*
+ * Checks if the small strings that fit in memory fails assertion.
+ */
+void
+test__find_memory_limited_substring__small_string(void **state)
+{
+	int subStringByteLength = -1;
+	int subStringCharLength = -1;
+	int totalByteLength = MEMORY_LIMIT;
+	char *strStart = 0xabcdefab;
+
+#ifdef USE_ASSERT_CHECKING
+	expect_any(ExceptionalCondition,conditionName);
+	expect_any(ExceptionalCondition,errorType);
+	expect_any(ExceptionalCondition,fileName);
+	expect_any(ExceptionalCondition,lineNumber);
+	will_be_called_with_sideeffect(ExceptionalCondition,&_ExceptionalCondition,NULL);
+
+	/* Test if within memory-limit strings cause assertion failure */
+	PG_TRY();
+	{
+		find_memory_limited_substring(strStart, totalByteLength, MEMORY_LIMIT, &subStringByteLength, &subStringCharLength);
+		assert_true(false);
+	}
+	PG_CATCH();
+	{
+	}
+	PG_END_TRY();
+#endif
+}
+
+/*
+ * Checks if null input string causes assertion failure.
+ */
+void
+test__find_memory_limited_substring__null_string(void **state)
+{
+	int subStringByteLength = -1;
+	int subStringCharLength = -1;
+	int totalByteLength = MEMORY_LIMIT + 1;
+	char *strStart = NULL;
+
+#ifdef USE_ASSERT_CHECKING
+	expect_any(ExceptionalCondition,conditionName);
+	expect_any(ExceptionalCondition,errorType);
+	expect_any(ExceptionalCondition,fileName);
+	expect_any(ExceptionalCondition,lineNumber);
+	will_be_called_with_sideeffect(ExceptionalCondition,&_ExceptionalCondition,NULL);
+
+ 	/* Test if null strings cause assertion failure */
+	PG_TRY();
+	{
+		find_memory_limited_substring(strStart, totalByteLength, MEMORY_LIMIT, &subStringByteLength, &subStringCharLength);
+		assert_true(false);
+	}
+	PG_CATCH();
+	{
+	}
+	PG_END_TRY();
+#endif
+}
+
+/*
+ * Checks if the returned string segments are within memory limit for ascii characters.
+ */
+void
+test__find_memory_limited_substring__ascii_chars_within_memory_limit(void **state)
+{
+	int subStringByteLength = -1;
+	int subStringCharLength = -1;
+	int cumulativeLengthConsidered = 0;
+
+	char *strStart = 0xabcdefab;
+
+	int totalByteLength = 25;
+
+	while (cumulativeLengthConsidered < totalByteLength - MEMORY_LIMIT)
+	{
+		will_return(pg_database_encoding_max_length, 1);
+		find_memory_limited_substring(strStart, totalByteLength - cumulativeLengthConsidered, MEMORY_LIMIT, &subStringByteLength, &subStringCharLength);
+		cumulativeLengthConsidered += subStringByteLength;
+		assert_true(subStringByteLength == MEMORY_LIMIT);
+		assert_true(subStringByteLength == subStringCharLength);
+	}
+
+#ifdef USE_ASSERT_CHECKING
+	expect_any(ExceptionalCondition,conditionName);
+	expect_any(ExceptionalCondition,errorType);
+	expect_any(ExceptionalCondition,fileName);
+	expect_any(ExceptionalCondition,lineNumber);
+	will_be_called_with_sideeffect(ExceptionalCondition,&_ExceptionalCondition,NULL);
+
+	/* Test if the left-over string that fits in memory cause assertion failure */
+	PG_TRY();
+	{
+		find_memory_limited_substring(strStart, totalByteLength - cumulativeLengthConsidered, MEMORY_LIMIT, &subStringByteLength, &subStringCharLength);
+		assert_true(false);
+	}
+	PG_CATCH();
+	{
+	}
+	PG_END_TRY();
+
+	expect_any(ExceptionalCondition,conditionName);
+	expect_any(ExceptionalCondition,errorType);
+	expect_any(ExceptionalCondition,fileName);
+	expect_any(ExceptionalCondition,lineNumber);
+	will_be_called_with_sideeffect(ExceptionalCondition,&_ExceptionalCondition,NULL);
+
+	/* Test if null strings cause assertion failure */
+	PG_TRY();
+	{
+		find_memory_limited_substring(NULL, totalByteLength, MEMORY_LIMIT, &subStringByteLength, &subStringCharLength);
+	}
+	PG_CATCH();
+	{
+		return;
+	}
+	PG_END_TRY();
+	assert_true(false);
+#endif
+}
+
+
+/*
+ * Checks if the returned string segments are within memory limit for multi-bytes chars.
+ */
+void
+test__find_memory_limited_substring__mb_chars_within_memory_limit(void **state)
+{
+	int subStringByteLength = -1;
+	int subStringCharLength = -1;
+	int cumulativeLengthConsidered = 0;
+
+	/* Lengths of the multi-byte characters at different positions */
+	int stringByteLengths[] = {3, 3, 3 /* seg1 */, 2, 2, 1, 2 /* seg2 */, 2, 1, 1, 1, 2, /* seg3 */ 5, 4 /* seg4 */, 4};
+
+	/* Total length in terms of number of characters */
+	int stringCharLength = sizeof(stringByteLengths) / sizeof(int);
+
+	/* Total byte lengths of all the characters */
+	int totalByteLength = 0;
+	for (int charIndex = 0; charIndex < stringCharLength; charIndex++)
+	{
+		totalByteLength += stringByteLengths[charIndex];
+	}
+
+	int segmentByteLength = 0; /* Number of bytes in current segment */
+	int segmentCharLength = 0; /* Number of characters in current segment */
+
+	/* Length of the char that spilled over from one partition to another */
+	int carryoverLength = 0;
+
+	/* Fictitious multi-byte string to segment */
+	char *strStart = 0xabcdefab;
+
+	for (int charIndex = 0; charIndex < stringCharLength; charIndex++)
+	{
+		if (carryoverLength > 0)
+		{
+			expect_any(pg_mblen, mbstr);
+			will_return(pg_mblen, carryoverLength);
+			carryoverLength = 0;
+		}
+
+		expect_any(pg_mblen, mbstr);
+		will_return(pg_mblen, stringByteLengths[charIndex]);
+		segmentByteLength += stringByteLengths[charIndex];
+		segmentCharLength++;
+
+		if (segmentByteLength > MEMORY_LIMIT)
+		{
+
+			will_return(pg_database_encoding_max_length, 6);
+			find_memory_limited_substring(strStart, totalByteLength - cumulativeLengthConsidered, MEMORY_LIMIT, &subStringByteLength, &subStringCharLength);
+			assert_true(subStringByteLength == (segmentByteLength - stringByteLengths[charIndex]));
+			assert_true(subStringCharLength == (segmentCharLength - 1));
+			assert_true(subStringByteLength <= MEMORY_LIMIT);
+			assert_true(subStringCharLength <= MEMORY_LIMIT);
+
+			cumulativeLengthConsidered += subStringByteLength;
+
+			segmentByteLength = stringByteLengths[charIndex];
+			segmentCharLength = 1;
+			carryoverLength = stringByteLengths[charIndex];
+		}
+	}
+
+	/* Now purge any unused pg_mblen call because of the suffix that does not exceed MEMORY_LIMIT */
+	for (int partitionCharIndex = 0; partitionCharIndex < segmentCharLength; partitionCharIndex++)
+	{
+		pg_mblen("a");
+	}
+
+#ifdef USE_ASSERT_CHECKING
+	expect_any(ExceptionalCondition,conditionName);
+	expect_any(ExceptionalCondition,errorType);
+	expect_any(ExceptionalCondition,fileName);
+	expect_any(ExceptionalCondition,lineNumber);
+	will_be_called_with_sideeffect(ExceptionalCondition,&_ExceptionalCondition,NULL);
+
+	/* Test if the left-over string that fits in memory cause assertion failure */
+	PG_TRY();
+	{
+		find_memory_limited_substring(strStart, totalByteLength - cumulativeLengthConsidered, MEMORY_LIMIT, &subStringByteLength, &subStringCharLength);
+	}
+	PG_CATCH();
+	{
+		return;
+	}
+	PG_END_TRY();
+
+	assert_true(false);
+#endif
+}
+
+int 
+main(int argc, char* argv[]) 
+{
+        cmockery_parse_arguments(argc, argv);
+        
+        const UnitTest tests[] = {
+			unit_test(test__find_memory_limited_substring__small_string),
+			unit_test(test__find_memory_limited_substring__null_string),
+			unit_test(test__find_memory_limited_substring__ascii_chars_within_memory_limit),
+			unit_test(test__find_memory_limited_substring__mb_chars_within_memory_limit)
+        };
+        return run_tests(tests);
+}
+
+


### PR DESCRIPTION
This commit is adding support to handle large strings (up to a GB) in text_to_array(). The fix has been picked from GPDB. 

The commits from GPDB are the following: 
i)https://stash.eng.pivotal.io/projects/GPDB/repos/main/commits/61642064acbc810aa5ddf1e4ddd00b8c4ceef5d7
ii)https://stash.eng.pivotal.io/projects/GPDB/repos/main/commits/e28f9404c7d364868fce6b3f7d8ac17643317886
iii)https://stash.eng.pivotal.io/projects/GPDB/repos/main/commits/1bfe96c6a7a0a997955491114bde5de0a33c4363

I could not cherry-pick them, because GPDB had different folder structure. Please add them to the final commit.