### PR TITLE
HAWQ-575. QE core dumped when report "Resume interrupt holdoff count is bad (0)…

### DIFF
--- a/src/backend/executor/execHHashagg.c
+++ b/src/backend/executor/execHHashagg.c
@@ -1182,7 +1182,7 @@ closeSpillFile(AggState *aggstate, SpillSet *spill_set, int file_no)
 	if (spill_file->file_info &&
 		spill_file->file_info->wfile != NULL)
 	{
-		workfile_mgr_close_file(hashtable->work_set, spill_file->file_info->wfile);
+		workfile_mgr_close_file(hashtable->work_set, spill_file->file_info->wfile, true);
 		spill_file->file_info->wfile = NULL;
 		freedspace += (BATCHFILE_METADATA - sizeof(BatchFileInfo));
 		
@@ -1516,7 +1516,7 @@ agg_hash_close_state_file(HashAggTable *hashtable)
 {
 	if (hashtable->state_file != NULL)
 	{
-		workfile_mgr_close_file(hashtable->work_set, hashtable->state_file);
+		workfile_mgr_close_file(hashtable->work_set, hashtable->state_file, true);
 		hashtable->state_file = NULL;
 	}
 }

--- a/src/backend/executor/execWorkfile.c
+++ b/src/backend/executor/execWorkfile.c
@@ -440,7 +440,7 @@ ExecWorkFile_Tell64(ExecWorkFile *workfile)
  *    Returns the actual size of the file on disk upon closing
  */
 int64
-ExecWorkFile_Close(ExecWorkFile *workfile)
+ExecWorkFile_Close(ExecWorkFile *workfile, bool canReportError)
 {
 	Assert(workfile != NULL);
 	bfz_t *bfz_file = NULL;
@@ -463,7 +463,7 @@ ExecWorkFile_Close(ExecWorkFile *workfile)
 				ExecWorkFile_AdjustBFZSize(workfile, file_size);
 			}
 
-			bfz_close(bfz_file, true, true);
+			bfz_close(bfz_file, true, canReportError);
 			break;
 		default:
 			insist_log(false, "invalid work file type: %d", workfile->fileType);

--- a/src/backend/executor/nodeHash.c
+++ b/src/backend/executor/nodeHash.c
@@ -698,13 +698,13 @@ ExecHashTableDestroy(HashState *hashState, HashJoinTable hashtable)
 
 		if (batch->innerside.workfile != NULL)
 		{
-			workfile_mgr_close_file(hashtable->work_set, batch->innerside.workfile);
+			workfile_mgr_close_file(hashtable->work_set, batch->innerside.workfile, true);
 			batch->innerside.workfile = NULL;
 		}
 
 		if (batch->outerside.workfile != NULL)
 		{
-			workfile_mgr_close_file(hashtable->work_set, batch->outerside.workfile);
+			workfile_mgr_close_file(hashtable->work_set, batch->outerside.workfile, true);
 			batch->outerside.workfile = NULL;
 		}
 	}
@@ -712,7 +712,7 @@ ExecHashTableDestroy(HashState *hashState, HashJoinTable hashtable)
 	/* Close state file as well */
 	if (hashtable->state_file != NULL)
 	{
-		workfile_mgr_close_file(hashtable->work_set, hashtable->state_file);
+		workfile_mgr_close_file(hashtable->work_set, hashtable->state_file, true);
 		hashtable->state_file = NULL;
 	}
 

--- a/src/backend/executor/nodeHashjoin.c
+++ b/src/backend/executor/nodeHashjoin.c
@@ -962,7 +962,7 @@ start_over:
 			batch = hashtable->batches[curbatch];
 			if (batch->outerside.workfile != NULL)
 			{
-				workfile_mgr_close_file(hashtable->work_set, batch->outerside.workfile);
+				workfile_mgr_close_file(hashtable->work_set, batch->outerside.workfile, true);
 			}
 			batch->outerside.workfile = NULL;
 		}
