### PR TITLE
HAWQ-502: Add --enable-orca flag to autoconf for building HAWQ with GPORCA

### DIFF
--- a/configure
+++ b/configure
@@ -731,9 +731,6 @@ with_perl
 with_tcl
 enable_thread_safety
 INCLUDES
-ORCA_DEPENDS_OPTIMIZER_VER
-ORCA_DEPENDS_LIBGPOS_VER
-ORCA_DEPENDS_XERCES_VER
 ORCA_DEPENDS_OBJDIR_DEFAULT
 ORCA_DEPENDS_DIR_INTER
 enable_orca
@@ -5523,32 +5520,8 @@ fi
 
 
 if test "$enable_orca" = yes ; then
-
-	if test -z "$ORCA_DEPENDS_DIR" ; then
-		as_fn_error $? "orca is enabled but ORCA_DEPENDS_DIR is not set" "$LINENO" 5]
-	fi
-
-	if test -z "$ORCA_OBJDIR_DEFAULT" ; then
-		as_fn_error $? "orca is enabled but ORCA_OBJDIR_DEFAULT is not set" "$LINENO" 5]
-	fi
-
-	if test -z "$XERCES_VER" ; then
-		as_fn_error $? "orca is enabled but XERCES_VER is not set" "$LINENO" 5]
-	fi
-
-	if test -z "$LIBGPOS_VER" ; then
-		as_fn_error $? "orca is enabled but LIBGPOS_VER is not set" "$LINENO" 5]
-	fi
-
-	if test -z "$OPTIMIZER_VER" ; then
-		as_fn_error $? "orca is enabled but OPTIMIZER_VER is not set" "$LINENO" 5]
-	fi
-
     ORCA_DEPENDS_DIR_INTER="$ORCA_DEPENDS_DIR"
     ORCA_DEPENDS_OBJDIR_DEFAULT="$ORCA_OBJDIR_DEFAULT"
-    ORCA_DEPENDS_XERCES_VER="$XERCES_VER"
-    ORCA_DEPENDS_LIBGPOS_VER="$LIBGPOS_VER"
-    ORCA_DEPENDS_OPTIMIZER_VER="$OPTIMIZER_VER"
 fi
 
 

--- a/configure.in
+++ b/configure.in
@@ -640,39 +640,12 @@ PGAC_ARG_BOOL(enable, orca, no, [  --enable-orca        enable Pivotal Query Opt
 AC_SUBST(enable_orca)
 
 if test "$enable_orca" = yes ; then
-
-	if test -z "$ORCA_DEPENDS_DIR" ; then
-		AC_MSG_ERROR([orca is enabled but ORCA_DEPENDS_DIR is not set])]
-	fi
-
-	if test -z "$ORCA_OBJDIR_DEFAULT" ; then
-		AC_MSG_ERROR([orca is enabled but ORCA_OBJDIR_DEFAULT is not set])]
-	fi
-	
-	if test -z "$XERCES_VER" ; then
-		AC_MSG_ERROR([orca is enabled but XERCES_VER is not set])]
-	fi
-	
-	if test -z "$LIBGPOS_VER" ; then
-		AC_MSG_ERROR([orca is enabled but LIBGPOS_VER is not set])]
-	fi
-	
-	if test -z "$OPTIMIZER_VER" ; then
-		AC_MSG_ERROR([orca is enabled but OPTIMIZER_VER is not set])]
-	fi
-
     ORCA_DEPENDS_DIR_INTER="$ORCA_DEPENDS_DIR"
     ORCA_DEPENDS_OBJDIR_DEFAULT="$ORCA_OBJDIR_DEFAULT"
-    ORCA_DEPENDS_XERCES_VER="$XERCES_VER"
-    ORCA_DEPENDS_LIBGPOS_VER="$LIBGPOS_VER"
-    ORCA_DEPENDS_OPTIMIZER_VER="$OPTIMIZER_VER"
 fi
 
 AC_SUBST(ORCA_DEPENDS_DIR_INTER)
 AC_SUBST(ORCA_DEPENDS_OBJDIR_DEFAULT)
