### PR TITLE
HAWQ-579. As we hasn't supported the guc value get_tmpdir_from_rm to …

### DIFF
--- a/src/backend/postmaster/identity.c
+++ b/src/backend/postmaster/identity.c
@@ -100,8 +100,9 @@ static SegmentIdentity SegmentId = { SEGMENT_ROLE_INVALID };
 static void DebugSegmentIdentity(struct SegmentIdentity *id);
 static void DebugProcessIdentity(struct ProcessIdentity *id);
 static bool	DeserializeProcessIdentity(struct ProcessIdentity *id, const char *str);
-static void GetLocalTmpDirFromRM(char *host, uint16_t port, int session_id, int command_id, int qeidx);
+//static void GetLocalTmpDirFromRM(char *host, uint16_t port, int session_id, int command_id, int qeidx);
 
+/*
 static void
 GetLocalTmpDirFromRM(char *host,
 					 uint16_t port,
@@ -156,6 +157,7 @@ GetLocalTmpDirFromRM(char *host,
                 session_id, command_id, qeidx); 
     }
 }
+*/
 
 static void
 SetSegmentRole(const char *name, SegmentIdentity *segment)
@@ -384,7 +386,10 @@ SetupProcessIdentity(const char *str)
         
         if (get_tmpdir_from_rm)
         {
+            elog(ERROR, "The GUC value get_tmpdir_from_rm to be true hasn't been supported yet. "
+			"Please set get_tmpdir_from_rm=false ");
             /* If QE is under one segment. */
+            /*
             if ( GetQEIndex() != -1 ) {
                 GetLocalTmpDirFromRM("127.0.0.1",//DRMGlobalInstance->SocketLocalHostName.Str,
                                      rm_segment_port,
@@ -392,7 +397,9 @@ SetupProcessIdentity(const char *str)
                                      gp_command_count,
                                      GetQEIndex());
             }
+            */
             /* QE is under master. */
+            /*
             else {
                 GetLocalTmpDirFromRM("127.0.0.1",//DRMGlobalInstance->SocketLocalHostName.Str,
                                      rm_master_port,
@@ -403,6 +410,7 @@ SetupProcessIdentity(const char *str)
 
             elog(DEBUG1, "Get temporary directory from segment resource manager, %s",
         		    LocalTempPath);
+            */
         }
         else
         {

--- a/src/backend/resourcemanager/communication/rmcomm_QD2RM.c
+++ b/src/backend/resourcemanager/communication/rmcomm_QD2RM.c
@@ -1221,6 +1221,7 @@ exit:
 	destroySelfMaintainBuffer(&recvbuffer);
 }
 
+/*
 int getLocalTmpDirFromMasterRM(char *errorbuf, int errorbufsize)
 {
 	static char 	 errorbuf2[ERRORMESSAGE_SIZE];
@@ -1273,7 +1274,7 @@ exit:
 	destroySelfMaintainBuffer(&recvbuffer);
 	return res;
 }
-
+*/
 
 int acquireResourceQuotaFromRM(int64_t		user_oid,
 							   uint32_t		max_seg_count_fix,

--- a/src/backend/resourcemanager/include/communication/rmcomm_QD2RM.h
+++ b/src/backend/resourcemanager/include/communication/rmcomm_QD2RM.h
@@ -167,7 +167,7 @@ void SendResourceRefreshHeartBeat(void);
 
 void sendFailedNodeToResourceManager(int hostNum, char **pghost);
 
-int getLocalTmpDirFromMasterRM(char *errorbuf, int errorbufsize);
+//int getLocalTmpDirFromMasterRM(char *errorbuf, int errorbufsize);
 
 int dumpResourceManagerStatus(uint32_t		 type,
 							  const char	*dump_file,

--- a/src/backend/utils/init/postinit.c
+++ b/src/backend/utils/init/postinit.c
@@ -448,12 +448,16 @@ InitPostgres(const char *in_dbname, Oid dboid, const char *username,
     {
         if (get_tmpdir_from_rm)
         {
+            elog(ERROR, "The GUC value get_tmpdir_from_rm to be true hasn't been supported yet. "
+			"Please set get_tmpdir_from_rm=false ");
+            /*
         	char errorbuf[ERRORMESSAGE_SIZE] = "";
             int res = getLocalTmpDirFromMasterRM(errorbuf, sizeof(errorbuf));
             if ( res != FUNC_RETURN_OK )
             {
             	elog(ERROR, "%s", errorbuf);
             }
+            */
         }
         else
         {


### PR DESCRIPTION
…be true, so remove them and add error information when users set get_tmpdir_from_rm=true;
As we hasn't supported the guc value get_tmpdir_from_rm to be true, so remove them and add error information when users set get_tmpdir_from_rm=true;