### PR TITLE
Remove traceflag that allows ORCA to run in multiple threads [#118416…

### DIFF
--- a/src/backend/gpopt/config/CConfigParamMapping.cpp
+++ b/src/backend/gpopt/config/CConfigParamMapping.cpp
@@ -127,13 +127,6 @@ CConfigParamMapping::SConfigMappingElem CConfigParamMapping::m_elem[] =
 		},
 
 		{
-		EopttraceParallel,
-		&optimizer_parallel,
-		false, // m_fNegate
-		GPOS_WSZ_LIT("Enable using threads in optimization engine.")
-		},
-
-		{
 		EopttraceMinidump,
 		&optimizer_minidump,
 		false, // m_fNegate

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -689,7 +689,6 @@ bool		optimizer_print_expression_properties;
 bool		optimizer_print_group_properties;
 bool		optimizer_print_optimization_context;
 bool		optimizer_print_optimization_stats;
-bool		optimizer_parallel;
 bool		optimizer_local;
 int 		optimizer_retries;
 bool  		optimizer_xforms[OPTIMIZER_XFORMS_COUNT] = {[0 ... OPTIMIZER_XFORMS_COUNT - 1] = false}; /* array of xforms disable flags */
@@ -3539,15 +3538,6 @@ static struct config_bool ConfigureNamesBool[] =
 		false, NULL, NULL
 	},
 
-	{
-		{"optimizer_parallel", PGC_USERSET, LOGGING_WHAT,
-			gettext_noop("Enable using threads in optimization engine."),
-			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
-		},
-		&optimizer_parallel,
-		false, NULL, NULL
-	},
  	{
 		{"optimizer_extract_dxl_stats", PGC_USERSET, LOGGING_WHAT,
 			gettext_noop("Extract plan stats in dxl."),

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -372,7 +372,6 @@ extern bool	optimizer_print_expression_properties;
 extern bool	optimizer_print_group_properties;
 extern bool	optimizer_print_optimization_context;
 extern bool optimizer_print_optimization_stats;
-extern bool	optimizer_parallel;
 extern bool	optimizer_local;
 extern int  optimizer_retries;
 extern bool  optimizer_xforms[OPTIMIZER_XFORMS_COUNT];


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HAWQ-763
Story: #118416535

Our team is integrating VEM with GPOS memory allocator. VMEM is not thread safe. So, ORCA/GPOS also need to be single threaded. Currently, customers are using only the single threaded Orca.

In this PR, we are removing the traceflag that allows ORCA to run in multiple threads so that our customers do not accidentally run ORCA in multiple threads.

Refer to #117374177 for more context. Eventually we would GPDB to use Orca in a multi-threaded fashion to reduce query optimization time.

@liming01 @changleicn please merge this PR