### PR TITLE
HAWQ-510. Change cdbProc->listenerAddr to "localhost" on entryDB when…

### DIFF
--- a/src/backend/cdb/motion/ic_common.c
+++ b/src/backend/cdb/motion/ic_common.c
@@ -1012,6 +1012,11 @@ void adjustMasterRouting(Slice *recvSlice)
 		CdbProcess *cdbProc = (CdbProcess *)lfirst(lc);
 
 		if (cdbProc->listenerAddr == NULL)
-			cdbProc->listenerAddr = pstrdup(MyProcPort->remote_host);
+		{
+			if (strcmp(MyProcPort->remote_host, "[local]") == 0)
+			    cdbProc->listenerAddr = pstrdup("localhost");
+			else
+			  cdbProc->listenerAddr = pstrdup(MyProcPort->remote_host);
+		}
 	}
 }


### PR DESCRIPTION
HAWQ-510. Change cdbProc->listenerAddr to "localhost" on entryDB when it tries to parse connection from QD, instead of direct using "[local]"