### PR TITLE
HAWQ-550. Automatically clean up records in gp_configuration_history longer than a GUC

### DIFF
--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -297,6 +297,7 @@ int    seg_addr_port;
 char  *dfs_url;
 char  *master_directory;
 char  *seg_directory;
+int    segment_history_keep_period;
 
 /* HAWQ 2.0 resource manager GUCs */
 int    rm_master_port;

--- a/src/backend/resourcemanager/include/resourcepool.h
+++ b/src/backend/resourcemanager/include/resourcepool.h
@@ -670,6 +670,9 @@ void adjustMemoryCoreValue(uint32_t *memorymb, uint32_t *core);
 /* Clean up gp_segment_configuration */
 void cleanup_segment_config(void);
 
+/* Clean up gp_configuration_history */
+void cleanup_segment_config_history(void);
+
 #define SEG_STATUS_DESCRIPTION_UP "segment is up"
 /* update a segment's status in gp_segment_configuration table */
 void update_segment_status(int32_t id, char status, char* description);

--- a/src/backend/resourcemanager/requesthandler_RMSEG.c
+++ b/src/backend/resourcemanager/requesthandler_RMSEG.c
@@ -307,7 +307,8 @@ bool handleRMSEGRequestRUAlive(void **arg)
 		{
 			if (retry == 0)
 			{
-				elog(LOG, "Segment's postmaster is down, PQconnectdb result : %d, %s",
+				elog(LOG, "Segment receives RUAlive from master "
+						  "and postmaster is down, PQconnectdb result : %d, %s",
 						  libpqres,
 						  PQerrorMessage(conn));
 				/* Don't send IMAlive anymore */
@@ -322,7 +323,7 @@ bool handleRMSEGRequestRUAlive(void **arg)
 		}
 		else
 		{
-			elog(DEBUG3, "Segment's postmaster is healthy.");
+			elog(LOG, "Segment receives RUAlive from master and postmaster is healthy.");
 			break;
 		}
 	}

--- a/src/backend/resourcemanager/resourcemanager.c
+++ b/src/backend/resourcemanager/resourcemanager.c
@@ -479,6 +479,8 @@ int ResManagerMainServer2ndPhase(void)
 	/* Clean up gp_segment_configuration table. */
 	cleanup_segment_config();
 
+	cleanup_segment_config_history();
+
 	/*
 	 * register itself into gp_segment_configuration table
 	 * master internal id is 0, segment id starts from 1

--- a/src/backend/resourcemanager/resourcepool.c
+++ b/src/backend/resourcemanager/resourcepool.c
@@ -473,7 +473,7 @@ cleanup:
 
 /*
  * Remove records in gp_configuration_history that are longer than
- * a period defined in GUC, the default values is 30 days.
+ * a period defined in GUC, the default values is 365 days.
  */
 void cleanup_segment_config_history(){
 	int	libpqres = CONNECTION_OK;
@@ -531,7 +531,8 @@ void cleanup_segment_config_history(){
 		goto cleanup;
 	}
 
-	elog(LOG, "Cleanup segment configuration history catalog table successfully!");
+	elog(LOG, "Cleanup segment configuration history catalog table successfully, "
+			  "keep period: recent %d days.", segment_history_keep_period);
 
 cleanup:
 	if(sql)

--- a/src/backend/resourcemanager/resourcepool.c
+++ b/src/backend/resourcemanager/resourcepool.c
@@ -28,6 +28,7 @@
 #include "gp-libpq-int.h"
 #include "utils/builtins.h"
 #include "catalog/pg_proc.h"
+#include "cdb/cdbvars.h"
 
 void addSegResourceAvailIndex(SegResource segres);
 void addSegResourceAllocIndex(SegResource segres);
@@ -471,6 +472,76 @@ cleanup:
 }
 
 /*
+ * Remove records in gp_configuration_history that are longer than
+ * a period defined in GUC, the default values is 30 days.
+ */
+void cleanup_segment_config_history(){
+	int	libpqres = CONNECTION_OK;
+	PGconn *conn = NULL;
+	char conninfo[512];
+	PQExpBuffer sql = NULL;
+	PGresult* result = NULL;
+
+	sprintf(conninfo, "options='-c gp_session_role=UTILITY -c allow_system_table_mods=dml' "
+			"dbname=template1 port=%d connect_timeout=%d", master_addr_port, CONNECT_TIMEOUT);
+	conn = PQconnectdb(conninfo);
+	if ((libpqres = PQstatus(conn)) != CONNECTION_OK)
+	{
+		elog(WARNING, "Fail to connect database when cleanup "
+				      "segment history catalog table, error code: %d, %s",
+				      libpqres,
+				      PQerrorMessage(conn));
+		PQfinish(conn);
+		return;
+	}
+
+	result = PQexec(conn, "BEGIN");
+	if (!result || PQresultStatus(result) != PGRES_COMMAND_OK)
+	{
+		elog(WARNING, "Fail to run SQL: %s when cleanup "
+				      "segment history catalog table, reason : %s",
+				      "BEGIN",
+				      PQresultErrorMessage(result));
+		goto cleanup;
+	}
+	PQclear(result);
+
+	sql = createPQExpBuffer();
+	appendPQExpBuffer(sql,"DELETE FROM gp_configuration_history WHERE "
+						  "current_timestamp - time > interval '%d days'",
+						  segment_history_keep_period);
+	result = PQexec(conn, sql->data);
+	if (!result || PQresultStatus(result) != PGRES_COMMAND_OK)
+	{
+		elog(WARNING, "Fail to run SQL: %s when cleanup "
+				      "segment history catalog table, reason : %s",
+				      sql->data,
+				      PQresultErrorMessage(result));
+		goto cleanup;
+	}
+	PQclear(result);
+
+	result = PQexec(conn, "COMMIT");
+	if (!result || PQresultStatus(result) != PGRES_COMMAND_OK)
+	{
+		elog(WARNING, "Fail to run SQL: %s when cleanup "
+				      "segment history catalog table, reason : %s",
+				      "COMMIT",
+				      PQresultErrorMessage(result));
+		goto cleanup;
+	}
+
+	elog(LOG, "Cleanup segment configuration history catalog table successfully!");
+
+cleanup:
+	if(sql)
+		destroyPQExpBuffer(sql);
+	if(result)
+		PQclear(result);
+	PQfinish(conn);
+}
+
+/*
  * Remove all entries in gp_configuration_history.
  *
  * gp_remove_segment_history()
@@ -500,7 +571,7 @@ gp_remove_segment_history(PG_FUNCTION_ARGS)
 	if ((libpqres = PQstatus(conn)) != CONNECTION_OK)
 	{
 		elog(WARNING, "Fail to connect database when cleanup "
-					  "segment configuration catalog table, error code: %d, %s",
+					  "segment history catalog table, error code: %d, %s",
 					  libpqres,
 					  PQerrorMessage(conn));
 		PQfinish(conn);

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -6269,7 +6269,7 @@ static struct config_int ConfigureNamesInt[] =
                     NULL
             },
             &segment_history_keep_period,
-            30, 1, INT_MAX, NULL, NULL
+            365, 1, INT_MAX, NULL, NULL
     },
 
     {

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -6264,6 +6264,15 @@ static struct config_int ConfigureNamesInt[] =
     },
 
     {
+            {"hawq_segment_history_keep_period", PGC_POSTMASTER, RESOURCES_MGM,
+                    gettext_noop("period of storing rows in segment_configuration_history"),
+                    NULL
+            },
+            &segment_history_keep_period,
+            30, 1, INT_MAX, NULL, NULL
+    },
+
+    {
             {"hawq_rm_master_domain_port", PGC_POSTMASTER, RESOURCES_MGM,
                     gettext_noop("resource manager master domain socket port number"),
                     NULL

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -1148,6 +1148,7 @@ extern int     seg_addr_port;
 extern char   *dfs_url;
 extern char   *master_directory;
 extern char   *seg_directory;
+extern int    segment_history_keep_period;
 
 /* HAWQ 2.0 resource manager GUCs */
 extern int	   rm_master_domain_port;


### PR DESCRIPTION
HAWQ-550. Automatically clean up records in gp_configuration_history longer than a GUC value.
default is 365 days.
Please review. 