### PR TITLE
HAWQ-576. Remove useless code which includes function GetAllWorkerHos…

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -17665,9 +17665,11 @@ static Datum transformExecOnClause(List	*on_clause, int *preferred_segment_num, 
           errOmitLocation(true)));
 
 			/* result: "ALL_SEGMENTS" */
+			/*
 			exec_location_str = (char *) palloc(12 + 1);
 			exec_location_str = "ALL_SEGMENTS";
 			*preferred_segment_num = GetAllWorkerHostNum();
+			*/
 		}
 		else if (strcmp(defel->defname, "hostname") == 0)
 		{
@@ -17678,10 +17680,12 @@ static Datum transformExecOnClause(List	*on_clause, int *preferred_segment_num, 
           errOmitLocation(true)));
 
 			/* result: "HOST:<hostname>" */
+			/*
 			value_str = strVal(defel->arg);
 			exec_location_str = (char *) palloc(5 + 1 + strlen(value_str) + 1);
 			sprintf((char *) exec_location_str, "HOST:%s", value_str);
 			*preferred_segment_num = GetAllWorkerHostNum();
+			*/
 		}
 		else if (strcmp(defel->defname, "eachhost") == 0)
 		{
@@ -17692,9 +17696,11 @@ static Datum transformExecOnClause(List	*on_clause, int *preferred_segment_num, 
           errOmitLocation(true)));
 
 			/* result: "PER_HOST" */
+			/*
 			exec_location_str = (char *) palloc(8 + 1);
 			exec_location_str = "PER_HOST";
 			*preferred_segment_num = GetAllWorkerHostNum();
+			*/
 		}
 		else if (strcmp(defel->defname, "master") == 0)
 		{

--- a/src/backend/postmaster/identity.c
+++ b/src/backend/postmaster/identity.c
@@ -228,18 +228,6 @@ IsOnMaster(void)
 	return SegmentId.role == SEGMENT_ROLE_MASTER;
 }
 
-SegmentFunctionList *
-GetSegmentFunctionList(void)
-{
-	return &SegmentId.function;
-}
-
-ProcessFunctionList *
-GetProcessFunctionList(void)
-{
-	return &SegmentId.pid.function;
-}
-
 static void
 GenerateProcessIdentityLabel(ProcessIdentity *id)
 {
@@ -573,6 +561,7 @@ GetUserDefinedFunctionVsegNum(void)
 	return GetQueryVsegNum();
 }
 
+/*
 int
 GetAllWorkerHostNum(void)
 {
@@ -583,6 +572,7 @@ GetAllWorkerHostNum(void)
 
 	return num;
 }
+*/
 
 static void
 DebugSegmentIdentity(SegmentIdentity *id)

--- a/src/include/postmaster/identity.h
+++ b/src/include/postmaster/identity.h
@@ -94,10 +94,7 @@ extern int GetRelOpt_bucket_num_fromRangeVar(const RangeVar* rel_rv, int default
 extern int GetDefaultPartitionNum(void);
 extern int GetHashDistPartitionNum(void);
 extern int GetExternalTablePartitionNum(void);
-extern int GetAllWorkerHostNum(void);
 
-extern SegmentFunctionList *GetSegmentFunctionList(void);
-extern ProcessFunctionList *GetProcessFunctionList(void);
 
 /* Assert used for everyone */
 #define		AssertOnMaster()		Assert(AmIMaster());


### PR DESCRIPTION
…tNum, GetSegmentFunctionList and GetProcessFunctionList for identitiy.c.

Remove useless code which includes function GetAllWorkerHostNum, GetSegmentFunctionList and GetProcessFunctionList for identitiy.c.