### PR TITLE
HAWQ-713 Make lc_numeric guc to have GUC_GPDB_ADDOPT

### DIFF
--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -7469,7 +7469,8 @@ static struct config_string ConfigureNamesString[] =
 	{
 		{"lc_numeric", PGC_USERSET, CLIENT_CONN_LOCALE,
 			gettext_noop("Sets the locale for formatting numbers."),
-			NULL
+			NULL,
+			GUC_GPDB_ADDOPT
 		},
 		&locale_numeric,
 		"C", locale_numeric_assign, NULL


### PR DESCRIPTION
Without GUC_GPDB_ADOPT, the values for guc is not going to be dispatched
to the QE processes.

This fix is ported from [GPDB commit ](https://github.com/greenplum-db/gpdb/commit/d5f3d6fa94b78115424b1e3703cf9913e54507dd).

I am not able to add ICG test since we don't have guc `gp_vmem_idle_resource_timeout`. I attached the test in Jira and that file can be added once the guc is available