### PR TITLE
HAWQ-573. Fix Resource leak when cancel a query during calling a RPC …

### DIFF
--- a/src/backend/tcop/pquery.c
+++ b/src/backend/tcop/pquery.c
@@ -110,7 +110,7 @@ static int64 DoPortalRunFetch(Portal portal,
 				 DestReceiver *dest);
 static void DoPortalRewind(Portal portal);
 
-static void AddToGlobalQueryResources(QueryResource *resource);
+static void AddToGlobalQueryResources(int resourceId, QueryResourceLife life);
 
 static int compare_segment(const void *e1, const void *e2);
 /*
@@ -792,6 +792,7 @@ AllocateResource(QueryResourceLife   life,
 		elog(ERROR, "%s. (%d)", errorbuf, errorcode);
 	}
 
+	AddToGlobalQueryResources(resourceId, life);
 	/* Acquire resource. */
 	ret = acquireResourceFromRM(resourceId,
 								gp_session_id,
@@ -899,7 +900,6 @@ AllocateResource(QueryResourceLife   life,
 	 * appropriate place.
 	 */
 	gp_segments_for_planner = list_length(resource->segments);
-	AddToGlobalQueryResources(resource);
 
 	return resource;
 }
@@ -917,13 +917,13 @@ AutoFreeResource(QueryResource *resource)
 }
 
 static void
-AddToGlobalQueryResources(QueryResource *resource)
+AddToGlobalQueryResources(int resourceId, QueryResourceLife life)
 {
   ListCell *lc;
   QueryResourceItem *newItem;
   MemoryContext old;
 
-  if ((!resource) || (resource->life == QRL_NONE))
+  if (life == QRL_NONE)
   {
     return;
   }
@@ -931,7 +931,7 @@ AddToGlobalQueryResources(QueryResource *resource)
   foreach(lc, GlobalQueryResources)
   {
     QueryResourceItem *qri = lfirst(lc);
-    if(qri->resource_id == resource->resource_id)
+    if(qri->resource_id == resourceId)
     {
       /*
        * found, no need to add.
@@ -947,7 +947,7 @@ AddToGlobalQueryResources(QueryResource *resource)
   old = MemoryContextSwitchTo(TopMemoryContext);
   newItem = palloc(sizeof(QueryResourceItem));
   newItem->alive = true;
-  newItem->resource_id = resource->resource_id;
+  newItem->resource_id = resourceId;
   GlobalQueryResources = lappend(GlobalQueryResources, newItem);
   MemoryContextSwitchTo(old);
 }


### PR DESCRIPTION
…to allocate resource.

When QD is running in the function processAllCommFileDescs (called by acquireResourceFromRM, which is a RPC to allocate resource from QD to RM), it received a "query cancel pending'" interrupt, and it handles the interrupt and error out. So we should add the resource into the GlobalQueryResources before it actually allocate. Otherwise it will cause resource leak.