### PR TITLE
HAWQ-633. Don't error out if we cannot delete workfile directory during AbortXact

### DIFF
--- a/src/backend/utils/workfile_manager/workfile_mgr.c
+++ b/src/backend/utils/workfile_manager/workfile_mgr.c
@@ -759,7 +759,14 @@ workfile_mgr_unlink_directory(const char *dirpath)
 
 	if (!res)
 	{
-		ereport(ERROR,
+		int error_level = ERROR;
+
+		/* If we are already in an abort transaction, don't throw an exception */
+		if (IsAbortInProgress())
+		{
+			error_level = WARNING;
+		}
+		ereport(error_level,
 				(errcode(ERRCODE_IO_ERROR),
 				errmsg("could not remove spill file directory")));
 	}


### PR DESCRIPTION
If we reach out of disk space when creating temporary spill files, we will error out during writing to disk, and abort the transaction.

When aborting the transaction, part of the cleanup code we call workfile_mgr_unlink_directory() to delete the directory containing all the work files. But in some cases that directory might not even be created, because of the out of disk space.

Instead of erroring out again, just give a warning and continue with the abort code.

