### PR TITLE
HAWQ-404. Add sort during INSERT of append only AO partition tables

### DIFF
--- a/src/backend/executor/execUtils.c
+++ b/src/backend/executor/execUtils.c
@@ -278,7 +278,7 @@ InternalCreateExecutorState(MemoryContext qcontext, bool is_subquery)
 	estate->es_result_relations = NULL;
 	estate->es_num_result_relations = 0;
 	estate->es_result_relation_info = NULL;
-	estate->es_last_parq_part = InvalidOid;
+	estate->es_last_inserted_part = InvalidOid;
 
 	estate->es_junkFilter = NULL;
 

--- a/src/backend/executor/nodeDML.c
+++ b/src/backend/executor/nodeDML.c
@@ -120,7 +120,7 @@ ExecDML(DMLState *node)
 		 */
 		ExecInsert(node->cleanedUpSlot, NULL /* destReceiver */,
 				node->ps.state, PLANGEN_OPTIMIZER /* Plan origin */, 
-				isUpdate);
+				isUpdate, plannode->inputSorted);
 	}
 	else /* DML_DELETE */
 	{

--- a/src/backend/gpopt/ivy.xml
+++ b/src/backend/gpopt/ivy.xml
@@ -38,7 +38,7 @@ under the License.
     </configurations>
 
     <dependencies>
-      <dependency org="emc"             name="optimizer"       rev="1.617"          conf="osx106_x86->osx106_x86_32;osx106_x86_32->osx106_x86_32;rhel5_x86_64->rhel5_x86_64;suse10_x86_64->suse10_x86_64" />
+      <dependency org="emc"             name="optimizer"       rev="1.623"          conf="osx106_x86->osx106_x86_32;osx106_x86_32->osx106_x86_32;rhel5_x86_64->rhel5_x86_64;suse10_x86_64->suse10_x86_64" />
       <dependency org="emc"             name="libgpos"         rev="1.133"          conf="osx106_x86->osx106_x86_32;osx106_x86_32->osx106_x86_32;rhel5_x86_64->rhel5_x86_64;suse10_x86_64->suse10_x86_64" />
       <dependency org="xerces"          name="xerces-c"        rev="3.1.1-p1"       conf="osx106_x86->osx106_x86_32;osx106_x86_32->osx106_x86_32;rhel5_x86_64->rhel5_x86_64;suse10_x86_64->suse10_x86_64" />
     </dependencies>

--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -4518,6 +4518,8 @@ CTranslatorDXLToPlStmt::PplanDML
 		plTargetListDML = plTargetListWithDroppedCols;
 	}
 	
+	pdml->inputSorted = pdxlop->FInputSorted();
+
 	// add ctid, action and oid columns to target list
 	pdml->oidColIdx = UlAddTargetEntryForColId(&plTargetListDML, &dxltrctxChild, pdxlop->UlOid(), true /*fResjunk*/);
 	pdml->actionColIdx = UlAddTargetEntryForColId(&plTargetListDML, &dxltrctxChild, pdxlop->UlAction(), true /*fResjunk*/);

--- a/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
@@ -597,6 +597,7 @@ CTranslatorRelcacheToDXL::Pmdrel
 	DrgPmdid *pdrgpmdidIndexes = NULL;
 	DrgPmdid *pdrgpmdidTriggers = NULL;
 	DrgPul *pdrgpulPartKeys = NULL;
+	ULONG ulLeafPartitions = 0;
 	BOOL fConvertHashToRandom = false;
 	DrgPdrgPul *pdrgpdrgpulKeys = NULL;
 	DrgPmdid *pdrgpmdidCheckConstraints = NULL;
@@ -652,6 +653,13 @@ CTranslatorRelcacheToDXL::Pmdrel
 				erelstorage = IMDRelation::ErelstorageAppendOnlyParquet;
 			}
 		}
+
+		// get number of leaf partitions
+		if (gpdb::FRelPartIsRoot(oid))
+		{
+		   ulLeafPartitions = gpdb::UlLeafPartitions(oid);
+		}
+
 		// get key sets
 		BOOL fAddDefaultKeys = FHasSystemColumns(rel->rd_rel->relkind);
 		pdrgpdrgpulKeys = PdrgpdrgpulKeys(pmp, oid, fAddDefaultKeys, fPartitioned, pulAttnoMapping);
@@ -722,6 +730,7 @@ CTranslatorRelcacheToDXL::Pmdrel
 							pdrgpmdcol,
 							pdrpulDistrCols,
 							pdrgpulPartKeys,
+							ulLeafPartitions,
 							fConvertHashToRandom,
 							pdrgpdrgpulKeys,
 							pdrgpmdidIndexes,

