### PR TITLE
HAWQ-559. Fix QD hang when QE is immediately killed after created

### DIFF
--- a/src/backend/cdb/dispatcher.c
+++ b/src/backend/cdb/dispatcher.c
@@ -1240,6 +1240,8 @@ dispatch_run(DispatchData *data)
 	 * Only after we have the executors, we can serialize the state. Or we
 	 * don't know the executor listening address.
 	 */
+	CHECK_FOR_INTERRUPTS();
+
 	dispatcher_serialize_state(data);
 	dispatcher_serialize_query_resource(data);
 	dispatcher_set_state_run(data);


### PR DESCRIPTION
Add errcode for executor after QD thread detects QE is no longer exists in function executormgr_is_dispatchable. 
