### PR TITLE
HAWQ-573. Fix Resource leak when cancel a query during calling a RPC …

### DIFF
--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -3518,6 +3518,8 @@ ProcessInterrupts(void)
 
 		QueryCancelPending = false;
 			ImmediateInterruptOK = false;	/* not idle anymore */
+			/* clean up the resource as it cancel the query. */
+			cleanupQD2RMComm();
 			DisableNotifyInterrupt();
 			DisableCatchupInterrupt();
 			if (Gp_role == GP_ROLE_EXECUTE)

--- a/src/backend/tcop/pquery.c
+++ b/src/backend/tcop/pquery.c
@@ -730,6 +730,8 @@ void GetResourceQuota(int		max_target_segment_num,
 	}
 }
 
+int ResourceIndex = -1;
+
 QueryResource *
 AllocateResource(QueryResourceLife   life,
 				 int32 			     slice_size,
@@ -791,6 +793,7 @@ AllocateResource(QueryResourceLife   life,
 		elog(ERROR, "%s. (%d)", errorbuf, errorcode);
 	}
 
+	ResourceIndex = resourceId;
 	/* Acquire resource. */
 	ret = acquireResourceFromRM(resourceId,
 								gp_session_id,

--- a/src/include/tcop/pquery.h
+++ b/src/include/tcop/pquery.h
@@ -19,6 +19,7 @@
 
 extern PGDLLIMPORT Portal ActivePortal;
 
+extern int ResourceIndex;
 
 extern PortalStrategy ChoosePortalStrategy(List *stmts);
 


### PR DESCRIPTION
…to AllocateResource.

When QD is running in the function processAllCommFileDescs (called by acquireResourceFromRM, which is a RPC to allocate resource from QD to RM), it received a "query cancel pending'" interrupt, and it handles the interrupt and error out. So we should mark and clean up resource as resource could have been allocated in RM side. Otherwise it will cause resource leak.