### PR TITLE
HAWQ-453. Do not allocate query resource in prepare stage for prepared statement

### DIFF
--- a/src/backend/cdb/cdbdatalocality.c
+++ b/src/backend/cdb/cdbdatalocality.c
@@ -41,6 +41,7 @@
 #include "utils/tqual.h"
 #include "utils/memutils.h"
 #include "executor/execdesc.h"
+#include "executor/spi.h"
 #include "nodes/nodes.h"
 #include "nodes/parsenodes.h"
 #include "optimizer/walkers.h"
@@ -3959,10 +3960,11 @@ static void cleanup_allocation_algorithm(
 
 /*
  * calculate_planner_segment_num
+ * fixedVsegNum is used by PBE, since all the execute should use the same number of vsegs.
  */
 SplitAllocResult *
 calculate_planner_segment_num(Query *query, QueryResourceLife resourceLife,
-		List *fullRangeTable, GpPolicy *intoPolicy, int sliceNum) {
+		List *fullRangeTable, GpPolicy *intoPolicy, int sliceNum, int fixedVsegNum) {
 	SplitAllocResult *result = NULL;
 	QueryResource *resource = NULL;
 	QueryResourceParameters *resource_parameters = NULL;
@@ -4046,7 +4048,15 @@ calculate_planner_segment_num(Query *query, QueryResourceLife resourceLife,
 
 		/*use inherit resource*/
 		if (resourceLife == QRL_INHERIT) {
-			resource = AllocateResource(resourceLife, sliceNum, 0, 0, 0, NULL, 0);
+
+			if ( SPI_IsInPrepare() && (GetActiveQueryResource() == NULL) )
+			{
+				resource = NULL;
+			}
+			else
+			{
+				resource = AllocateResource(resourceLife, sliceNum, 0, 0, 0, NULL, 0);
+			}
 
 			saveQueryResourceParameters(
 							resource_parameters,  /* resource_parameters */
@@ -4197,6 +4207,11 @@ calculate_planner_segment_num(Query *query, QueryResourceLife resourceLife,
 				maxTargetSegmentNumber = enforce_virtual_segment_number;
 				minTargetSegmentNumber = enforce_virtual_segment_number;
 			}
+			/* in PBE mode, the execute should use the same vseg number. */
+			if(fixedVsegNum > 0 ){
+				maxTargetSegmentNumber = fixedVsegNum;
+				minTargetSegmentNumber = fixedVsegNum;
+			}
 			uint64_t before_rm_allocate_resource = gettime_microsec();
 
 			/* cost is use by RM to balance workload between hosts. the cost is at least one block size*/
@@ -4204,9 +4219,40 @@ calculate_planner_segment_num(Query *query, QueryResourceLife resourceLife,
 			mincost <<= 20;
 			int64 queryCost = context.total_size < mincost ? mincost : context.total_size;
 			if (QRL_NONE != resourceLife) {
-				resource = AllocateResource(QRL_ONCE, sliceNum, queryCost,
-						maxTargetSegmentNumber, minTargetSegmentNumber,
-						context.host_context.hostnameVolInfos, context.host_context.size);
+
+				if (SPI_IsInPrepare())
+				{
+					resource = NULL;
+					/*
+					 * prepare need to get resource quota from RM
+					 * and pass quota(planner_segments) to Orca or Planner to generate plan
+					 * the following executes(in PBE) should reallocate the same number
+					 * of resources.
+					 */
+					uint32 seg_num;
+					uint32 seg_num_min;
+					uint32 seg_memory_mb;
+					double seg_core;
+
+					GetResourceQuota(maxTargetSegmentNumber,
+					                 minTargetSegmentNumber,
+					                 &seg_num,
+					                 &seg_num_min,
+					                 &seg_memory_mb,
+					                 &seg_core);
+
+					planner_segments = seg_num;
+					minTargetSegmentNumber = planner_segments;
+					maxTargetSegmentNumber = planner_segments;
+				}
+				else
+				{
+					resource = AllocateResource(QRL_ONCE, sliceNum, queryCost,
+					                            maxTargetSegmentNumber,
+					                            minTargetSegmentNumber,
+					                            context.host_context.hostnameVolInfos,
+					                            context.host_context.size);
+				}
 
 				saveQueryResourceParameters(
 								resource_parameters,                   /* resource_parameters */
@@ -4236,7 +4282,7 @@ calculate_planner_segment_num(Query *query, QueryResourceLife resourceLife,
 
 			if (resource == NULL) {
 				result->resource = NULL;
-				result->resource_parameters = NULL;
+				result->resource_parameters = resource_parameters;
 				result->alloc_results = NIL;
 				result->relsType = NIL;
 				result->planner_segments = planner_segments;

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -495,7 +495,8 @@ resource_negotiator(Query *parse, int cursorOptions, ParamListInfo boundParams,
        */
       allocResult = calculate_planner_segment_num(my_parse, resourceLife,
                                           plannedstmt->rtable, plannedstmt->intoPolicy,
-                                          plannedstmt->nMotionNodes + plannedstmt->nInitPlans + 1);
+                                          plannedstmt->nMotionNodes + plannedstmt->nInitPlans + 1,
+                                          -1);
 
       Assert(allocResult);
 

--- a/src/include/cdb/cdbdatalocality.h
+++ b/src/include/cdb/cdbdatalocality.h
@@ -86,7 +86,7 @@ void saveQueryResourceParameters(
  * we calculate the appropriate planner segment_num.
  */
 SplitAllocResult * calculate_planner_segment_num(Query *query, QueryResourceLife resourceLife,
-                                                List *rtable, GpPolicy *intoPolicy, int sliceNum);
+                                                List *rtable, GpPolicy *intoPolicy, int sliceNum, int fixedVsegNum);
 
 FILE *fp;
 FILE *fpaoseg;

--- a/src/include/executor/spi.h
+++ b/src/include/executor/spi.h
@@ -155,4 +155,11 @@ extern uint64 SPI_GetMemoryReservation(void);
 extern void SPI_ReserveMemory(uint64 mem_reserved);
 extern bool SPI_IsMemoryReserved(void);
 
+/**
+ * Query resource related routines.
+ */
+extern bool SPI_IsInPrepare(void);
+extern void SPI_IncreasePrepareCounter(void);
+extern void SPI_DecreasePrepareCounter(void);
+
 #endif   /* SPI_H */


### PR DESCRIPTION
The change includes:
1. In SPI prepare, we generate plan, get and save query resource parameters
2. In SPI execute, we allocate query resource according to saved query resource parameters, and allocate datalocality