### PR TITLE
HAWQ-462. Adding dfs_address from pgfilespace along with fragment dat…

### DIFF
--- a/src/backend/access/external/hd_work_mgr.c
+++ b/src/backend/access/external/hd_work_mgr.c
@@ -769,11 +769,15 @@ make_allocation_output_string(List *segment_fragments)
 	initStringInfo(&segwork);
 	appendStringInfoString(&segwork, SEGWORK_PREFIX);
 	
-	/* Add dfs_address from pg_filespace to the segment data. Fixes HAWQ-462 *//* dfs_address from pg_filespace entry */
-	char* dfs_address = NULL;
-	get_hdfs_location_from_filespace(&dfs_address);
-	appendStringInfoString(&segwork, dfs_address);
-	appendStringInfoChar(&segwork, SEGWORK_DFS_DELIM);
+	if (enable_secure_filesystem)
+	{
+		/* Add dfs_address from pg_filespace to the segment data. Fixes HAWQ-462 *//* dfs_address from pg_filespace entry */
+		char* dfs_address = NULL;
+		get_hdfs_location_from_filespace(&dfs_address);
+		appendStringInfoString(&segwork, dfs_address);
+		appendStringInfoChar(&segwork, SEGWORK_DFS_DELIM);
+		pfree(dfs_address);
+	}
 
 	foreach(frag_cell, segment_fragments)
 	{
@@ -802,7 +806,6 @@ make_allocation_output_string(List *segment_fragments)
 		appendStringInfoString(&segwork, fragment_str.data);
 		pfree(fragment_str.data);
 	}
-	pfree(dfs_address);
 
 	return segwork.data;
 }

--- a/src/backend/access/external/hd_work_mgr.c
+++ b/src/backend/access/external/hd_work_mgr.c
@@ -768,6 +768,9 @@ make_allocation_output_string(List *segment_fragments)
 	initStringInfo(&segwork);
 	appendStringInfoString(&segwork, SEGWORK_PREFIX);
 	
+	char* dfs_address = NULL;
+	get_hdfs_location_from_filespace(&dfs_address);
+
 	foreach(frag_cell, segment_fragments)
 	{
 		AllocatedDataFragment *frag = (AllocatedDataFragment*)lfirst(frag_cell);
@@ -783,6 +786,10 @@ make_allocation_output_string(List *segment_fragments)
 		appendStringInfoChar(&fragment_str, SEGWORK_IN_PAIR_DELIM);
 		if (frag->fragment_md)
 			appendStringInfo(&fragment_str, "%s", frag->fragment_md);
+		/* Adding dfs_address from pg_filespace entry required for HAWQ-462 */
+		appendStringInfoChar(&fragment_str, SEGWORK_IN_PAIR_DELIM);
+		if (dfs_address)
+			appendStringInfo(&fragment_str, "%s", dfs_address);
 		if (frag->user_data)
 		{
 			appendStringInfoChar(&fragment_str, SEGWORK_IN_PAIR_DELIM);

--- a/src/backend/access/external/hd_work_mgr.c
+++ b/src/backend/access/external/hd_work_mgr.c
@@ -771,7 +771,7 @@ make_allocation_output_string(List *segment_fragments)
 	
 	if (enable_secure_filesystem)
 	{
-		/* Add dfs_address from pg_filespace to the segment data. Fixes HAWQ-462 *//* dfs_address from pg_filespace entry */
+		/* Add dfs_address from pg_filespace to the segment data. Fixes HAWQ-462 */
 		char* dfs_address = NULL;
 		get_hdfs_location_from_filespace(&dfs_address);
 		appendStringInfoString(&segwork, dfs_address);

--- a/src/backend/access/external/hd_work_mgr.c
+++ b/src/backend/access/external/hd_work_mgr.c
@@ -803,6 +803,7 @@ make_allocation_output_string(List *segment_fragments)
 		pfree(fragment_str.data);
 
 	}
+	pfree(dfs_address);
 
 	return segwork.data;
 }

--- a/src/backend/access/external/pxfuriparser.c
+++ b/src/backend/access/external/pxfuriparser.c
@@ -709,7 +709,15 @@ GPHDUri_parse_fragment(char* fragment, List* fragments)
 	*value_end = '\0';
 	fragment_data->index = pstrdup(value_start);
 	value_start = value_end + 1;
+
 	/* expect fragment metadata */
+	value_end = strchr(value_start, segwork_separator);
+	Assert(value_end != NULL);
+	*value_end = '\0';
+	fragment_data->fragment_md = pstrdup(value_start);
+	value_start = value_end + 1;
+
+	/* expect fragment dfs_address */
 	Assert(value_start);
 
 	/* check for user data */
@@ -719,7 +727,7 @@ GPHDUri_parse_fragment(char* fragment, List* fragments)
 		has_user_data = true;
 		*value_end = '\0';
 	}