--- a/src/backend/gpopt/utils/COptTasks.cpp
+++ b/src/backend/gpopt/utils/COptTasks.cpp
@@ -774,13 +774,15 @@ COptTasks::PoconfCreate
 	DOUBLE dDampingFactorGroupBy = (DOUBLE) optimizer_damping_factor_groupby;
 
 	ULONG ulCTEInliningCutoff =  (ULONG) optimizer_cte_inlining_bound;
+	ULONG ulPartsToForceSortOnInsert =  (ULONG) optimizer_parts_to_force_sort_on_insert;
 
 	return GPOS_NEW(pmp) COptimizerConfig
 						(
 						GPOS_NEW(pmp) CEnumeratorConfig(pmp, ullPlanId, ullSamples, dCostThreshold),
 						GPOS_NEW(pmp) CStatisticsConfig(pmp, dDampingFactorFilter, dDampingFactorJoin, dDampingFactorGroupBy),
 						GPOS_NEW(pmp) CCTEConfig(ulCTEInliningCutoff),
-						pcm
+						pcm,
+						GPOS_NEW(pmp) CHint(ulPartsToForceSortOnInsert)
 						);
 }
 

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -1119,6 +1119,7 @@ _copyDML(const DML *from)
 	COPY_SCALAR_FIELD(actionColIdx);
 	COPY_SCALAR_FIELD(ctidColIdx);
 	COPY_SCALAR_FIELD(tupleoidColIdx);
+	COPY_SCALAR_FIELD(inputSorted);
 
 	return newnode;
 }

--- a/src/backend/nodes/outfast.c
+++ b/src/backend/nodes/outfast.c
@@ -981,6 +981,7 @@ _outDML(StringInfo str, DML *node)
 	WRITE_INT_FIELD(actionColIdx);
 	WRITE_INT_FIELD(ctidColIdx);
 	WRITE_INT_FIELD(tupleoidColIdx);
+	WRITE_BOOL_FIELD(inputSorted);
 
 	_outPlanInfo(str, (Plan *) node);
 }

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -987,6 +987,7 @@ _outDML(StringInfo str, DML *node)
 	WRITE_INT_FIELD(actionColIdx);
 	WRITE_INT_FIELD(ctidColIdx);
 	WRITE_INT_FIELD(tupleoidColIdx);
+	WRITE_BOOL_FIELD(inputSorted);
 
 	_outPlanInfo(str, (Plan *) node);
 }

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -3604,6 +3604,7 @@ _readDML(const char ** str)
 	READ_INT_FIELD(actionColIdx);
 	READ_INT_FIELD(ctidColIdx);
 	READ_INT_FIELD(tupleoidColIdx);
+	READ_BOOL_FIELD(inputSorted);
 
 	readPlanInfo(str, (Plan *)local_node);
 

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -6150,7 +6150,7 @@ static struct config_int ConfigureNamesInt[] =
 		{"optimizer_parts_to_force_sort_on_insert", PGC_USERSET, DEVELOPER_OPTIONS,
 			gettext_noop("Minimum number of partitions required to force sorting tuples during insertion in an append only row-oriented partitioned table"),
 			NULL,
-			GUC_NOT_IN_SAMPLE
+			GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
 		},
 		&optimizer_parts_to_force_sort_on_insert,
 		INT_MAX, 0, INT_MAX, NULL, NULL

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -762,6 +762,7 @@ bool 		optimizer_multilevel_partitioning;
 bool        optimizer_enable_derive_stats_all_groups;
 bool		optimizer_explain_show_status;
 bool		optimizer_prefer_scalar_dqa_multistage_agg;
+int		optimizer_parts_to_force_sort_on_insert;
 
 /* Security */
 bool		gp_reject_internal_tcp_conn = true;
@@ -6143,6 +6144,16 @@ static struct config_int ConfigureNamesInt[] =
 		},
 		&optimizer_segments,
 		0, 0, INT_MAX, NULL, NULL
