### PR TITLE
Explicitly initialize GPOPT and its dependencies.

### DIFF
--- a/src/backend/gpopt/CGPOptimizer.cpp
+++ b/src/backend/gpopt/CGPOptimizer.cpp
@@ -48,7 +48,7 @@
 void
 CGPOptimizer::TouchLibraryInitializers()
 {
-	void (*gpos)() = gpos_init;
+	void (*gpos)(gpos_init_params*) = gpos_init;
 	void (*dxl)() = gpdxl_init;
 	void (*opt)() = gpopt_init;
 }
@@ -90,6 +90,39 @@ CGPOptimizer::SzDXLPlan
 	return COptTasks::SzOptimize(pquery);
 }
 
+//---------------------------------------------------------------------------
+//	@function:
+//		InitGPOPT()
+//
+//	@doc:
+//		Initialize GPTOPT and dependent libraries
+//
+//---------------------------------------------------------------------------
+void
+CGPOptimizer::InitGPOPT ()
+{
+  // Use GPORCA's default allocators
+  struct gpos_init_params params = { NULL, NULL };
+  gpos_init(&params);
+  gpdxl_init();
+  gpopt_init();
+}
+
+//---------------------------------------------------------------------------
+//	@function:
+//		TerminateGPOPT()
+//
+//	@doc:
+//		Terminate GPOPT and dependent libraries
+//
+//---------------------------------------------------------------------------
+void
+CGPOptimizer::TerminateGPOPT ()
+{
+  gpopt_terminate();
+  gpdxl_terminate();
+  gpos_terminate();
+}
 
 //---------------------------------------------------------------------------
 //	@function:
@@ -127,6 +160,38 @@ char *SzDXLPlan
 	)
 {
 	return CGPOptimizer::SzDXLPlan(pquery);
+}
+}
+
+//---------------------------------------------------------------------------
+//	@function:
+//		InitGPOPT()
+//
+//	@doc:
+//		Initialize GPTOPT and dependent libraries
+//
+//---------------------------------------------------------------------------
+extern "C"
+{
+void InitGPOPT ()
+{
+	return CGPOptimizer::InitGPOPT();
+}
+}
+
+//---------------------------------------------------------------------------
+//	@function:
+//		TerminateGPOPT()
+//
+//	@doc:
+//		Terminate GPOPT and dependent libraries
+//
+//---------------------------------------------------------------------------
+extern "C"
+{
+void TerminateGPOPT ()
+{
+	return CGPOptimizer::TerminateGPOPT();
 }
 }
 

--- a/src/backend/gpopt/ivy.xml
+++ b/src/backend/gpopt/ivy.xml
@@ -38,8 +38,8 @@ under the License.
     </configurations>
 
     <dependencies>
-      <dependency org="emc"             name="optimizer"       rev="1.630"          conf="osx106_x86->osx106_x86_32;osx106_x86_32->osx106_x86_32;rhel5_x86_64->rhel5_x86_64;suse10_x86_64->suse10_x86_64" />
-      <dependency org="emc"             name="libgpos"         rev="1.136"          conf="osx106_x86->osx106_x86_32;osx106_x86_32->osx106_x86_32;rhel5_x86_64->rhel5_x86_64;suse10_x86_64->suse10_x86_64" />
+      <dependency org="emc"             name="optimizer"       rev="1.633"          conf="osx106_x86->osx106_x86_32;osx106_x86_32->osx106_x86_32;rhel5_x86_64->rhel5_x86_64;suse10_x86_64->suse10_x86_64" />
+      <dependency org="emc"             name="libgpos"         rev="1.137"          conf="osx106_x86->osx106_x86_32;osx106_x86_32->osx106_x86_32;rhel5_x86_64->rhel5_x86_64;suse10_x86_64->suse10_x86_64" />
       <dependency org="xerces"          name="xerces-c"        rev="3.1.1-p1"       conf="osx106_x86->osx106_x86_32;osx106_x86_32->osx106_x86_32;rhel5_x86_64->rhel5_x86_64;suse10_x86_64->suse10_x86_64" />
     </dependencies>
 </ivy-module>

--- a/src/backend/utils/init/postinit.c
+++ b/src/backend/utils/init/postinit.c
@@ -62,6 +62,11 @@ static void InitCommunication(void);
 static void ShutdownPostgres(int code, Datum arg);
 static bool ThereIsAtLeastOneRole(void);
 
+#ifdef USE_ORCA
+extern void InitGPOPT();
+extern void TerminateGPOPT();
+#endif
+
 /*** InitPostgres support ***/
 
 /*
@@ -471,6 +476,11 @@ InitPostgres(const char *in_dbname, Oid dboid, const char *username,
 	/* Initialize memory protection */
 	GPMemoryProtect_Init();
 
+#ifdef USE_ORCA
+	/* Initialize GPOPT */
+	InitGPOPT();
+#endif
+
 	/*
 	 * Initialize my entry in the shared-invalidation manager's array of
 	 * per-backend data.
@@ -726,6 +736,10 @@ ShutdownPostgres(int code, Datum arg)
 	 * our usage, report now.
 	 */
 	ReportOOMConsumption();
+
+#ifdef USE_ORCA
+	TerminateGPOPT();
+#endif
 
 	/* Disable memory protection */
 	GPMemoryProtect_Shutdown();

--- a/src/include/gpopt/CGPOptimizer.h
+++ b/src/include/gpopt/CGPOptimizer.h
@@ -57,6 +57,13 @@ class CGPOptimizer
 		// serialize planned statement into DXL
 		static
 		char *SzDXLPlan(Query *pquery);
+
+		// gpopt initialize and terminate
+		static
+		void InitGPOPT();
+
+		static
+		void TerminateGPOPT();
 };
 
 #endif // CGPOptimizer_H


### PR DESCRIPTION
    These were initialized by constructors earlier. To pass any parameters
    for initializing GPOPT or any of its dependendencies, we need to do that
    explicitly.