### PR TITLE
HAWQ-713 Make lc_numeric guc to have GUC_GPDB_ADDOPT

### DIFF
--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -7494,7 +7494,9 @@ static struct config_string ConfigureNamesString[] =
 	{
 		{"lc_numeric", PGC_USERSET, CLIENT_CONN_LOCALE,
 			gettext_noop("Sets the locale for formatting numbers."),
-			NULL
+			NULL,
+			/* Please don't remove GUC_GPDB_ADDOPT or lc_numeric won't work correctly */
+			GUC_GPDB_ADDOPT
 		},
 		&locale_numeric,
 		"C", locale_numeric_assign, NULL


### PR DESCRIPTION
Without GUC_GPDB_ADOPT, the values for guc 'lc_numeric' is not dispatched
to the QE processes.

This fix is ported from GPDB.