@@ -1006,13 +1006,13 @@ start_over:
 		/* Release associated temp files right away. */
 		if (batch->innerside.workfile != NULL)
 		{
-			workfile_mgr_close_file(hashtable->work_set, batch->innerside.workfile);
+			workfile_mgr_close_file(hashtable->work_set, batch->innerside.workfile, true);
 		}
 		batch->innerside.workfile = NULL;
 		
 		if (batch->outerside.workfile != NULL)
 		{
-			workfile_mgr_close_file(hashtable->work_set, batch->outerside.workfile);
+			workfile_mgr_close_file(hashtable->work_set, batch->outerside.workfile, true);
 		}
 		batch->outerside.workfile = NULL;
 
@@ -1083,7 +1083,7 @@ start_over:
 				hashtable->stats->batchstats[curbatch].innerfilesize =
 						ExecWorkFile_Tell64(hashtable->batches[curbatch]->innerside.workfile);
 			}
-			workfile_mgr_close_file(hashtable->work_set, batch->innerside.workfile);
+			workfile_mgr_close_file(hashtable->work_set, batch->innerside.workfile, true);
 			batch->innerside.workfile = NULL;
 		}
     }
@@ -1577,7 +1577,7 @@ SaveBatchFileNameAndClose(HashJoinTable hashtable, ExecWorkFile *workfile)
 	{
 		batch_file_name = pstrdup(ExecWorkFile_GetFileName(workfile));
 		free_name = true;
-		workfile_mgr_close_file(hashtable->work_set, workfile);
+		workfile_mgr_close_file(hashtable->work_set, workfile, true);
 	}
 
 	bool res = WriteStringWorkFile(hashtable->state_file, batch_file_name);
@@ -1662,7 +1662,7 @@ ExecHashJoinSaveState(HashJoinTable hashtable)
 		hashtable->batches[i]->outerside.workfile = NULL;
 	}
 
-	workfile_mgr_close_file(hashtable->work_set, hashtable->state_file);
+	workfile_mgr_close_file(hashtable->work_set, hashtable->state_file, true);
 	hashtable->state_file = NULL;
 }
 

--- a/src/backend/utils/sort/logtape.c
+++ b/src/backend/utils/sort/logtape.c
@@ -426,7 +426,7 @@ void
 LogicalTapeSetClose(LogicalTapeSet *lts, workfile_set *workset)
 {
 	Assert(lts != NULL);
-	workfile_mgr_close_file(workset, lts->pfile);
+	workfile_mgr_close_file(workset, lts->pfile, true);
 	if(lts->freeBlocks)
 		pfree(lts->freeBlocks);
 	pfree(lts);

--- a/src/backend/utils/sort/tuplesort.c
+++ b/src/backend/utils/sort/tuplesort.c
@@ -918,7 +918,7 @@ tuplesort_end(Tuplesortstate *state)
 
 		if (state->pfile_rwfile_state)
         {
-			workfile_mgr_close_file(NULL /* workset */, state->pfile_rwfile_state);
+			workfile_mgr_close_file(NULL /* workset */, state->pfile_rwfile_state, true);
         }
 	}
 

--- a/src/backend/utils/sort/tuplesort_mk.c
+++ b/src/backend/utils/sort/tuplesort_mk.c
@@ -982,7 +982,7 @@ tuplesort_end_mk(Tuplesortstate_mk *state)
 
         if (state->tapeset_state_file)
         {
-        	workfile_mgr_close_file(state->work_set, state->tapeset_state_file);
+        	workfile_mgr_close_file(state->work_set, state->tapeset_state_file, true);
         }
     }
 

--- a/src/backend/utils/sort/tuplestorenew.c
+++ b/src/backend/utils/sort/tuplestorenew.c
@@ -614,7 +614,7 @@ static NTupleStorePage *nts_load_prev_page(NTupleStore *store, NTupleStorePage *
 	}
 }
 
