### PR TITLE
HAWQ-488. Fix bug which cannot drop schema madlib and re-deploy MADlib in schema madlib

### DIFF
--- a/src/backend/commands/schemacmds.c
+++ b/src/backend/commands/schemacmds.c
@@ -280,8 +280,7 @@ RemoveSchema_internal(const char *schemaName, DropBehavior behavior,
 
 	/* Additional check to protect reserved schema names, exclude temp schema */
 	if (!is_internal && !allowSystemTableModsDDL &&
-		((IsReservedName(schemaName) && strncmp(schemaName, "pg_temp", 7) != 0) ||
-		 strcmp(schemaName, "madlib") == 0))
+	    (IsReservedName(schemaName) && strncmp(schemaName, "pg_temp", 7) != 0))
 	{
 		ereport(ERROR,
 				(errcode(ERRCODE_RESERVED_NAME),
@@ -378,8 +377,7 @@ RenameSchema(const char *oldname, const char *newname)
 		aclcheck_error(aclresult, ACL_KIND_DATABASE,
 					   get_database_name(MyDatabaseId));
 
-	if (!allowSystemTableModsDDL &&
-		(IsReservedName(oldname) || strcmp(oldname, "madlib") == 0))
+	if (!allowSystemTableModsDDL && IsReservedName(oldname))
 	{
 		ereport(ERROR,
 				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
@@ -387,8 +385,7 @@ RenameSchema(const char *oldname, const char *newname)
 				 errdetail("Schema %s is reserved for system use.", oldname)));
 	}
 
-	if (!allowSystemTableModsDDL &&
-		(IsReservedName(newname) || strcmp(newname, "madlib") == 0))
+	if (!allowSystemTableModsDDL && IsReservedName(newname))
 	{
 		ereport(ERROR,
 				(errcode(ERRCODE_RESERVED_NAME),
@@ -474,8 +471,7 @@ AlterSchemaOwner(const char *name, Oid newOwnerId)
 				(errcode(ERRCODE_UNDEFINED_SCHEMA),
 				 errmsg("schema \"%s\" does not exist", name)));
 
-	if (!allowSystemTableModsDDL &&
-		(IsReservedName(name) || strcmp(name, "madlib") == 0))
+	if (!allowSystemTableModsDDL && IsReservedName(name))
 	{
 		ereport(ERROR,
 				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -1080,9 +1080,7 @@ selectDumpableNamespace(NamespaceInfo *nsinfo)
 	else if (strncmp(nsinfo->dobj.name, "pg_", 3) == 0 ||
 			 strcmp(nsinfo->dobj.name, "information_schema") == 0 ||
 			 strcmp(nsinfo->dobj.name, "gp_toolkit") == 0 ||
-			 strcmp(nsinfo->dobj.name, "hawq_toolkit") == 0 ||
-			 strcmp(nsinfo->dobj.name, "madlib") == 0 ||
-			 strcmp(nsinfo->dobj.name, "retail_demo") == 0)
+			 strcmp(nsinfo->dobj.name, "hawq_toolkit") == 0)
 		nsinfo->dobj.dump = false;
 	else
 		nsinfo->dobj.dump = true;


### PR DESCRIPTION
The fix are in two folds:

1. Cannot drop schema madlib and re-deploy MADlib in schema madlib

2. pg_dump skip dumping content of schema madlib/retail_demo, which should be dumped by default actually. To skip dumping some schema, you can specify it in command line option of pg_dump. 