### PR TITLE
HAWQ-597. Add Travis CI(OSX)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ compiler:
   - clang
 
 before_install:
-  - brew update
+  - "brew update 2>&1 > /tmp/brew-update.txt || (cat /tmp/brew-update.txt && false)"
 
 install:
   - brew install
@@ -36,6 +36,8 @@ install:
   - sudo pip install
     "http://darcs.idyll.org/~t/projects/figleaf-${FIGLEAF_VERSION}.tar.gz"
   - brew uninstall postgresql
+
+before_script:
   - wget -O "/tmp/libhdfs3" "https://github.com/Pivotal-DataFabric/libhdfs3/archive/apache-rpc-9.zip"
   - unzip -d "/tmp" "/tmp/libhdfs3"
   - cd "/tmp/libhdfs3-apache-rpc-9"
@@ -45,8 +47,6 @@ install:
   - make -j2
   - sudo make install
   - cd /tmp && rm -rf /tmp/libhdfs3*
-
-before_script:
   - cd $TRAVIS_BUILD_DIR
   - cd $TRAVIS_BUILD_DIR/depends/libyarn
   - mkdir build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,65 @@
+language: c
+
+os:
+  - osx
+
+env:
+  - PYCHECKER_VERSION=0.8.19 FIGLEAF_VERSION=0.6.1
+
+compiler:
+  - clang
+
+before_install:
+  - brew update
+
+install:
+  - brew install
+    protobuf
+    protobuf-c
+    Gsasl
+    openssl
+    thrift
+    ccache
+    snappy
+    libevent
+    python
+  - brew outdated libyaml || brew upgrade libyaml
+  - brew outdated json-c || brew upgrade json-c
+  - brew outdated boost || brew upgrade boost
+  - brew outdated maven || brew upgrade maven
+  - brew tap brona/iproute2mac
+  - brew install iproute2mac
+  - sudo pip install pygresql
+  - sudo pip install unittest2 pycrypto lockfile paramiko psi
+  - sudo pip install
+    "http://sourceforge.net/projects/pychecker/files/pychecker/${PYCHECKER_VERSION}/pychecker-${PYCHECKER_VERSION}.tar.gz/download"
+  - sudo pip install
+    "http://darcs.idyll.org/~t/projects/figleaf-${FIGLEAF_VERSION}.tar.gz"
+  - brew uninstall postgresql
+  - wget -O "/tmp/libhdfs3" "https://github.com/Pivotal-DataFabric/libhdfs3/archive/apache-rpc-9.zip"
+  - unzip -d "/tmp" "/tmp/libhdfs3"
+  - cd "/tmp/libhdfs3-apache-rpc-9"
+  - mkdir build
+  - cd build
+  - ../bootstrap --prefix=/usr/local/
+  - make -j2
+  - sudo make install
+  - cd /tmp && rm -rf /tmp/libhdfs3*
+
+before_script:
+  - cd $TRAVIS_BUILD_DIR
+  - cd $TRAVIS_BUILD_DIR/depends/libyarn
+  - mkdir build
+  - cd build
+  - ../bootstrap --prefix=/usr/local
+  - make -j2
+  - sudo make install
+  - cd $TRAVIS_BUILD_DIR
+  - ./configure
+
+script:
+  - make -j2
+
+branches:
+  except:
+    - legacy


### PR DESCRIPTION
Add Travis CI support under OSX, help user verify local commit before sending pull request.

More info can be found: https://travis-ci.org/xunzhang/incubator-hawq/builds/118761850