### PR TITLE
HAWQ-613. Cannot cancel query when PL UDF has infinity loops

### DIFF
--- a/src/backend/executor/execQual.c
+++ b/src/backend/executor/execQual.c
@@ -1619,13 +1619,13 @@ restart:
 				fcinfo.isnull = false;
 				rsinfo.isDone = ExprSingleResult;
 
-				bool save_ImmediateInterruptOK = ImmediateInterruptOK;
+				bool savedImmediateInterruptOK = ImmediateInterruptOK;
 				/* Allow "die" interrupt to be processed while waiting */
 				ImmediateInterruptOK = true;
 				InterruptWhenCallingPLUDF = true;
 				result = FunctionCallInvoke(&fcinfo);
 				InterruptWhenCallingPLUDF = false;
-				ImmediateInterruptOK = save_ImmediateInterruptOK;
+				ImmediateInterruptOK = savedImmediateInterruptOK;
 
 				*isNull = fcinfo.isnull;
 				*isDone = rsinfo.isDone;
@@ -1755,13 +1755,13 @@ restart:
 		}
 		fcinfo.isnull = false;
 
-		bool save_ImmediateInterruptOK = ImmediateInterruptOK;
+		bool savedImmediateInterruptOK = ImmediateInterruptOK;
 		/* Allow "die" interrupt to be processed while waiting */
 		ImmediateInterruptOK = true;
 		InterruptWhenCallingPLUDF = true;
 		result = FunctionCallInvoke(&fcinfo);
 		InterruptWhenCallingPLUDF = false;
-		ImmediateInterruptOK = save_ImmediateInterruptOK;
+		ImmediateInterruptOK = savedImmediateInterruptOK;
 
 		*isNull = fcinfo.isnull;
 	}
@@ -1824,13 +1824,13 @@ ExecMakeFunctionResultNoSets(FuncExprState *fcache,
 	}
 	/* fcinfo.isnull = false; */	/* handled by InitFunctionCallInfoData */
 
-	bool save_ImmediateInterruptOK = ImmediateInterruptOK;
+	bool savedImmediateInterruptOK = ImmediateInterruptOK;
 	/* Allow "die" interrupt to be processed while waiting */
 	ImmediateInterruptOK = true;
 	InterruptWhenCallingPLUDF = true;
 	result = FunctionCallInvoke(&fcinfo);
 	InterruptWhenCallingPLUDF = false;
-	ImmediateInterruptOK = save_ImmediateInterruptOK;
+	ImmediateInterruptOK = savedImmediateInterruptOK;
 
 	*isNull = fcinfo.isnull;
 
@@ -1987,13 +1987,13 @@ ExecMakeTableFunctionResult(ExprState *funcexpr,
 			fcinfo.isnull = false;
 			rsinfo.isDone = ExprSingleResult;
 
-			bool save_ImmediateInterruptOK = ImmediateInterruptOK;
+			bool savedImmediateInterruptOK = ImmediateInterruptOK;
 			/* Allow "die" interrupt to be processed while waiting */
 			ImmediateInterruptOK = true;
 			InterruptWhenCallingPLUDF = true;
 			result = FunctionCallInvoke(&fcinfo);
 			InterruptWhenCallingPLUDF = false;
-			ImmediateInterruptOK = save_ImmediateInterruptOK;
+			ImmediateInterruptOK = savedImmediateInterruptOK;
 		}
 		else
 		{

--- a/src/backend/executor/execQual.c
+++ b/src/backend/executor/execQual.c
@@ -1618,7 +1618,15 @@ restart:
 			{
 				fcinfo.isnull = false;
 				rsinfo.isDone = ExprSingleResult;
+
+				bool save_ImmediateInterruptOK = ImmediateInterruptOK;
+				/* Allow "die" interrupt to be processed while waiting */
+				ImmediateInterruptOK = true;
+				InterruptWhenCallingPLUDF = true;
 				result = FunctionCallInvoke(&fcinfo);
+				InterruptWhenCallingPLUDF = false;
+				ImmediateInterruptOK = save_ImmediateInterruptOK;
+
 				*isNull = fcinfo.isnull;
 				*isDone = rsinfo.isDone;
 			}
@@ -1746,7 +1754,15 @@ restart:
 			}
 		}
 		fcinfo.isnull = false;