+	},
+
+	{
+		{"optimizer_parts_to_force_sort_on_insert", PGC_USERSET, DEVELOPER_OPTIONS,
+			gettext_noop("Minimum number of partitions required to force sorting tuples during insertion in an append only row-oriented partitioned table"),
+			NULL,
+			GUC_NOT_IN_SAMPLE
+		},
+		&optimizer_parts_to_force_sort_on_insert,
+		INT_MAX, 0, INT_MAX, NULL, NULL
 	},
 
 	{

--- a/src/include/executor/execDML.h
+++ b/src/include/executor/execDML.h
@@ -54,7 +54,8 @@ ExecInsert(TupleTableSlot *slot,
 		   DestReceiver *dest,
 		   EState *estate,
 		   PlanGenerator planGen,
-		   bool isUpdate);
+		   bool isUpdate,
+		   bool isInputSorted);
 
 extern void
 ExecDelete(ItemPointer tupleid,

--- a/src/include/gpopt/translate/CTranslatorUtils.h
+++ b/src/include/gpopt/translate/CTranslatorUtils.h
@@ -70,10 +70,6 @@ namespace gpdxl
 {
 	using namespace gpopt;
 
-	// hash maps mapping INT -> ULONG
-	typedef CHashMap<INT, ULONG, gpos::UlHash<INT>, gpos::FEqual<INT>,
-					CleanupDelete<INT>, CleanupDelete<ULONG> > HMIUl;
-
 	//---------------------------------------------------------------------------
 	//	@class:
 	//		CTranslatorUtils

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -278,7 +278,7 @@ typedef struct JunkFilter
  *  aoInsertDesc        context for appendonly relation buffered INSERT
  *  extInsertDesc       context for external table INSERT
  *  parquetInsertDesc   context for parquet table INSERT
- *  parquetSendBack     information to be sent back to dispatch after INSERT in a parquet table
+ *  insertSendBack      information to be sent back to dispatch after INSERT in a parquet or AO table
  *  aosegno             the AO segfile we inserted into.
  *  aoprocessed         tuples processed for AO
  *  partInsertMap       map input attrno to target attrno
@@ -307,7 +307,8 @@ typedef struct ResultRelInfo
 
 	struct ExternalInsertDescData   *ri_extInsertDesc;
 	struct ParquetInsertDescData    *ri_parquetInsertDesc;
-	struct QueryContextDispatchingSendBackData *ri_parquetSendBack;
+
+	struct QueryContextDispatchingSendBackData *ri_insertSendBack;
 
 	List *ri_aosegnos;
 
@@ -501,7 +502,7 @@ typedef struct EState
 	ResultRelInfo *es_result_relation_info;                /* currently active array elt */
 	JunkFilter *es_junkFilter;        /* currently active junk filter */
 
-	Oid es_last_parq_part; /* The Oid of the last parquet partition we opened for insertion */
+	Oid es_last_inserted_part; /* The Oid of the last partition we opened for insertion */
 
 	/* partitioning info for target relation */
 	PartitionNode *es_result_partitions;

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -1149,6 +1149,7 @@ typedef struct DML
 	AttrNumber	actionColIdx;	/* index of action column into the target list */
 	AttrNumber	ctidColIdx;		/* index of ctid column into the target list */
 	AttrNumber	tupleoidColIdx;	/* index of tuple oid column into the target list */
+	bool		inputSorted;		/* needs the data to be sorted */
 
 } DML;
 

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -434,6 +434,7 @@ extern bool optimizer_multilevel_partitioning;
 extern bool optimizer_enable_derive_stats_all_groups;
 extern bool optimizer_explain_show_status;
 extern bool optimizer_prefer_scalar_dqa_multistage_agg;
+extern int  optimizer_parts_to_force_sort_on_insert;
 
 /**
  * Enable logging of DPE match in optimizer.

--- a/src/test/regress/expected/goh_partition.out
+++ b/src/test/regress/expected/goh_partition.out
@@ -2197,3 +2197,129 @@ NOTICE:  CREATE TABLE will create partition "rank3_1_prt_girls_2_prt_jan04_3_prt
 NOTICE:  CREATE TABLE will create partition "rank3_1_prt_girls_2_prt_jan05_3_prt_mass" for table "rank3_1_prt_girls_2_prt_jan05"
 NOTICE:  CREATE TABLE will create partition "rank3_1_prt_girls_2_prt_jan05_3_prt_cali" for table "rank3_1_prt_girls_2_prt_jan05"
 NOTICE:  CREATE TABLE will create partition "rank3_1_prt_girls_2_prt_jan05_3_prt_ohio" for table "rank3_1_prt_girls_2_prt_jan05"
+-- Tests for sort operator before insert with AO and PARQUET tables (HAWQ-404)
+-- A GUC's value is set to less than the number of partitions in the example table, so that sort is activated.
+DROP TABLE IF EXISTS ch_sort_src, ch_sort_aodest, ch_sort_pqdest, ch_sort_aopqdest, ch_sort__pq_table;
+SET optimizer_parts_to_force_sort_on_insert = 5;
+CREATE TABLE ch_sort_src (id int, year int, month int, day int, region text)
+DISTRIBUTED BY (month); 
+INSERT INTO ch_sort_src select i, 2000 + i, i % 12, (2*i) % 30, i::text from generate_series(0, 99) i; 
+-- AO partitioned table
+CREATE TABLE ch_sort_aodest (id int, year int, month int, day int, region text)
+WITH (APPENDONLY=TRUE)
+DISTRIBUTED BY (id)
+PARTITION BY RANGE (year)
+( 
+    START (2002) END (2010) EVERY (1),
+    DEFAULT PARTITION outlying_years
+);
+NOTICE:  CREATE TABLE will create partition "ch_sort_aodest_1_prt_outlying_years" for table "ch_sort_aodest"
+NOTICE:  CREATE TABLE will create partition "ch_sort_aodest_1_prt_2" for table "ch_sort_aodest"
+NOTICE:  CREATE TABLE will create partition "ch_sort_aodest_1_prt_3" for table "ch_sort_aodest"
+NOTICE:  CREATE TABLE will create partition "ch_sort_aodest_1_prt_4" for table "ch_sort_aodest"
+NOTICE:  CREATE TABLE will create partition "ch_sort_aodest_1_prt_5" for table "ch_sort_aodest"
+NOTICE:  CREATE TABLE will create partition "ch_sort_aodest_1_prt_6" for table "ch_sort_aodest"
+NOTICE:  CREATE TABLE will create partition "ch_sort_aodest_1_prt_7" for table "ch_sort_aodest"
+NOTICE:  CREATE TABLE will create partition "ch_sort_aodest_1_prt_8" for table "ch_sort_aodest"
+NOTICE:  CREATE TABLE will create partition "ch_sort_aodest_1_prt_9" for table "ch_sort_aodest"
+-- PARQUET partitioned table
+CREATE TABLE ch_sort_pqdest (id int, year int, month int, day int, region text)
+WITH (APPENDONLY=TRUE, ORIENTATION = PARQUET)
+DISTRIBUTED BY (id)
+PARTITION BY RANGE (year)
+( 
+    START (2002) END (2010) EVERY (1),
+    DEFAULT PARTITION outlying_years
+);
+NOTICE:  CREATE TABLE will create partition "ch_sort_pqdest_1_prt_outlying_years" for table "ch_sort_pqdest"
+NOTICE:  CREATE TABLE will create partition "ch_sort_pqdest_1_prt_2" for table "ch_sort_pqdest"
+NOTICE:  CREATE TABLE will create partition "ch_sort_pqdest_1_prt_3" for table "ch_sort_pqdest"
+NOTICE:  CREATE TABLE will create partition "ch_sort_pqdest_1_prt_4" for table "ch_sort_pqdest"
+NOTICE:  CREATE TABLE will create partition "ch_sort_pqdest_1_prt_5" for table "ch_sort_pqdest"
+NOTICE:  CREATE TABLE will create partition "ch_sort_pqdest_1_prt_6" for table "ch_sort_pqdest"
+NOTICE:  CREATE TABLE will create partition "ch_sort_pqdest_1_prt_7" for table "ch_sort_pqdest"
+NOTICE:  CREATE TABLE will create partition "ch_sort_pqdest_1_prt_8" for table "ch_sort_pqdest"
+NOTICE:  CREATE TABLE will create partition "ch_sort_pqdest_1_prt_9" for table "ch_sort_pqdest"
+-- AO/PARQUET mixed table
+CREATE TABLE ch_sort_aopqdest (id int, year int, month int, day int, region text)
+WITH (APPENDONLY=TRUE)
+DISTRIBUTED BY (id)
+PARTITION BY RANGE (year)
+( 
+    START (2002) END (2010) EVERY (1),
+    DEFAULT PARTITION outlying_years
+);
+NOTICE:  CREATE TABLE will create partition "ch_sort_aopqdest_1_prt_outlying_years" for table "ch_sort_aopqdest"
+NOTICE:  CREATE TABLE will create partition "ch_sort_aopqdest_1_prt_2" for table "ch_sort_aopqdest"
+NOTICE:  CREATE TABLE will create partition "ch_sort_aopqdest_1_prt_3" for table "ch_sort_aopqdest"
+NOTICE:  CREATE TABLE will create partition "ch_sort_aopqdest_1_prt_4" for table "ch_sort_aopqdest"
+NOTICE:  CREATE TABLE will create partition "ch_sort_aopqdest_1_prt_5" for table "ch_sort_aopqdest"
+NOTICE:  CREATE TABLE will create partition "ch_sort_aopqdest_1_prt_6" for table "ch_sort_aopqdest"
+NOTICE:  CREATE TABLE will create partition "ch_sort_aopqdest_1_prt_7" for table "ch_sort_aopqdest"
+NOTICE:  CREATE TABLE will create partition "ch_sort_aopqdest_1_prt_8" for table "ch_sort_aopqdest"
+NOTICE:  CREATE TABLE will create partition "ch_sort_aopqdest_1_prt_9" for table "ch_sort_aopqdest"
+CREATE TABLE ch_sort__pq_table (id int, year int, month int, day int, region text)
+WITH (APPENDONLY=TRUE, ORIENTATION = PARQUET)
+DISTRIBUTED BY (id);
+ALTER TABLE ch_sort_aopqdest
+EXCHANGE PARTITION FOR(2006)
+WITH TABLE ch_sort__pq_table;
+-- Test that inserts work
+INSERT INTO ch_sort_aodest SELECT * FROM ch_sort_src;
+SELECT COUNT(*) FROM ch_sort_aodest;
+ count 
+-------
+   100
+(1 row)
+
+SELECT COUNT(*) FROM ch_sort_aodest_1_prt_6;
+ count 
+-------
+     1
+(1 row)
+
+SELECT COUNT(*) FROM ch_sort_aodest_1_prt_outlying_years;
+ count 
+-------
+    92
+(1 row)
+
+INSERT INTO ch_sort_pqdest SELECT * FROM ch_sort_src;
+SELECT COUNT(*) FROM ch_sort_pqdest;
+ count 
+-------
+   100
+(1 row)
+
+SELECT COUNT(*) FROM ch_sort_pqdest_1_prt_6;
+ count 
+-------
+     1
+(1 row)
+
+SELECT COUNT(*) FROM ch_sort_pqdest_1_prt_outlying_years;
+ count 
+-------
+    92
+(1 row)
+
+INSERT INTO ch_sort_aopqdest SELECT * FROM ch_sort_src;
+SELECT COUNT(*) FROM ch_sort_aopqdest;
+ count 
+-------
+   100
+(1 row)
+
+SELECT COUNT(*) FROM ch_sort_aopqdest_1_prt_6;
+ count 
+-------
+     1
+(1 row)
+
+SELECT COUNT(*) FROM ch_sort_aopqdest_1_prt_outlying_years;
+ count 
+-------
+    92
+(1 row)
+
+RESET optimizer_parts_to_force_sort_on_insert;

--- a/src/test/regress/expected/gpsql_alter_table_optimizer.out
+++ b/src/test/regress/expected/gpsql_alter_table_optimizer.out
@@ -41,7 +41,7 @@ SELECT a, b, c FROM altable WHERE a = 12;
 ROLLBACK;
 ALTER TABLE altable ALTER COLUMN c SET NOT NULL;
 INSERT INTO altable(a, b) VALUES(13, '13');
-ERROR:  NULL value in column "c" violates not-null constraint (COptTasks.cpp:1294)
+ERROR:  null value in column "c" violates not-null constraint (COptTasks.cpp:1756)
 ALTER TABLE altable ALTER COLUMN c DROP NOT NULL;
 INSERT INTO altable(a, b) VALUES(13, '13');
 SELECT a, b, c FROM altable WHERE a = 13;

--- a/src/test/regress/expected/insert_optimizer.out
+++ b/src/test/regress/expected/insert_optimizer.out
@@ -5,7 +5,7 @@ create table inserttest (col1 int4, col2 int4 NOT NULL, col3 text default 'testi
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'col1' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into inserttest (col1, col2, col3) values (DEFAULT, DEFAULT, DEFAULT);
-ERROR:  NULL value in column "col2" violates not-null constraint (COptTasks.cpp:1688)
+ERROR:  null value in column "col2" violates not-null constraint (COptTasks.cpp:1756)
 insert into inserttest (col2, col3) values (3, DEFAULT);
 insert into inserttest (col1, col2, col3) values (DEFAULT, 5, DEFAULT);
 insert into inserttest values (DEFAULT, 5, 'test');


### PR DESCRIPTION
This PR adds a new GUC for GPORCA: `optimizer_parts_to_force_sort_on_insert `, which implies the minimum number of partitions required to force sorting tuples during insertion in an append only row-oriented partitioned table.

For AO with small number of partitions that is less than the GUC value of `optimizer_parts_to_force_sort_on_insert `, sort is not needed for insert. For a relatively large number of partitions that is larger or equal to `optimizer_parts_to_force_sort_on_insert `, sort is needed.  

Sort during inserting on append only row oriented partitioned tables is disabled by default, with the default GUC value as INT_MAX.

This requires GPORCA version number >= 1.623