### PR TITLE
HAWQ-528. Reset gp_connections_per_thread for dispatcher guc range

### DIFF
--- a/src/backend/cdb/dispatcher.c
+++ b/src/backend/cdb/dispatcher.c
@@ -1656,12 +1656,7 @@ dispatcher_compute_threads_num(DispatchData *data)
 	/* TODO: decide the groups(threads) number. */
 	if (query_executors_num == 0)
 		threads_num = 1;
-	if (executors_num_per_thread == 0)
-	{
-		threads_num = query_executors_num;
-		executors_num_per_thread = 1;
-	}
-	else if (executors_num_per_thread > query_executors_num)
+	if (executors_num_per_thread > query_executors_num)
 		threads_num = 1;
 	else
 		threads_num = (query_executors_num / executors_num_per_thread) + ((query_executors_num % executors_num_per_thread == 0) ? 0 : 1); 

--- a/src/backend/cdb/dispatcher_mgt.c
+++ b/src/backend/cdb/dispatcher_mgt.c
@@ -449,14 +449,7 @@ dispmgt_create_concurrent_connect_state(List *executors, int executors_num_per_t
 	int		i, j;
 
 	/* Compute threads_num */
-	if (executors_num == 0)
-		return NIL;
-	else if (executors_num_per_thread == 0)
-	{
-		threads_num = executors_num;
-		executors_num_per_thread = 1;
-	}
-	else if (executors_num_per_thread > executors_num)
+	if (executors_num_per_thread > executors_num)
 		threads_num = 1;
 	else
 		threads_num = (executors_num / executors_num_per_thread) + ((executors_num % executors_num_per_thread == 0) ? 0 : 1); 

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -5647,7 +5647,7 @@ static struct config_int ConfigureNamesInt[] =
 			GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
 		},
 		&gp_connections_per_thread,
-		512, 0, INT_MAX, assign_gp_connections_per_thread, show_gp_connections_per_thread
+		512, 1, INT_MAX, assign_gp_connections_per_thread, show_gp_connections_per_thread
 	},
 
 	{


### PR DESCRIPTION
Reset gp_connections_per_thread for dispatcher guc range from 1 to 512, 0 is invalid.