### PR TITLE
HAWQ-621. Fixing tuple descriptor leak in split_rows during an ALTER TABLE SPLIT PARTITION. 

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -15601,6 +15601,23 @@ split_rows(Relation intoa, Relation intob, Relation temprel, List *splits, int s
 	ExecDropSingleTupleTableSlot(rria->ri_partSlot);
 	ExecDropSingleTupleTableSlot(rrib->ri_partSlot);
 
+	/*
+	 * We may have created "cached" version of our target result tuple table slot
+	 * inside reconstructMatchingTupleSlot. Drop any such slots.
+	 */
+	if (NULL != rria->ri_resultSlot)
+	{
+		Assert(NULL != rria->ri_resultSlot->tts_tupleDescriptor);
+		ExecDropSingleTupleTableSlot(rria->ri_resultSlot);
+		rria->ri_resultSlot = NULL;
+	}
+	if (NULL != rrib->ri_resultSlot)
+	{
+		Assert(NULL != rrib->ri_resultSlot->tts_tupleDescriptor);
+		ExecDropSingleTupleTableSlot(rrib->ri_resultSlot);
+		rrib->ri_resultSlot = NULL;
+	}
+
 	if (rria->ri_partInsertMap)
 		pfree(rria->ri_partInsertMap);
 	if (rrib->ri_partInsertMap)

--- a/src/test/regress/expected/alter_table.out
+++ b/src/test/regress/expected/alter_table.out
@@ -1968,3 +1968,27 @@ NOTICE:  drop cascades to constraint testbug_char5_1_prt_part201204_check on app
 NOTICE:  drop cascades to append only columnar table mpp17582.testbug_char5_1_prt_part201203
 NOTICE:  drop cascades to constraint testbug_char5_1_prt_part201203_check on append only columnar table mpp17582.testbug_char5_1_prt_part201203
 NOTICE:  drop cascades to table mpp17582.testbug_char5
+-- Test for tuple descriptor leak during row splitting
+DROP TABLE IF EXISTS split_tupdesc_leak;
+NOTICE:  table "split_tupdesc_leak" does not exist, skipping
+CREATE TABLE split_tupdesc_leak
+(
+   ym character varying(6) NOT NULL,
+   suid character varying(50) NOT NULL,
+   genre_ids character varying(20)[]
+) 
+WITH (APPENDONLY=true, ORIENTATION=row, COMPRESSTYPE=zlib, OIDS=FALSE)
+DISTRIBUTED BY (suid)
+PARTITION BY LIST(ym)
+(
+	DEFAULT PARTITION p_split_tupdesc_leak_ym  WITH (appendonly=true, orientation=row, compresstype=zlib)
+);
+NOTICE:  CREATE TABLE will create partition "split_tupdesc_leak_1_prt_p_split_tupdesc_leak_ym" for table "split_tupdesc_leak"
+INSERT INTO split_tupdesc_leak VALUES ('201412','0001EC1TPEvT5SaJKIR5yYXlFQ7tS','{0}');
+ALTER TABLE split_tupdesc_leak SPLIT DEFAULT PARTITION AT ('201412')
+	INTO (PARTITION p_split_tupdesc_leak_ym, PARTITION p_split_tupdesc_leak_ym_201412);
+NOTICE:  exchanged partition "p_split_tupdesc_leak_ym" of relation "split_tupdesc_leak" with relation "pg_temp_323542"
+NOTICE:  dropped partition "p_split_tupdesc_leak_ym" for relation "split_tupdesc_leak"
+NOTICE:  CREATE TABLE will create partition "split_tupdesc_leak_1_prt_p_split_tupdesc_leak_ym_201412" for table "split_tupdesc_leak"
+NOTICE:  CREATE TABLE will create partition "split_tupdesc_leak_1_prt_p_split_tupdesc_leak_ym" for table "split_tupdesc_leak"
+DROP TABLE split_tupdesc_leak;

--- a/src/test/regress/expected/alter_table_optimizer.out
+++ b/src/test/regress/expected/alter_table_optimizer.out
@@ -2163,3 +2163,27 @@ NOTICE:  drop cascades to constraint testbug_char5_1_prt_part201204_check on app
 NOTICE:  drop cascades to append only columnar table mpp17582.testbug_char5_1_prt_part201203
 NOTICE:  drop cascades to constraint testbug_char5_1_prt_part201203_check on append only columnar table mpp17582.testbug_char5_1_prt_part201203
 NOTICE:  drop cascades to table mpp17582.testbug_char5
+-- Test for tuple descriptor leak during row splitting
+DROP TABLE IF EXISTS split_tupdesc_leak;
+NOTICE:  table "split_tupdesc_leak" does not exist, skipping
+CREATE TABLE split_tupdesc_leak
+(
+   ym character varying(6) NOT NULL,
+   suid character varying(50) NOT NULL,
+   genre_ids character varying(20)[]
+) 
+WITH (APPENDONLY=true, ORIENTATION=row, COMPRESSTYPE=zlib, OIDS=FALSE)
+DISTRIBUTED BY (suid)
+PARTITION BY LIST(ym)
+(
+	DEFAULT PARTITION p_split_tupdesc_leak_ym  WITH (appendonly=true, orientation=row, compresstype=zlib)
+);
+NOTICE:  CREATE TABLE will create partition "split_tupdesc_leak_1_prt_p_split_tupdesc_leak_ym" for table "split_tupdesc_leak"
+INSERT INTO split_tupdesc_leak VALUES ('201412','0001EC1TPEvT5SaJKIR5yYXlFQ7tS','{0}');
+ALTER TABLE split_tupdesc_leak SPLIT DEFAULT PARTITION AT ('201412')
+	INTO (PARTITION p_split_tupdesc_leak_ym, PARTITION p_split_tupdesc_leak_ym_201412);
+NOTICE:  exchanged partition "p_split_tupdesc_leak_ym" of relation "split_tupdesc_leak" with relation "pg_temp_323542"
+NOTICE:  dropped partition "p_split_tupdesc_leak_ym" for relation "split_tupdesc_leak"
+NOTICE:  CREATE TABLE will create partition "split_tupdesc_leak_1_prt_p_split_tupdesc_leak_ym_201412" for table "split_tupdesc_leak"
+NOTICE:  CREATE TABLE will create partition "split_tupdesc_leak_1_prt_p_split_tupdesc_leak_ym" for table "split_tupdesc_leak"
+DROP TABLE split_tupdesc_leak;

--- a/src/test/regress/sql/alter_table.sql
+++ b/src/test/regress/sql/alter_table.sql
@@ -1336,3 +1336,25 @@ select * from testbug_char5;
 
 set search_path=public;
 drop schema if exists mpp17582 cascade;
+
+-- Test for tuple descriptor leak during row splitting
+DROP TABLE IF EXISTS split_tupdesc_leak;
+CREATE TABLE split_tupdesc_leak
+(
+   ym character varying(6) NOT NULL,
+   suid character varying(50) NOT NULL,
+   genre_ids character varying(20)[]
+) 
+WITH (APPENDONLY=true, ORIENTATION=row, COMPRESSTYPE=zlib, OIDS=FALSE)
+DISTRIBUTED BY (suid)
+PARTITION BY LIST(ym)
+(
+	DEFAULT PARTITION p_split_tupdesc_leak_ym  WITH (appendonly=true, orientation=row, compresstype=zlib)
+);
+
+INSERT INTO split_tupdesc_leak VALUES ('201412','0001EC1TPEvT5SaJKIR5yYXlFQ7tS','{0}');
+
+ALTER TABLE split_tupdesc_leak SPLIT DEFAULT PARTITION AT ('201412')
+	INTO (PARTITION p_split_tupdesc_leak_ym, PARTITION p_split_tupdesc_leak_ym_201412);
+
+DROP TABLE split_tupdesc_leak;


### PR DESCRIPTION
During split_rows, we may create new tuple table slot inside reconstructMatchingTupleSlot() if the descriptor of the new target relation does not match the source relation. We then cache this slot inside the target relation's ri_resultSlot. This process pins the tuple descriptor of the new target relation. However, at the end of split_rows, when we are finished with this "cached" tuple table slot, we don't free them. This results in a WARNING that we leaked a tuple descriptor.


Solution:
-----------

Following the call path of split_rows, the method split_rows() is only called from 

```
split_rows(Relation, Relation, Relation) : void
	ATPExecPartSplit(Relation *, AlterPartitionCmd *) : void
		ATExecCmd(List * *, AlteredTableInfo *, Relation *, AlterTableCmd *) : void
			ATPExecPartAlter(List * *, AlteredTableInfo *, Relation, AlterPartitionCmd *) : void
			ATRewriteCatalogs(List * *) : void
```

By the time we call split_rows, we know precisely the two relation where we will be inserting into. We create ResultRelInfo for both of these relations (the two target relations) at the beginning of split_rows(), called rria, and rrib. Both of these ResultRelInfo only have lifespan of the containing method split_rows(). We use the ri_resultSlot of these two rria and rrib to cache the TupleTableSlot inside reconstructMatchingTupleSlot() where we create additional TupleTableSlot using the tuple descriptors of the two target relations, therefore pinning these two target relation's TupleDesc. As the rria and rrib only live during split_rows() and only used for all the tuples in ONE CALL of split_rows(), we can easily drop the additional TupleTableSlot ri_resultSlot of both rria and rrib, and that will also unpin underlying TupleDesc.