### PR TITLE
HAWQ-447. YARN mode resource manager does not count available segment back in to available segment counter

### DIFF
--- a/src/backend/resourcemanager/resourcepool.c
+++ b/src/backend/resourcemanager/resourcepool.c
@@ -1440,7 +1440,9 @@ int setSegResHAWQAvailability( SegResource segres, uint8_t newstatus)
 							  segres->Stat->GRMTotalCore);
 
 		addNewResourceToResourceManagerByBundle(&(segres->Allocated));
-		if ( DRMGlobalInstance->ImpType == NONE_HAWQ2 )
+		if ( (DRMGlobalInstance->ImpType == NONE_HAWQ2) ||
+			 (DRMGlobalInstance->ImpType != NONE_HAWQ2 &&
+			  IS_SEGSTAT_GRMAVAILABLE(segres->Stat)))
 		{
 			PRESPOOL->AvailNodeCount++;
 		}


### PR DESCRIPTION
The fix is to add available segment counter when segment is FTS available again but GRM available already.