-	fragment_data->fragment_md = pstrdup(value_start);
+	fragment_data->dfs_address = pstrdup(value_start);
 
 	/* read user data */
 	if (has_user_data)

--- a/src/backend/access/external/pxfuriparser.c
+++ b/src/backend/access/external/pxfuriparser.c
@@ -663,7 +663,7 @@ GPHDUri_parse_segwork(GPHDUri *uri, const char *uri_str)
 
 /*
  * Parsed a fragment string in the form:
- * <ip>@<port>@<index>[@user_data] - 192.168.1.1@1422@1[@user_data]
+ * <ip>@<port>@<index>@<fragment_md>@<dfs_address>[@user_data] - 192.168.1.1@1422@1@<fragment metadata>@hdfs://nameservice/hawq_default[@user_data]
  * to authority ip:port - 192.168.1.1:1422
  * to index - 1
  * user data is optional
@@ -752,6 +752,10 @@ GPHDUri_free_fragments(GPHDUri *uri)
 		pfree(data->authority);
 		pfree(data->index);
 		pfree(data->source_name);
+		pfree(data->fragment_md);
+		pfree(data->dfs_address);
+		if(data->user_data)
+			pfree(data->user_data);
 		pfree(data);
 	}
 	list_free(uri->fragments);

--- a/src/backend/access/external/pxfuriparser.c
+++ b/src/backend/access/external/pxfuriparser.c
@@ -644,7 +644,7 @@ GPHDUri_parse_segwork(GPHDUri *uri, const char *uri_str)
 	{
 		/* parse dfs address */
 		size_end = strchr(segwork, segwork_dfs_separator);
-		if(size_end != NULL)
+		if (size_end != NULL)
 		{
 			*size_end = '\0';
 			uri->dfs_address = pnstrdup(segwork, size_end-segwork);
@@ -760,7 +760,7 @@ GPHDUri_free_fragments(GPHDUri *uri)
 		pfree(data->index);
 		pfree(data->source_name);
 		pfree(data->fragment_md);
-		if(data->user_data)
+		if (data->user_data)
 			pfree(data->user_data);
 		pfree(data);
 	}

--- a/src/backend/access/external/pxfuriparser.c
+++ b/src/backend/access/external/pxfuriparser.c
@@ -623,7 +623,8 @@ GPHDUri_debug_print_segwork(GPHDUri *uri)
 
 /*
  * GPHDUri_parse_segwork parses the segwork section of the uri.
- * ...&segwork=dfs_address@<size>@<ip>@<port>@<index><size>@<ip>@<port>@<index><size>...
+ * ...&segwork=<dfs_address>@<size>@<ip>@<port>@<index><size>@<ip>@<port>@<index><size>...
+ * <dfs_address>@ is present only if secure
  */
 static void
 GPHDUri_parse_segwork(GPHDUri *uri, const char *uri_str)
@@ -639,13 +640,16 @@ GPHDUri_parse_segwork(GPHDUri *uri, const char *uri_str)
 		return;
 	segwork += strlen(segwork_substring);
 
