### PR TITLE
HAWQ-504. Crash when WALSendServer and standby connection timeout

### DIFF
--- a/src/backend/postmaster/walsendserver.c
+++ b/src/backend/postmaster/walsendserver.c
@@ -324,6 +324,12 @@ void
 WalSendServerGetClientTimeout(struct timeval *timeout)
 {
 	ServiceGetClientTimeout(&WalSendServer_ServiceConfig, timeout);
+
+	// Here we need to set client timeout greater than the server timeout, otherwise this timeout
+	// will be triggered before the connection between WalSendServer and standby timeout trigger,
+	// it will lead to the QD process report FATAL, and all processes on master restart.
+	timeout->tv_sec *= 2;
+	timeout->tv_usec *= 2;
 }
 
 /*


### PR DESCRIPTION
Here just fixed the timeout problem. The auto re-sync standby functionality will be implemented as a feature in the future.