### PR TITLE
HAWQ-404. Reset default value to 160 for GUC

### DIFF
--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -6194,7 +6194,7 @@ static struct config_int ConfigureNamesInt[] =
 			GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
 		},
 		&optimizer_parts_to_force_sort_on_insert,
-		INT_MAX, 0, INT_MAX, NULL, NULL
+		160, 0, INT_MAX, NULL, NULL
 	},
 
 	{


### PR DESCRIPTION
optimizer_parts_to_force_sort_on_insert [#110377582]

Signed-off-by: Jacob Frank <jfrank@pivotal.io>