-AC_SUBST(ORCA_DEPENDS_XERCES_VER)
-AC_SUBST(ORCA_DEPENDS_LIBGPOS_VER)
-AC_SUBST(ORCA_DEPENDS_OPTIMIZER_VER)
 
 #
 # Include directories

--- a/src/backend/Makefile
+++ b/src/backend/Makefile
@@ -52,7 +52,7 @@ LIBS := $(filter-out -lpgport, $(LIBS)) $(LDAP_LIBS_BE) $(CONNECTEMCLIB)
 
 # The backend doesn't need everything that's in LIBS, however
 LIBS := $(filter-out -lreadline -ledit -ltermcap -lncurses -lcurses, $(LIBS))
-LIBS := -lprotobuf -lboost_thread -lboost_system -lboost_date_time -lstdc++ -lhdfs3 -lgsasl -lxml2 $(LIBS)
+LIBS := -lprotobuf -lboost_thread-mt -lboost_system -lboost_date_time -lstdc++ -lhdfs3 -lgsasl -lxml2 $(LIBS)
 
 # adding orca libraries
 ifeq ($(enable_orca),yes)
@@ -213,9 +213,6 @@ ifeq ($(MAKE_DLL), true)
 	$(INSTALL_DATA) libpostgres.a '$(DESTDIR)$(libdir)/libpostgres.a'
 endif
 endif
-ifeq ($(enable_orca),yes)
-	$(MAKE) -C gpopt install
-endif
 	$(MAKE) -C catalog install-data
 	$(INSTALL_DATA) $(srcdir)/libpq/pg_hba.conf.sample '$(DESTDIR)$(datadir)/pg_hba.conf.sample'
 	$(INSTALL_DATA) $(srcdir)/libpq/pg_ident.conf.sample '$(DESTDIR)$(datadir)/pg_ident.conf.sample'
@@ -228,6 +225,9 @@ endif
 	${INSTALL_DATA} $(srcdir)/utils/misc/etc/slaves ${sysconfdir}
 	${INSTALL_DATA} $(srcdir)/utils/misc/etc/template-hawq-site.xml ${sysconfdir}
 	${INSTALL_DATA} $(srcdir)/utils/misc/etc/gpcheck.cnf ${sysconfdir}
+ifeq ($(enable_orca), yes)
+	$(MAKE) -C gpopt $@ INSTLOC=$(DESTDIR)$(libdir)
+endif
 
 install-bin: postgres $(POSTGRES_IMP) installdirs
 	$(INSTALL_PROGRAM) postgres$(X) '$(DESTDIR)$(bindir)/postgres$(X)'

--- a/src/backend/gpopt/gpopt.mk
+++ b/src/backend/gpopt/gpopt.mk
@@ -25,6 +25,7 @@
 
 UNAME = $(shell uname)
 UNAME_P = $(shell uname -p)
+UNAME_M = $(shell uname -m)
 ARCH_OS = GPOS_$(UNAME)
 ARCH_CPU = GPOS_$(UNAME_P)
 
@@ -41,8 +42,9 @@ ifeq "$(BLD_TYPE)" "opt"
 	GPOPT_flags = -O3 -fno-omit-frame-pointer -g3
 endif
 
-ARCH_BIT = GPOS_64BIT
-ifeq (Darwin, $(UNAME))
+ifeq (x86_64, $(UNAME_M))
+	ARCH_BIT = GPOS_64BIT
+else
 	ARCH_BIT = GPOS_32BIT
 endif
 
@@ -52,12 +54,18 @@ else
 	ARCH_FLAGS = -m64
 endif
 
