### PR TITLE
HAWQ-479: Update JSON-C from 0.6 to 0.12

### DIFF
--- a/configure
+++ b/configure
@@ -11145,9 +11145,9 @@ fi
 
 # json-c
 
-for ac_header in json/json.h
+for ac_header in json-c/json.h
 do :
-  ac_fn_c_check_header_mongrel "$LINENO" "json/json.h" "ac_cv_header_json_json_h" "$ac_includes_default"
+  ac_fn_c_check_header_mongrel "$LINENO" "json-c/json.h" "ac_cv_header_json_json_h" "$ac_includes_default"
 if test "x$ac_cv_header_json_json_h" = xyes; then :
   cat >>confdefs.h <<_ACEOF
 #define HAVE_JSON_JSON_H 1

--- a/configure.in
+++ b/configure.in
@@ -1310,7 +1310,7 @@ fi
 
 # json-c 
 
-AC_CHECK_HEADERS(json/json.h, [], [AC_MSG_ERROR([json-c is required])])
+AC_CHECK_HEADERS(json-c/json.h, [], [AC_MSG_ERROR([json-c is required])])
 AC_SEARCH_LIBS(json_tokener_parse, json-c json, [], [AC_MSG_ERROR([json-c is required])], [])
 
 # libxml2

--- a/src/backend/access/external/hd_work_mgr.c
+++ b/src/backend/access/external/hd_work_mgr.c
@@ -27,7 +27,7 @@
 
 #include "postgres.h"
 #include <curl/curl.h>
-#include <json/json.h>
+#include <json-c/json.h>
 #include "access/pxfmasterapi.h"
 #include "access/hd_work_mgr.h"
 #include "access/libchurl.h"

--- a/src/backend/access/external/pxfanalyze.c
+++ b/src/backend/access/external/pxfanalyze.c
@@ -25,7 +25,7 @@
 
 #include "postgres.h"
 #include <curl/curl.h>
-#include <json/json.h>
+#include <json-c/json.h>
 #include "access/hd_work_mgr.h"
 #include "access/pxfanalyze.h"
 #include "catalog/namespace.h"

--- a/src/backend/access/external/pxfmasterapi.c
+++ b/src/backend/access/external/pxfmasterapi.c
@@ -25,7 +25,7 @@
  *
  *-------------------------------------------------------------------------
  */
-#include <json/json.h>
+#include <json-c/json.h>
 #include "access/pxfmasterapi.h"
 #include "catalog/hcatalog/externalmd.h"
 

--- a/src/backend/catalog/hcatalog/externalmd.c
+++ b/src/backend/catalog/hcatalog/externalmd.c
@@ -28,7 +28,7 @@
  */
 
 #include "postgres.h"
-#include <json/json.h>
+#include <json-c/json.h>
 
 #include "miscadmin.h"
 #include "access/transam.h"

--- a/src/include/pg_config.h.in
+++ b/src/include/pg_config.h.in
@@ -262,7 +262,7 @@
 /* Define to 1 if you have isinf(). */
 #undef HAVE_ISINF
 
-/* Define to 1 if you have the <json/json.h> header file. */
+/* Define to 1 if you have the <json-c/json.h> header file. */
 #undef HAVE_JSON_JSON_H
 
 /* Define to 1 if you have the <kernel/image.h> header file. */


### PR DESCRIPTION
- Uses new path `json-c/json.h` rather than `json/json.h`

Signed-off-by: Xin Zhang <xzhang@pivotal.io>