### PR TITLE
HAWQ-543. Remove references to bootstrap_tokens.h

### DIFF
--- a/src/backend/Makefile
+++ b/src/backend/Makefile
@@ -256,7 +256,7 @@ utils/probes.o: utils/probes.d $(SUBDIROBJS)
 
 distprep:
 	$(MAKE) -C parser	gram.c gram.h scan.c
-	$(MAKE) -C bootstrap	bootparse.c bootstrap_tokens.h bootscanner.c
+	$(MAKE) -C bootstrap	bootparse.c bootscanner.c
 	$(MAKE) -C utils/misc	guc-file.c
 
 
@@ -376,7 +376,6 @@ distclean: clean
 maintainer-clean: distclean
 	rm -f $(srcdir)/bootstrap/bootparse.c \
 	      $(srcdir)/bootstrap/bootscanner.c \
-	      $(srcdir)/bootstrap/bootstrap_tokens.h \
 	      $(srcdir)/parser/gram.c \
 	      $(srcdir)/parser/scan.c \
 	      $(srcdir)/parser/gram.h \

--- a/src/backend/bootstrap/.gitignore
+++ b/src/backend/bootstrap/.gitignore
@@ -1,3 +1,2 @@
 bootparse.c
 bootscanner.c
-bootstrap_tokens.h


### PR DESCRIPTION
`bootstrap_tokens.h` isn't a file that exists anymore; was causing `make distprep` to fail