+
+		bool save_ImmediateInterruptOK = ImmediateInterruptOK;
+		/* Allow "die" interrupt to be processed while waiting */
+		ImmediateInterruptOK = true;
+		InterruptWhenCallingPLUDF = true;
 		result = FunctionCallInvoke(&fcinfo);
+		InterruptWhenCallingPLUDF = false;
+		ImmediateInterruptOK = save_ImmediateInterruptOK;
+
 		*isNull = fcinfo.isnull;
 	}
 
@@ -1807,7 +1823,15 @@ ExecMakeFunctionResultNoSets(FuncExprState *fcache,
 		}
 	}
 	/* fcinfo.isnull = false; */	/* handled by InitFunctionCallInfoData */
+
+	bool save_ImmediateInterruptOK = ImmediateInterruptOK;
+	/* Allow "die" interrupt to be processed while waiting */
+	ImmediateInterruptOK = true;
+	InterruptWhenCallingPLUDF = true;
 	result = FunctionCallInvoke(&fcinfo);
+	InterruptWhenCallingPLUDF = false;
+	ImmediateInterruptOK = save_ImmediateInterruptOK;
+
 	*isNull = fcinfo.isnull;
 
 	return result;
@@ -1962,7 +1986,14 @@ ExecMakeTableFunctionResult(ExprState *funcexpr,
 		{
 			fcinfo.isnull = false;
 			rsinfo.isDone = ExprSingleResult;
+
+			bool save_ImmediateInterruptOK = ImmediateInterruptOK;
+			/* Allow "die" interrupt to be processed while waiting */
+			ImmediateInterruptOK = true;
+			InterruptWhenCallingPLUDF = true;
 			result = FunctionCallInvoke(&fcinfo);
+			InterruptWhenCallingPLUDF = false;
+			ImmediateInterruptOK = save_ImmediateInterruptOK;
 		}
 		else
 		{

--- a/src/backend/storage/ipc/ipc.c
+++ b/src/backend/storage/ipc/ipc.c
@@ -158,6 +158,7 @@ proc_exit_prepare(int code)
 	QueryCancelPending = false;
 	/* And let's just make *sure* we're not interrupted ... */
 	ImmediateInterruptOK = false;
+	InterruptWhenCallingPLUDF = false;
 	InterruptHoldoffCount = 1;
 	CritSectionCount = 0;
 

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -265,6 +265,9 @@ static bool renice_current_process(int nice_level);
 static int getSlaveHostNumber(FILE *fp);
 static bool CheckSlaveFile();
 
+/*saved interrupt global variable for client_read_xxx functions*/
+static bool saveImmediateInterruptOK = false;
+static bool saveQueryCancelPending = false;
 
 /*
  * Change the priority of the current process to the specified level
@@ -608,9 +611,11 @@ prepare_for_client_read(void)
 		EnableClientWaitTimeoutInterrupt();
 
 		/* Allow "die" interrupt to be processed while waiting */
+		saveImmediateInterruptOK = ImmediateInterruptOK;
 		ImmediateInterruptOK = true;
 
 		/* And don't forget to detect one that already arrived */
+		saveQueryCancelPending = QueryCancelPending;
 		QueryCancelPending = false;
 		CHECK_FOR_INTERRUPTS();
 	}
@@ -624,8 +629,9 @@ client_read_ended(void)
 {
 	if (DoingCommandRead)
 	{
-		ImmediateInterruptOK = false;
-		QueryCancelPending = false;		/* forget any CANCEL signal */
+		/* set back to saved status so that not overwrite when set before calling PL UDF */
+		ImmediateInterruptOK = saveImmediateInterruptOK;
+		QueryCancelPending = saveQueryCancelPending;
 
 		DisableClientWaitTimeoutInterrupt();
 		DisableNotifyInterrupt();
@@ -3362,7 +3368,7 @@ StatementCancelHandler(SIGNAL_ARGS)
 			/* bump holdoff count to make ProcessInterrupts() a no-op */
 			/* until we are done getting ready for it */
 			InterruptHoldoffCount++;
-			if (LockWaitCancel())
+			if (LockWaitCancel()||InterruptWhenCallingPLUDF)
 			{
 				DisableNotifyInterrupt();
 				DisableCatchupInterrupt();

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -266,8 +266,8 @@ static int getSlaveHostNumber(FILE *fp);
 static bool CheckSlaveFile();
 
 /*saved interrupt global variable for client_read_xxx functions*/
-static bool saveImmediateInterruptOK = false;
-static bool saveQueryCancelPending = false;
+static bool SavedImmediateInterruptOK = false;
+static bool SavedQueryCancelPending = false;
 
 /*
  * Change the priority of the current process to the specified level
@@ -611,11 +611,11 @@ prepare_for_client_read(void)
 		EnableClientWaitTimeoutInterrupt();
 
 		/* Allow "die" interrupt to be processed while waiting */
-		saveImmediateInterruptOK = ImmediateInterruptOK;
+		SavedImmediateInterruptOK = ImmediateInterruptOK;
 		ImmediateInterruptOK = true;
 
 		/* And don't forget to detect one that already arrived */
-		saveQueryCancelPending = QueryCancelPending;
+		SavedQueryCancelPending = QueryCancelPending;
 		QueryCancelPending = false;
 		CHECK_FOR_INTERRUPTS();
 	}
@@ -630,8 +630,8 @@ client_read_ended(void)
 	if (DoingCommandRead)
 	{
 		/* set back to saved status so that not overwrite when set before calling PL UDF */
-		ImmediateInterruptOK = saveImmediateInterruptOK;
-		QueryCancelPending = saveQueryCancelPending;
+		ImmediateInterruptOK = SavedImmediateInterruptOK;
+		QueryCancelPending = SavedQueryCancelPending;
 
 		DisableClientWaitTimeoutInterrupt();
 		DisableNotifyInterrupt();

--- a/src/backend/utils/error/elog.c
+++ b/src/backend/utils/error/elog.c
@@ -443,6 +443,7 @@ errstart(int elevel, const char *filename, int lineno,
             if (recursion_depth > 2 * ERRORDATA_STACK_SIZE)
             {
                 ImmediateInterruptOK = false;
+                InterruptWhenCallingPLUDF = false;
                 fflush(stdout);
                 fflush(stderr);
                 return false;
@@ -554,6 +555,7 @@ errfinish(int dummy __attribute__((unused)),...)
 
         /* This is just in case the error came while waiting for input */
         ImmediateInterruptOK = false;
+        InterruptWhenCallingPLUDF = false;
 
         /*
          * Reset InterruptHoldoffCount in case we ereport'd from inside an
@@ -642,6 +644,7 @@ errfinish(int dummy __attribute__((unused)),...)
          * For a FATAL error, we let proc_exit clean up and exit.
          */
         ImmediateInterruptOK = false;
+        InterruptWhenCallingPLUDF = false;
 
         /*
          * If we just reported a startup failure, the client will disconnect
@@ -677,6 +680,7 @@ errfinish(int dummy __attribute__((unused)),...)
          * children...
          */
         ImmediateInterruptOK = false;
+        InterruptWhenCallingPLUDF = false;
         fflush(stdout);
         fflush(stderr);
         abort();

--- a/src/backend/utils/init/globals.c
+++ b/src/backend/utils/init/globals.c
@@ -32,6 +32,7 @@ volatile bool QueryCancelCleanup = false;
 volatile bool ProcDiePending = false;
 volatile bool ClientConnectionLost = false;
 volatile bool ImmediateInterruptOK = false;
+volatile bool InterruptWhenCallingPLUDF = false;
 
 // Make these signed integers (instead of uint32) to detect garbage negative values.
 volatile int32 InterruptHoldoffCount = 0;

--- a/src/include/miscadmin.h
+++ b/src/include/miscadmin.h
@@ -80,6 +80,7 @@ extern volatile bool ClientConnectionLost;
 
 /* these are marked volatile because they are examined by signal handlers: */
 extern volatile bool ImmediateInterruptOK;
+extern volatile bool InterruptWhenCallingPLUDF;
 extern PGDLLIMPORT volatile int32 InterruptHoldoffCount;
 extern PGDLLIMPORT volatile int32 CritSectionCount;
 


### PR DESCRIPTION
Notes:
(1) Here just change some UDF calling may introduce hung problem, I don't go through all code lines PL UDF maybe called.
(2)  in client_read_ended(), i just set QueryCancelPending to saveQueryCancelPending, instead of set it to false, it means it only process the cancel request during client read period.
(3) InterruptWhenCallingPLUDF need to be reset during error report and process exists.

Please review, thanks.

