### PR TITLE
HAWQ-708. Bump GPORCA to 1.630 [#117643411]

### DIFF
--- a/src/backend/gpopt/ivy.xml
+++ b/src/backend/gpopt/ivy.xml
@@ -38,8 +38,8 @@ under the License.
     </configurations>
 
     <dependencies>
-      <dependency org="emc"             name="optimizer"       rev="1.627"          conf="osx106_x86->osx106_x86_32;osx106_x86_32->osx106_x86_32;rhel5_x86_64->rhel5_x86_64;suse10_x86_64->suse10_x86_64" />
-      <dependency org="emc"             name="libgpos"         rev="1.133"          conf="osx106_x86->osx106_x86_32;osx106_x86_32->osx106_x86_32;rhel5_x86_64->rhel5_x86_64;suse10_x86_64->suse10_x86_64" />
+      <dependency org="emc"             name="optimizer"       rev="1.630"          conf="osx106_x86->osx106_x86_32;osx106_x86_32->osx106_x86_32;rhel5_x86_64->rhel5_x86_64;suse10_x86_64->suse10_x86_64" />
+      <dependency org="emc"             name="libgpos"         rev="1.136"          conf="osx106_x86->osx106_x86_32;osx106_x86_32->osx106_x86_32;rhel5_x86_64->rhel5_x86_64;suse10_x86_64->suse10_x86_64" />
       <dependency org="xerces"          name="xerces-c"        rev="3.1.1-p1"       conf="osx106_x86->osx106_x86_32;osx106_x86_32->osx106_x86_32;rhel5_x86_64->rhel5_x86_64;suse10_x86_64->suse10_x86_64" />
     </dependencies>
 </ivy-module>

--- a/src/backend/gpopt/utils/COptTasks.cpp
+++ b/src/backend/gpopt/utils/COptTasks.cpp
@@ -129,7 +129,7 @@ using namespace gpdbcost;
 #define GPOPT_ERROR_BUFFER_SIZE 10 * 1024 * 1024
 
 // definition of default AutoMemoryPool
-#define AUTO_MEM_POOL(amp) CAutoMemoryPool amp(CAutoMemoryPool::ElcExc, CMemoryPoolManager::EatMalloc, optimizer_parallel)
+#define AUTO_MEM_POOL(amp) CAutoMemoryPool amp(CAutoMemoryPool::ElcExc, CMemoryPoolManager::EatTracker, optimizer_parallel)
 
 // default id for the source system
 const CSystemId sysidDefault(IMDId::EmdidGPDB, GPOS_WSZ_STR_LENGTH("GPDB"));
@@ -557,7 +557,7 @@ COptTasks::Execute
 
 	bool abort_flag = false;
 
-	CAutoMemoryPool amp(CAutoMemoryPool::ElcNone, CMemoryPoolManager::EatMalloc, optimizer_parallel);
+	CAutoMemoryPool amp(CAutoMemoryPool::ElcNone, CMemoryPoolManager::EatTracker, optimizer_parallel);
 	IMemoryPool *pmp = amp.Pmp();
 	CHAR *err_buf = SzAllocate(pmp, GPOPT_ERROR_BUFFER_SIZE);
 
@@ -775,6 +775,7 @@ COptTasks::PoconfCreate
 
 	ULONG ulCTEInliningCutoff =  (ULONG) optimizer_cte_inlining_bound;
 	ULONG ulPartsToForceSortOnInsert =  (ULONG) optimizer_parts_to_force_sort_on_insert;
+	ULONG ulJoinArityForAssociativityCommutativity =  (ULONG) optimizer_join_arity_for_associativity_commutativity;
 
 	return GPOS_NEW(pmp) COptimizerConfig
 						(
@@ -782,7 +783,7 @@ COptTasks::PoconfCreate
 						GPOS_NEW(pmp) CStatisticsConfig(pmp, dDampingFactorFilter, dDampingFactorJoin, dDampingFactorGroupBy),
 						GPOS_NEW(pmp) CCTEConfig(ulCTEInliningCutoff),
 						pcm,
-						GPOS_NEW(pmp) CHint(ulPartsToForceSortOnInsert)
+						GPOS_NEW(pmp) CHint(ulPartsToForceSortOnInsert /* optimizer_parts_to_force_sort_on_insert */, ulJoinArityForAssociativityCommutativity)
 						);
 }
 

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -766,6 +766,7 @@ bool        optimizer_enable_derive_stats_all_groups;
 bool		optimizer_explain_show_status;
 bool		optimizer_prefer_scalar_dqa_multistage_agg;
 int		optimizer_parts_to_force_sort_on_insert;
+int		optimizer_join_arity_for_associativity_commutativity;
 
 /* Security */
 bool		gp_reject_internal_tcp_conn = true;
@@ -6190,6 +6191,16 @@ static struct config_int ConfigureNamesInt[] =
 		},
 		&optimizer_parts_to_force_sort_on_insert,
 		160, 0, INT_MAX, NULL, NULL
+	},
+
+	{
+		{"optimizer_join_arity_for_associativity_commutativity", PGC_USERSET, QUERY_TUNING_METHOD,
+				gettext_noop("Maximum number of children n-ary-join have without disabling commutativity and associativity transform"),
+				NULL,
+				GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+		},
+		&optimizer_join_arity_for_associativity_commutativity,
+		INT_MAX, 0, INT_MAX, NULL, NULL
 	},
 
 	{

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -442,6 +442,7 @@ extern bool optimizer_enable_derive_stats_all_groups;
 extern bool optimizer_explain_show_status;
 extern bool optimizer_prefer_scalar_dqa_multistage_agg;
 extern int  optimizer_parts_to_force_sort_on_insert;
+extern int  optimizer_join_arity_for_associativity_commutativity;
 
 /**
  * Enable logging of DPE match in optimizer.


### PR DESCRIPTION
-- 1.628 and rename EatMalloc to EatTracker

Better memory tracking.

-- 1.629 to include new GUC for Join Exploration

New GUC optimizer_join_arity_for_associativity_commutativity is added to
control Join exploration, hence speed up optimization time [#116333899]

For example, `set optimizer_join_arity_for_associativity_commutativity=x` will
hint at the optimizer to stop exploring join associativity and join
commutativity transformations when an n-ary join operator has more than
x children during optimization, pruning quite a bit of the search space.

-- 1.630 to fix CTE Predicate pushdown

This fix will prevent predicate pushdown with volatile function like
random(), which caused wrong result if predicates were duplicated.