### PR TITLE
HAWQ-669. Fix interconnect guc gp_interconnect_transmit_timeout type …

### DIFF
--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -148,7 +148,7 @@ int			Gp_interconnect_timer_checking_period=20;
 int			Gp_interconnect_default_rtt=20;
 int			Gp_interconnect_min_rto=20;
 int			Gp_interconnect_fc_method=INTERCONNECT_FC_METHOD_LOSS;
-int			Gp_interconnect_transmit_timeout=3600;
+int64		Gp_interconnect_transmit_timeout=3600;
 int			Gp_interconnect_min_retries_before_timeout=100;
 
 int			Gp_interconnect_hash_multiplier=2;	/* sets the size of the hash table used by the UDP-IC */

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -463,7 +463,7 @@ extern int	Gp_interconnect_timer_period;
 extern int	Gp_interconnect_timer_checking_period;
 extern int	Gp_interconnect_default_rtt;
 extern int	Gp_interconnect_min_rto;
-extern int  Gp_interconnect_transmit_timeout;
+extern int64  Gp_interconnect_transmit_timeout;
 extern int	Gp_interconnect_min_retries_before_timeout;
 
 /* UDP recv buf size in KB.  For testing */


### PR DESCRIPTION
Interconnect guc gp_interconnect_transmit_timeout type is int, when compute it by us, integer is overflowed.