-	/* parse dfs address */
-	size_end = strchr(segwork, segwork_dfs_separator);
-	if(size_end != NULL)
+	if (enable_secure_filesystem)
 	{
-		*size_end = '\0';
-		uri->dfs_address = pnstrdup(segwork, size_end-segwork);
-		segwork = size_end + 1;
+		/* parse dfs address */
+		size_end = strchr(segwork, segwork_dfs_separator);
+		if(size_end != NULL)
+		{
+			*size_end = '\0';
+			uri->dfs_address = pnstrdup(segwork, size_end-segwork);
+			segwork = size_end + 1;
+		}
 	}
 
 	/*

--- a/src/bin/gpfusion/gpbridgeapi.c
+++ b/src/bin/gpfusion/gpbridgeapi.c
@@ -52,7 +52,7 @@ void	append_churl_header_if_exists(gphadoop_context* context,
 void    set_current_fragment_headers(gphadoop_context* context);
 void	gpbridge_import_start(PG_FUNCTION_ARGS);
 void	gpbridge_export_start(PG_FUNCTION_ARGS);
-PxfServer* get_pxf_server(GPHDUri* gphd_uri, const Relation rel);
+PxfServer* get_pxf_server(gphadoop_context* context, const Relation rel);
 size_t	gpbridge_read(PG_FUNCTION_ARGS);
 size_t	gpbridge_write(PG_FUNCTION_ARGS);
 void	parse_gphd_uri(gphadoop_context* context, bool is_import, PG_FUNCTION_ARGS);
@@ -60,7 +60,7 @@ void	build_uri_for_read(gphadoop_context* context);
 void 	build_file_name_for_write(gphadoop_context* context);
 void 	build_uri_for_write(gphadoop_context* context, PxfServer* rest_server);
 size_t	fill_buffer(gphadoop_context* context, char* start, size_t size);
-void	add_delegation_token(PxfInputData *inputData);
+void	add_delegation_token(PxfInputData *inputData, char* dfs_address);
 void	free_token_resources(PxfInputData *inputData);
 
 /* Custom protocol entry point for read
@@ -181,8 +181,8 @@ void add_querydata_to_http_header(gphadoop_context* context, PG_FUNCTION_ARGS)
 	inputData.gphduri = context->gphd_uri;
 	inputData.rel = EXTPROTOCOL_GET_RELATION(fcinfo);
 	inputData.filterstr = serializePxfFilterQuals(EXTPROTOCOL_GET_SCANQUALS(fcinfo));
-	add_delegation_token(&inputData);
-	
+	add_delegation_token(&inputData, ((FragmentData*)lfirst(context->current_fragment))->dfs_address);
+
 	build_http_header(&inputData);
 	free_token_resources(&inputData);
 }
@@ -251,7 +251,7 @@ void gpbridge_export_start(PG_FUNCTION_ARGS)
 
 	/* get rest servers list and choose one */
 	Relation rel = EXTPROTOCOL_GET_RELATION(fcinfo);