+GREP_SED_VAR = $(top_builddir)/src/backend/gpopt/ivy.xml | sed -e 's|\(.*\)rev="\(.*\)"[ ]*conf\(.*\)|\2|'
+
+XERCES_VER  = $(shell grep "\"xerces-c\""   $(GREP_SED_VAR))
+LIBGPOS_VER = $(shell grep "\"libgpos\""    $(GREP_SED_VAR))
+OPTIMIZER_VER = $(shell grep "\"optimizer\""  $(GREP_SED_VAR))
+
 BLD_FLAGS = $(ARCH_FLAGS) -D$(ARCH_BIT) -D$(ARCH_CPU) -D$(ARCH_OS) $(GPOPT_flags)
 override CPPFLAGS := -fPIC $(CPPFLAGS)
 override CPPFLAGS := $(BLD_FLAGS)  $(CPPFLAGS)
-override CPPFLAGS := -DGPOS_VERSION=\"$(ORCA_DEPENDS_LIBGPOS_VER)\" $(CPPFLAGS)
-override CPPFLAGS := -DGPOPT_VERSION=\"$(ORCA_DEPENDS_OPTIMIZER_VER)\" $(CPPFLAGS)
-override CPPFLAGS := -DXERCES_VERSION=\"$(ORCA_DEPENDS_XERCES_VER)\" $(CPPFLAGS)
+override CPPFLAGS := -DGPOS_VERSION=\"$(LIBGPOS_VER)\" $(CPPFLAGS)
+override CPPFLAGS := -DGPOPT_VERSION=\"$(OPTIMIZER_VER)\" $(CPPFLAGS)
+override CPPFLAGS := -DXERCES_VERSION=\"$(XERCES_VER)\" $(CPPFLAGS)
 override CPPFLAGS := -I $(ORCA_DEPENDS_DIR_INTER)/include $(CPPFLAGS)
 override CPPFLAGS := -I $(ORCA_DEPENDS_DIR_INTER)/libgpos/include $(CPPFLAGS)
 override CPPFLAGS := -I $(ORCA_DEPENDS_DIR_INTER)/libgpopt/include $(CPPFLAGS)

--- a/src/bin/gpcheckhdfs/Makefile
+++ b/src/bin/gpcheckhdfs/Makefile
@@ -20,7 +20,7 @@ subdir = src/bin/gpcheckhdfs
 top_builddir = ../../..
 include $(top_builddir)/src/Makefile.global
 
-LIBS := -lprotobuf -lboost_thread -lboost_system -lboost_date_time -lstdc++ -lhdfs3 -lgsasl $(LIBS)
+LIBS := -lprotobuf -lboost_thread-mt -lboost_system -lboost_date_time -lstdc++ -lhdfs3 -lgsasl $(LIBS)
 
 OBJS=gpcheckhdfs.o 
 

--- a/src/bin/gpfilesystem/hdfs/Makefile
+++ b/src/bin/gpfilesystem/hdfs/Makefile
@@ -24,7 +24,7 @@ OBJS       = gpfshdfs.o
 
 PG_CPPFLAGS = -I$(libpq_srcdir)
 PG_LIBS = $(libpq_pgport)
-SHLIB_LINK = -lprotobuf -lboost_thread -lboost_system -lboost_date_time -lstdc++ -lhdfs3
+SHLIB_LINK = -lprotobuf -lboost_thread-mt -lboost_system -lboost_date_time -lstdc++ -lhdfs3
 
 ifdef USE_PGXS
 PGXS := $(shell pg_config --pgxs)


### PR DESCRIPTION
This change adds support for the `--enable-orca` flag for autoconf.  This includes:
- gpopt interface change
- Change `boost_thread` to use `boost_thread_mt` on OSX
- Update `ivy.xml` version detection

Small changes to two CPP files are necessary to get this to actually compile with the latest ORCA.  Due to build infrastructure issues between the `make sync_tools` dependency workflow and the newer workflow, those changes were temporarily reverted by commit c398ceb2 (see HAWQ-404).  This PR can be reviewed on its own, but shouldn't actually be merged to master until those issues are resolved and the aforementioned reverted change is put back in.