### PR TITLE
HAWQ-596. change gucs hawq_rm_tolerate_nseg_limit and hawq_rm_rejectrequest_nseg_limit to a percentage value

### DIFF
--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -361,10 +361,12 @@ int		rm_segment_config_refresh_interval; /* How many seconds to wait before
 int		rm_segment_tmpdir_detect_interval;	/* How many seconds to wait before
 											   another detecting local temporary
 											   directories. */
-int		rm_tolerate_nseg_limit;
-int		rm_rejectrequest_nseg_limit;
+
 int		rm_nvseg_variance_among_seg_limit;
 int		rm_container_batch_limit;
+
+double	rm_tolerate_nseg_limit;
+double	rm_rejectrequest_nseg_limit;
 
 char   *rm_resourcepool_test_filename;
 

--- a/src/backend/resourcemanager/requesthandler.c
+++ b/src/backend/resourcemanager/requesthandler.c
@@ -381,21 +381,13 @@ bool handleRMRequestAcquireResource(void **arg)
 	/*--------------------------------------------------------------------------
 	 * We firstly check if the cluster has too many unavailable segments, which
 	 * is measured by rm_rejectrequest_nseg_limit. The expected cluster size is
-	 * loaded from couting hosts in $GPHOME/etc/slaves. Resource manager rejects
-	 * query  resource requests at once if currently there are more than
-	 * rm_rejectrequest_nseg_limit segments unavailable.
-	 *
-	 * NOTE: If the number of hosts in $GPHOME/etc/slaves is not greater than
-	 * 		 rm_rejectrequest_nseg_limit, this guc value is treated as 0, i.e.
-	 * 		 all the segments must be available before accepting query resource
-	 * 		 requests.
+	 * loaded from counting hosts in $GPHOME/etc/slaves. Resource manager rejects
+	 * query  resource requests at once if currently there are too many segments
+	 * unavailable.
 	 *--------------------------------------------------------------------------
 	 */
 	Assert(PRESPOOL->SlavesHostCount > 0);
-	int rejectlimit = PRESPOOL->SlavesHostCount <= rm_rejectrequest_nseg_limit ?
-					  0 :
-					  rm_rejectrequest_nseg_limit;
-
+	int rejectlimit = ceil(PRESPOOL->SlavesHostCount * rm_rejectrequest_nseg_limit);
 	int unavailcount = PRESPOOL->SlavesHostCount - PRESPOOL->AvailNodeCount;
 	if ( unavailcount > rejectlimit )
 	{

--- a/src/backend/resourcemanager/resourcepool.c
+++ b/src/backend/resourcemanager/resourcepool.c
@@ -4558,10 +4558,7 @@ void fixClusterMemoryCoreRatio(void)
 	{
 		return;
 	}
-
-	int rejectlimit = PRESPOOL->SlavesHostCount <= rm_rejectrequest_nseg_limit ?
-					  0 :
-					  rm_rejectrequest_nseg_limit;
+	int rejectlimit = ceil(PRESPOOL->SlavesHostCount * rm_rejectrequest_nseg_limit);
 	int criteria1 = PRESPOOL->SlavesHostCount - rejectlimit;
 	int criteria2 = (PRESPOOL->SlavesHostCount + 1) / 2;
 

--- a/src/backend/resourcemanager/resqueuemanager.c
+++ b/src/backend/resourcemanager/resqueuemanager.c
@@ -4624,15 +4624,15 @@ RESOURCEPROBLEM isResourceAcceptable(ConnectionTrack conn, int segnumact)
 	 */
 	if ( segnumact > list_length(conn->Resource) )
 	{
-		if ( PRESPOOL->SlavesHostCount - rm_tolerate_nseg_limit >
-			 list_length(conn->Resource) )
+		int limit = ceil(PRESPOOL->SlavesHostCount * rm_tolerate_nseg_limit);
+		if ( PRESPOOL->SlavesHostCount - limit > list_length(conn->Resource) )
 		{
 			elog(WARNING, "Find virtual segments are dispatched to %d segments in "
 						  "the cluster containing %d segments defined in slaves file. "
 						  "The number of excluded segments are more than %d.",
 						  list_length(conn->Resource),
 						  PRESPOOL->SlavesHostCount,
-						  rm_tolerate_nseg_limit);
+						  limit);
 			return RESPROBLEM_TOOFEWSEG;
 		}
 	}

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -6537,27 +6537,6 @@ static struct config_int ConfigureNamesInt[] =
 	},
 
 	{
-		{"hawq_rm_tolerate_nseg_limit", PGC_POSTMASTER, RESOURCES_MGM,
-			gettext_noop("resource manager re-allocates resource if the number of exclusive "
-						 "segments is greater than this limit value when there is at least "
-						 "one segment containing two or more virtual segments."),
-			NULL
-		},
-		&rm_tolerate_nseg_limit,
-		2, 0, 65535, NULL, NULL
-	},
-
-	{
-		{"hawq_rm_rejectrequest_nseg_limit", PGC_POSTMASTER, RESOURCES_MGM,
-			gettext_noop("resource manager rejects new resource request if the number of "
-						 "unavailable segments is greater than this limit value."),
-			NULL
-		},
-		&rm_rejectrequest_nseg_limit,
-		2, 0, 65535, NULL, NULL
-	},
-
-	{
 		{"hawq_rm_nvseg_variance_amon_seg_limit", PGC_POSTMASTER, RESOURCES_MGM,
 			gettext_noop("the variance of vseg number in each segment that resource manager should tolerate at most."),
 			NULL
@@ -6960,6 +6939,29 @@ static struct config_real ConfigureNamesReal[] =
 		},
 		&rm_seg_core_use,
 		16.0, 1.0, INT_MAX, NULL, NULL
+	},
+
+	{
+		{"hawq_rm_tolerate_nseg_limit", PGC_POSTMASTER, RESOURCES_MGM,
+			gettext_noop("resource manager re-allocates resource if the percentage of exclusive "
+						 "segments is greater than this limit value when there is at least "
+						 "one segment containing two or more virtual segments. Total expected "
+						 "cluster size is the number of hosts in file slaves."),
+			NULL
+		},
+		&rm_tolerate_nseg_limit,
+		0.25, 0.0, 1.0, NULL, NULL
+	},
+
+	{
+		{"hawq_rm_rejectrequest_nseg_limit", PGC_POSTMASTER, RESOURCES_MGM,
+			gettext_noop("resource manager rejects new resource request if the percentage of "
+						 "unavailable segments is greater than this limit value. Total expected "
+						 "cluster size is the number of hosts in file slaves."),
+			NULL
+		},
+		&rm_rejectrequest_nseg_limit,
+		0.25, 0.0, 1.0, NULL, NULL
 	},
 
 	{

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -1190,8 +1190,8 @@ extern int	   rm_segment_config_refresh_interval;
 extern int	   rm_segment_tmpdir_detect_interval;
 
 extern int	   rm_nocluster_timeout;
-extern int	   rm_tolerate_nseg_limit;
-extern int	   rm_rejectrequest_nseg_limit;
+extern double  rm_tolerate_nseg_limit;
+extern double  rm_rejectrequest_nseg_limit;
 extern int	   rm_nvseg_variance_among_seg_limit;
 extern int	   rm_container_batch_limit;
 extern char   *rm_resourcepool_test_filename;


### PR DESCRIPTION
double type gucs, the value range is [0.0,1.0], the default values of both hawq_rm_tolerate_nseg_limit and hawq_rm_rejectrequest_nseg_limit are changed to 0.25.