-	PxfServer* rest_server = get_pxf_server(context->gphd_uri, rel);
+	PxfServer* rest_server = get_pxf_server(context, rel);
 
 	if (!rest_server)
 		ereport(ERROR,
@@ -290,8 +290,9 @@ static void init_client_context(ClientContext *client_context)
  * if pxf_isilon is true, there are no PXF instances on the datanodes.
  * TODO: add locality
  */
-PxfServer* get_pxf_server(GPHDUri* gphd_uri, const Relation rel)
+PxfServer* get_pxf_server(gphadoop_context* context, const Relation rel)
 {
+	GPHDUri* gphd_uri = context->gphd_uri;
 	ClientContext client_context; /* holds the communication info */
 	PxfInputData inputData = {0};
 	List	 	*rest_servers = NIL;
@@ -313,7 +314,6 @@ PxfServer* get_pxf_server(GPHDUri* gphd_uri, const Relation rel)
 	{
 		return NULL;
 	}
-
 	/*
 	 * Enrich the curl HTTP header
 	 */
@@ -321,7 +321,7 @@ PxfServer* get_pxf_server(GPHDUri* gphd_uri, const Relation rel)
 	inputData.gphduri = gphd_uri;
 	inputData.rel = rel;
 	inputData.filterstr = NULL; /* We do not supply filter data to the HTTP header */
-	add_delegation_token(&inputData);
+	add_delegation_token(&inputData, ((FragmentData*)lfirst(context->current_fragment))->dfs_address);
 	build_http_header(&inputData);
 
 	int port = atoi(gphd_uri->port);
@@ -505,20 +505,16 @@ size_t fill_buffer(gphadoop_context* context, char* start, size_t size)
  * Both regular and HA cases are handled the same way,
  * where a nameservice is parsed by HdfsParsePath()@fd.c
  */
-void add_delegation_token(PxfInputData *inputData)
+void add_delegation_token(PxfInputData *inputData, char *dfs_address)
 {
 	PxfHdfsTokenData *token = NULL;
-	char* dfs_address = NULL;
 
 	if (!enable_secure_filesystem)
 		return;
 
 	token = palloc0(sizeof(PxfHdfsTokenData));
 
-	get_hdfs_location_from_filespace(&dfs_address);
-
-    elog(DEBUG2, "locating token for %s", dfs_address);
-
+	elog(DEBUG2, "locating token for %s", dfs_address);
 	token->hdfs_token = find_filesystem_credential_with_uri(dfs_address);
 
 	if (token->hdfs_token == NULL)
@@ -526,8 +522,6 @@ void add_delegation_token(PxfInputData *inputData)
 	elog(DEBUG2, "Delegation token for %s found", dfs_address);
 
 	inputData->token = token;
-
-	pfree(dfs_address);
 }
 
 void free_token_resources(PxfInputData *inputData)

--- a/src/bin/gpfusion/gpbridgeapi.c
+++ b/src/bin/gpfusion/gpbridgeapi.c
@@ -292,7 +292,6 @@ static void init_client_context(ClientContext *client_context)
  */
 PxfServer* get_pxf_server(GPHDUri* gphd_uri, const Relation rel)
 {
-	GPHDUri* gphd_uri = context->gphd_uri;
 	ClientContext client_context; /* holds the communication info */
 	PxfInputData inputData = {0};
 	List	 	*rest_servers = NIL;

--- a/src/include/access/pxfuriparser.h
+++ b/src/include/access/pxfuriparser.h
@@ -45,7 +45,6 @@ typedef struct FragmentData
 	char	 *index;
 	char	 *source_name;
 	char	 *fragment_md;
-	char 	 *dfs_address;
 	char	 *user_data;
 } FragmentData;
 
@@ -77,6 +76,9 @@ typedef struct GPHDUri
 	 * NNHAConf  will also occupy <host> and <port> members
 	 */
 	NNHAConf        *ha_nodes;
+
+	/* dfs address from pg_filespace (optional) */
+	char			*dfs_address;
 } GPHDUri;
 
 GPHDUri	*parseGPHDUri(const char *uri_str);

--- a/src/include/access/pxfuriparser.h
+++ b/src/include/access/pxfuriparser.h
@@ -77,7 +77,7 @@ typedef struct GPHDUri
 	 */
 	NNHAConf        *ha_nodes;
 
-	/* dfs address from pg_filespace (optional) */
+	/* dfs address from pg_filespace (optional, required only if secure) */
 	char			*dfs_address;
 } GPHDUri;
 

--- a/src/include/access/pxfuriparser.h
+++ b/src/include/access/pxfuriparser.h
@@ -45,6 +45,7 @@ typedef struct FragmentData
 	char	 *index;
 	char	 *source_name;
 	char	 *fragment_md;
+	char 	 *dfs_address;
 	char	 *user_data;
 } FragmentData;
 


### PR DESCRIPTION
HAWQ-317 attempts to use the dfs_address from pg_filespace_entry. The segments (gpbridge) do not have catalog access. Adding the dfs_address along with the fragment data passed from the master to the segments. This fixes the pxf handling of secure isilon and hcatalog with or without HA