### PR TITLE
HAWQ-628. Return -1 instead of error.

### DIFF
--- a/src/backend/utils/adt/dbsize.c
+++ b/src/backend/utils/adt/dbsize.c
@@ -179,10 +179,9 @@ calculate_database_size(Oid dbOid)
 
 	Assert(Gp_role != GP_ROLE_EXECUTE);
 
+    /* Do not error out because it would break some existing client calls*/
 	if (dbOid == HcatalogDbOid)
-		ereport(ERROR,
-			(ERRCODE_UNDEFINED_DATABASE,
-			errmsg("database hcatalog (OID 6120) is reserved")));
+		return -1;
 
 	/* User must have connect privilege for target database */
 	aclresult = pg_database_aclcheck(dbOid, GetUserId(), ACL_CONNECT);

--- a/src/test/regress/input/hcatalog_lookup.source
+++ b/src/test/regress/input/hcatalog_lookup.source
@@ -142,7 +142,7 @@ select r1.*, r2.* from hcatalog.test_schema.r r1, test_schema.r r2;
 -- negative test: partitioned tables and hcatalog
 alter table test_schema.p exchange partition p1 with table hcatalog.test_schema.r;
 
--- negative test: cannot run pg_database_size on hcatalog
+-- negative test: return -1 as a size for hcatalog
 select pg_catalog.pg_database_size('hcatalog');
 select pg_catalog.pg_database_size(6120);
 

--- a/src/test/regress/output/hcatalog_lookup.source
+++ b/src/test/regress/output/hcatalog_lookup.source
@@ -275,11 +275,19 @@ select r1.*, r2.* from hcatalog.test_schema.r r1, test_schema.r r2;
 -- negative test: partitioned tables and hcatalog
 alter table test_schema.p exchange partition p1 with table hcatalog.test_schema.r;
 ERROR:  reference to hcatalog table "hcatalog.test_schema.r" is not allowed in this context
--- negative test: cannot run pg_database_size on hcatalog
+-- negative test: return -1 as a size for hcatalog
 select pg_catalog.pg_database_size('hcatalog');
-ERROR:  database hcatalog (OID 6120) is reserved (SOMEFILE:SOMEFUNC)
+ pg_database_size 
+------------------
+               -1
+(1 row)
+
 select pg_catalog.pg_database_size(6120);
-ERROR:  database hcatalog (OID 6120) is reserved (SOMEFILE:SOMEFUNC)
+ pg_database_size 
+------------------
+               -1
+(1 row)
+
 --positive test: should be able to create table named "hcatalog"
 CREATE TABLE hcatalog(a int);
 --negative test: cannot create database named "hcatalog"


### PR DESCRIPTION
As for now Postgres' verison of psql fails on \l+ command because of error during call of pg_catalog.pg_database_size(6120) stored procedure. This fix changes error to -1 value so \l+ works on Postgres' psql as well.