### PR TITLE
HAWQ-483. Fix bug for Error in debug1 state.

### DIFF
--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -6204,4 +6204,3 @@ SyncAgentMain(int argc, char *argv[], const char *username)
 	return 1;					/* keep compiler quiet */
 }
 
-

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -4760,7 +4760,6 @@ PostgresMain(int argc, char *argv[], const char *username)
 					const char *serializedIdentity = NULL;
 					const char *serializedResource = NULL;
 					
-					char *completeSerializedIdentity = NULL;
 					int query_string_len = 0;
 					int serializedSnapshotlen = 0;
 					int serializedQuerytreelen = 0;
@@ -4886,11 +4885,10 @@ PostgresMain(int argc, char *argv[], const char *username)
 						 * serializedIdentity doesn't include '\0', which will cause core dump in SetupProcessIdentity() with using elog(DEBUG1).
 						 * So palloc a new string with '\0'.
 						 */
-						completeSerializedIdentity = (char *) palloc((serializedIdentityLen + 1) * sizeof(char) );
+						char *completeSerializedIdentity = (char *) palloc((serializedIdentityLen + 1) * sizeof(char) );
 						memcpy(completeSerializedIdentity, serializedIdentity, serializedIdentityLen);
 						completeSerializedIdentity[serializedIdentityLen] = '\0';
-						serializedIdentity = completeSerializedIdentity;
-						SetupProcessIdentity(serializedIdentity);
+						SetupProcessIdentity((const char*)completeSerializedIdentity);
 						pfree(completeSerializedIdentity);
 					}
 


### PR DESCRIPTION
"serializedIdentity" doesn't include '\0', which will cause core dump in SetupProcessIdentity() with using elog(DEBUG1).
So palloc a new string with '\0'.