### PR TITLE
HAWQ-665. Dumping memory usage during runaway query termination.

### DIFF
--- a/src/backend/utils/mmgr/runaway_cleaner.c
+++ b/src/backend/utils/mmgr/runaway_cleaner.c
@@ -274,6 +274,15 @@ RunawayCleaner_RunawayCleanupDoneForProcess(bool ignoredCleanup)
 		 */
 		RunawayCleaner_RunawayCleanupDoneForSession();
 	}
+
+	/*
+	 * Finally we are done with all critical cleanup, which includes releasing all our memory and
+	 * releasing our cleanup counter so that another session can be marked as runaway, if needed.
+	 * Now, we have some head room to actually record our usage.
+	 */
+	write_stderr("Logging memory usage because of runaway cleanup. Note, this is a post-cleanup logging and may be incomplete.");
+	MemoryAccounting_SaveToLog();
+	MemoryContextStats(TopMemoryContext);
 }
 
 /*


### PR DESCRIPTION
Previously when we ran out of memory, we logged the memory usage of
all the running queries on the segment where OOM happened. However,
if runaway termination successfully terminates the biggest offender,
before we hit OOM, we did not have any logging mechanism. This left
us with insufficient information for root cause analysis of memory leaks.

This PR is introducing logging of memory usage for only the runaway query.
Note, we do not log usage for all the other queries, like we do for out
of memory. Rather we restrict ourselves to only the biggest violator that
is getting terminated. Moreover, because of the sensitive nature of runaway
termination, we need to terminate as fast as possible, to prevent hitting
an out of memory in other processes. Therefore, we cannot log the full memory
context dump at the time of runaway cleanup. Rather, we attempt to dump
memory usage after the cleanup. This gives us the details of memory accounting p
eak usage for all the operators. For memory context, however, we only dump partial
memory context tree as most of the memory contexts will have been dropped
by then. This is still a valuable piece of information to do root cause
analysis as the memory accounting tree represents the execution plan closely
and helps us pinpoint the operator where we might have excessive memory consumption.

Signed-off-by: Nikos Armenatzoglou <nikos.armenatzoglou@gmail.com>