### PR TITLE
HAWQ-629. Insert into table select generate_series free resource too …

### DIFF
--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -1376,6 +1376,11 @@ ExecutorEnd(QueryDesc *queryDesc)
 		 */
 		FreeExecutorState(estate);
 
+		/* Cleanup the global resource reference for spi/function resource inheritate. */
+		if (Gp_role == GP_ROLE_DISPATCH) {
+		  AutoFreeResource(queryDesc->resource);
+		  queryDesc->resource = NULL;
+		}
 		PG_RE_THROW();
 	}
 	PG_END_TRY();


### PR DESCRIPTION
…early.

If exception happends, we also need to free the resource in catch.