### PR TITLE
 HAWQ-599. Fixed coverity issues.

### DIFF
--- a/src/backend/access/external/hd_work_mgr.c
+++ b/src/backend/access/external/hd_work_mgr.c
@@ -886,7 +886,6 @@ static void init_client_context(ClientContext *client_context)
 {
 	client_context->http_headers = NULL;
 	client_context->handle = NULL;
-	memset(client_context->chunk_buf, 0, RAW_BUF_SIZE);
 	initStringInfo(&(client_context->the_rest_buf));
 }
 

--- a/src/backend/access/external/pxfutils.c
+++ b/src/backend/access/external/pxfutils.c
@@ -100,10 +100,11 @@ call_rest(GPHDUri *hadoop_uri,
 static void process_request(ClientContext* client_context, char *uri)
 {
 	size_t n = 0;
+	char buffer[RAW_BUF_SIZE];
 
 	print_http_headers(client_context->http_headers);
 	client_context->handle = churl_init_download(uri, client_context->http_headers);
-	memset(client_context->chunk_buf, 0, RAW_BUF_SIZE);
+	memset(buffer, 0, RAW_BUF_SIZE);
 	resetStringInfo(&(client_context->the_rest_buf));
 
 	/*
@@ -115,10 +116,10 @@ static void process_request(ClientContext* client_context, char *uri)
 	{
 		/* read some bytes to make sure the connection is established */
 		churl_read_check_connectivity(client_context->handle);
-		while ((n = churl_read(client_context->handle, client_context->chunk_buf, sizeof(client_context->chunk_buf))) != 0)
+		while ((n = churl_read(client_context->handle, buffer, sizeof(buffer))) != 0)
 		{
-			appendBinaryStringInfo(&(client_context->the_rest_buf), client_context->chunk_buf, n);
-			memset(client_context->chunk_buf, 0, RAW_BUF_SIZE);
+			appendBinaryStringInfo(&(client_context->the_rest_buf), buffer, n);
+			memset(buffer, 0, RAW_BUF_SIZE);
 		}
 		churl_cleanup(client_context->handle, false);
 	}

--- a/src/backend/utils/adt/pxf_functions.c
+++ b/src/backend/utils/adt/pxf_functions.c
@@ -63,7 +63,7 @@ pxf_item_fields_enum_next(ItemContext *item_context)
 	else if (lnext(item_context->current_field))
 		item_context->current_field = lnext(item_context->current_field);
 	/* next item */
-	else if (lnext(item_context->current_item))
+	else if (item_context->current_item && lnext(item_context->current_item))
 	{
 		item_context->current_item = lnext(item_context->current_item);
 		item_context->current_field = list_head(((PxfItem *) lfirst(item_context->current_item))->fields);

--- a/src/bin/gpfusion/gpbridgeapi.c
+++ b/src/bin/gpfusion/gpbridgeapi.c
@@ -280,7 +280,6 @@ static void init_client_context(ClientContext *client_context)
 {
 	client_context->http_headers = NULL;
 	client_context->handle = NULL;
-	memset(client_context->chunk_buf, 0, RAW_BUF_SIZE);
 	initStringInfo(&(client_context->the_rest_buf));
 }
 

--- a/src/include/access/pxfutils.h
+++ b/src/include/access/pxfutils.h
@@ -28,7 +28,7 @@ typedef struct sClientContext
 {
 	CHURL_HEADERS http_headers;
 	CHURL_HANDLE handle;
-	char chunk_buf[RAW_BUF_SIZE];	/* part of the HTTP response - received	*/
+									/* part of the HTTP response - received	*/
 									/* from one call to churl_read 			*/
 	StringInfoData the_rest_buf; 	/* contains the complete HTTP response 	*/
 } ClientContext;


### PR DESCRIPTION
We were carrying character buffer size of 64k over stack which was unnecessary because it was used in method pxfutils.process_request only, moved it to local variable.