### PR TITLE
HAWQ-499: Fix IPv6 on OSX > 10.11

### DIFF
--- a/tools/bin/lib/hawqinit.sh
+++ b/tools/bin/lib/hawqinit.sh
@@ -190,7 +190,7 @@ LOAD_GP_TOOLKIT () {
 }
 
 get_master_ipv6_addresses() {
-    if [ "${distro_based_on}" = "Mac" ] && [ "${distro_version:0:5}" = "10.11" ]; then
+    if [ "${distro_based_on}" = "Mac" ]; then
         MASTER_IPV6_LOCAL_ADDRESS_ALL=(`${IFCONFIG} | ${GREP} inet6 | ${AWK} '{print $2}' | cut -d'%' -f1`)
     else
         MASTER_IPV6_LOCAL_ADDRESS_ALL=(`ip -6 address show |${GREP} inet6|${AWK} '{print $2}' |cut -d'/' -f1`)


### PR DESCRIPTION
On OSX < 10.11, IPv6 addresses are currently fetched with a command that doesn't exist on OSX.

The impact is that `hawq init cluster -a` **fails**:
`/usr/local/hawq/bin/lib/hawqinit.sh: line 196: ip: command not found`

This PR introduces a quick fix for that issue that is exactly the same as the corresponding fix to the IPv4 path.