### PR TITLE
HAWQ-544. Fixed assertion failure in AdvanceMemoryAccountingGeneration

### DIFF
--- a/src/backend/utils/mmgr/memaccounting.c
+++ b/src/backend/utils/mmgr/memaccounting.c
@@ -1170,6 +1170,8 @@ AdvanceMemoryAccountingGeneration()
 	{
 		/* Overflow happened, we need to adjust for generation */
 		elog(LOG, "Migrating all allocated memory chunks to generation %u due to generation counter exhaustion and QE recycling", MemoryAccountingCurrentGeneration);
+		/* elog might have allocated more memory and we need to record that in current RolloverMemoryAccount->peak */
+		RolloverMemoryAccount->peak = Max(RolloverMemoryAccount->peak, MemoryAccountingPeakBalance);
 		HandleMemoryAccountingGenerationOverflow(TopMemoryContext);
 	}
 


### PR DESCRIPTION
Fixed assertion failure in AdvanceMemoryAccountingGeneration when we have a generation overflow

In function AdvanceMemoryAccountingGeneration, we first assign "RolloverMemoryAccount->peak = Max(RolloverMemoryAccount->peak, MemoryAccountingPeakBalance);", then we call elog if there is a generation overflow. Then we assert "Assert(RolloverMemoryAccount->peak >= MemoryAccountingPeakBalance);".

If elog allocates additional memory, then this causes the assertion to fail.


Signed-off-by: George Caragea <caragea.work@gmail.com>