### PR TITLE
HAWQ-635. QE process does not exit in libhdfs

### DIFF
--- a/depends/libhdfs3/src/rpc/RpcClient.cpp
+++ b/depends/libhdfs3/src/rpc/RpcClient.cpp
@@ -155,8 +155,6 @@ RpcChannel & RpcClientImpl::getChannel(const RpcAuth & auth,
             allChannels[key] = rc;
         }
 
-        rc->addRef();
-
         if (!cleaning) {
             cleaning = true;
 
@@ -166,6 +164,8 @@ RpcChannel & RpcClientImpl::getChannel(const RpcAuth & auth,
 
             CREATE_THREAD(cleaner, bind(&RpcClientImpl::clean, this));
         }
+        // increase ref count after successfully done without any exception
+        rc->addRef();
     } catch (const HdfsRpcException & e) {
         throw;
     } catch (...) {


### PR DESCRIPTION
1) The problem is caused by the wrong refs in RpcChannelImpl class, so it run a dead loop when process exiting. I suspect it is caused by the exception thrown by RpcClientImpl::getChannel(), which already addRef(), but doesn't call close() when exception occurs.

2) This problem cannot be fixed by enable SIGNAL handle before calling libhdfs functions, because the clean up process is already called when dead loop occurs.
