### PR TITLE
HAWQ-655. Allocate resource for PerformSharedStorageOpTasks bug.

### DIFF
--- a/src/backend/cdb/cdbsharedstorageop.c
+++ b/src/backend/cdb/cdbsharedstorageop.c
@@ -156,7 +156,7 @@ void PerformSharedStorageOpTasks(SharedStorageOpTasks *tasks,
   int gp_segments_for_planner_before = gp_segments_for_planner;
 
   QueryResource *resource =
-      AllocateResource(QRL_INHERIT, 0, 0, 1, tasks->numTasks, NULL, 0);
+      AllocateResource(QRL_INHERIT, 0, 0, tasks->numTasks, 1, NULL, 0);
   DispatchDataResult result;
   dispatch_statement_node((Node *) stat, contextdisp, resource, &result);
   dispatch_free_result(&result);


### PR DESCRIPTION
Allocate resource for PerformSharedStorageOpTasks pass the wrong order of parameters: should be(.., maxvseg,minvseg,...) while now is (.., minvseg,maxvseg,...)