-static void ntuplestore_cleanup(NTupleStore *ts, bool fNormal)
+static void ntuplestore_cleanup(NTupleStore *ts, bool fNormal, bool canReportError)
 {
 	NTupleStorePage *p = ts->first_page;
 
@@ -651,12 +651,12 @@ static void ntuplestore_cleanup(NTupleStore *ts, bool fNormal)
 
 	if(ts->pfile)
 	{
-		workfile_mgr_close_file(ts->work_set, ts->pfile);
+		workfile_mgr_close_file(ts->work_set, ts->pfile, canReportError);
 		ts->pfile = NULL;
 	}
 	if(ts->plobfile)
 	{
-		workfile_mgr_close_file(ts->work_set, ts->plobfile);
+		workfile_mgr_close_file(ts->work_set, ts->plobfile, canReportError);
 		ts->plobfile = NULL;
 	}
 
@@ -671,7 +671,7 @@ static void ntuplestore_cleanup(NTupleStore *ts, bool fNormal)
 
 static void XCallBack_NTS(XactEvent event, void *nts)
 {
-	ntuplestore_cleanup((NTupleStore *)nts, false);
+	ntuplestore_cleanup((NTupleStore *)nts, false, (event!=XACT_EVENT_ABORT));
 }
 
 NTupleStore *
@@ -927,7 +927,7 @@ void
 ntuplestore_destroy(NTupleStore *ts)
 {
 	UnregisterXactCallbackOnce(XCallBack_NTS, (void *) ts);
-	ntuplestore_cleanup(ts, true);
+	ntuplestore_cleanup(ts, true, true);
 }
 
 NTupleStoreAccessor* 

--- a/src/backend/utils/workfile_manager/workfile_file.c
+++ b/src/backend/utils/workfile_manager/workfile_file.c
@@ -122,7 +122,7 @@ workfile_mgr_open_filename(workfile_set *work_set, const char *file_name)
  *  Returns the actual size of the file on disk in bytes upon closing
  */
 int64
-workfile_mgr_close_file(workfile_set *work_set, ExecWorkFile *file)
+workfile_mgr_close_file(workfile_set *work_set, ExecWorkFile *file, bool canReportError)
 {
 	Assert(NULL != file);
 
@@ -133,7 +133,7 @@ workfile_mgr_close_file(workfile_set *work_set, ExecWorkFile *file)
 	int64 size = 0;
 	PG_TRY();
 	{
-		size = ExecWorkFile_Close(file);
+		size = ExecWorkFile_Close(file, canReportError);
 	}
 	PG_CATCH();
 	{

--- a/src/backend/utils/workfile_manager/workfile_mgr.c
+++ b/src/backend/utils/workfile_manager/workfile_mgr.c
@@ -1017,7 +1017,7 @@ workfile_mgr_save_plan(workfile_set *work_set, workfile_set_plan *sf_plan)
 		workfile_mgr_report_error();
 	}
 
-	workfile_mgr_close_file(work_set, plan_file);
+	workfile_mgr_close_file(work_set, plan_file, true);
 }
 
 /*
@@ -1113,7 +1113,7 @@ workfile_mgr_compare_plan(workfile_set *work_set, workfile_set_plan *sf_plan)
 		plan_offset += size_read;
 	}
 
-	workfile_mgr_close_file(work_set, plan_file);
+	workfile_mgr_close_file(work_set, plan_file, true);
 	return match;
 }
 

--- a/src/backend/utils/workfile_manager/workfile_mgr_test.c
+++ b/src/backend/utils/workfile_manager/workfile_mgr_test.c
@@ -1331,7 +1331,7 @@ execworkfile_buffile_test(void)
 	unit_test_result(success && expected_size == WorkfileSegspace_GetSize() - initial_diskspace);
 
 	elog(LOG, "Running sub-test: Closing EWF/Buffile");
-	final_size = ExecWorkFile_Close(ewf);
+	final_size = ExecWorkFile_Close(ewf, true);
 	unit_test_result(final_size == expected_size);
 
 	elog(LOG, "Running sub-test: Opening existing EWF/Buffile and checking size");
@@ -1354,7 +1354,7 @@ execworkfile_buffile_test(void)
 	pfree(buf);
 
 	elog(LOG, "Running sub-test: Closing EWF/Buffile");
-	final_size = ExecWorkFile_Close(ewf);
+	final_size = ExecWorkFile_Close(ewf, true);
 
 	unit_test_result(final_size == current_size);
 
@@ -1449,7 +1449,7 @@ execworkfile_bfz_zlib_test(void)
 	unit_test_result(true);
 
 	elog(LOG, "Running sub-test: Closing EWF/BFZ");
-	final_size = ExecWorkFile_Close(ewf);
+	final_size = ExecWorkFile_Close(ewf, true);
 
 	unit_test_result(final_size < expected_size);
 
@@ -1472,7 +1472,7 @@ execworkfile_bfz_zlib_test(void)
 	pfree(buf);
 
 	elog(LOG, "Running sub-test: Closing EWF/BFZ");
-	final_size = ExecWorkFile_Close(ewf);
+	final_size = ExecWorkFile_Close(ewf, true);
 
 	unit_test_result(final_size == current_size);
 
@@ -1568,7 +1568,7 @@ execworkfile_bfz_uncompressed_test(void)
 	unit_test_result(true);
 
 	elog(LOG, "Running sub-test: Closing EWF/BFZ");
-	final_size = ExecWorkFile_Close(ewf);
+	final_size = ExecWorkFile_Close(ewf, true);
 
 	/* For uncompressed files, final file may contain checksums, which makes it
 	 * larger than expected */
@@ -1593,7 +1593,7 @@ execworkfile_bfz_uncompressed_test(void)
 	pfree(buf);
 
 	elog(LOG, "Running sub-test: Closing EWF/BFZ");
-	final_size = ExecWorkFile_Close(ewf);
+	final_size = ExecWorkFile_Close(ewf, true);
 
 	unit_test_result(final_size == current_size);
 
@@ -2110,7 +2110,7 @@ execworkfile_create_one_MB_file(void)
 
 	elog(LOG, "Running sub-test: Closing file %s", filename->data);
 
-	int64 final_size = workfile_mgr_close_file(NULL /* work_set */, ewf);
+	int64 final_size = workfile_mgr_close_file(NULL /* work_set */, ewf, true);
 
 	/* Verify correct size of the created file */
 	unit_test_result (final_size == (int64)nchars*sizeof(char) );
@@ -2303,7 +2303,7 @@ workfile_create_and_individual_cleanup(void)
 
 	for (int i=0; i < TEST_MAX_NUM_WORKFILES; i++)
 	{
-		workfile_mgr_close_file(work_set, ewfiles[i]);
+		workfile_mgr_close_file(work_set, ewfiles[i], true);
 
 		if (i % 1000 == 999)
 		{

--- a/src/include/executor/execWorkfile.h
+++ b/src/include/executor/execWorkfile.h
@@ -153,7 +153,7 @@ ExecWorkFile_Tell64(ExecWorkFile *workfile);
  *    close the work file, and release the space.
  */
 int64
-ExecWorkFile_Close(ExecWorkFile *workfile);
+ExecWorkFile_Close(ExecWorkFile *workfile, bool canReportError);
 
 int ExecWorkFile_Seek(ExecWorkFile *workfile, uint64 offset, int whence);
 void ExecWorkFile_Flush(ExecWorkFile *workfile);

--- a/src/include/utils/workfile_mgr.h
+++ b/src/include/utils/workfile_mgr.h
@@ -195,7 +195,7 @@ ExecWorkFile *workfile_mgr_create_file(workfile_set *work_set);
 ExecWorkFile *workfile_mgr_create_fileno(workfile_set *work_set, uint32 file_no);
 ExecWorkFile *workfile_mgr_open_fileno(workfile_set *work_set, uint32 file_no);
 ExecWorkFile *workfile_mgr_open_filename(workfile_set *work_set, const char *file_name);
-int64 workfile_mgr_close_file(workfile_set *work_set, ExecWorkFile *file);
+int64 workfile_mgr_close_file(workfile_set *work_set, ExecWorkFile *file, bool canReportError);
 
 /* Workfile diskspace operations */
 void WorkfileDiskspace_Init(void);


### PR DESCRIPTION
… (xact.c:2907)"

The root cause is: 
AT AbortTransaction(),  we will disable interrupt processing by calling  "HOLD_INTERRUPTS();" and "RESUME_INTERRUPTS();", these 2 functions will change "InterruptHoldoffCount" to indicate that we are in such a section. When in such a section, we can't report error, because it will set  InterruptHoldoffCount to 0. 

On the other side, from the user demand, when transaction abort, we can't report error if temp file cannot be deleted, we need to just report warning. 