### PR TITLE
HAWQ-738. Allocate query resource twice in function call through jdbc

### DIFF
--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -543,14 +543,16 @@ resource_negotiator(Query *parse, int cursorOptions, ParamListInfo boundParams,
     }else{
     		find_udf(my_parse, &udf_context);
     		if(udf_context.udf_exist){
-    			if ((resourceLife == QRL_ONCE) || (resourceLife == QRL_NONE)) {
+    			if ((resourceLife == QRL_ONCE)) {
     				int64 mincost = min_cost_for_each_query;
     				mincost <<= 20;
     				int avgSliceNum = 3;
     				(*result)->saResult.resource = AllocateResource(QRL_ONCE, avgSliceNum, mincost,
     						GetUserDefinedFunctionVsegNum(),GetUserDefinedFunctionVsegNum(),NULL, 0);
-    			}else{
+    			} else if (resourceLife == QRL_INHERIT) {
     				(*result)->saResult.resource = AllocateResource(resourceLife, 0, 0, 0, 0, NULL, 0);
+    			} else {
+    				/* Do not allocate resource for query with resourceLife = QRL_NONE */
     			}
     		}
     }


### PR DESCRIPTION
Root cause analysis:

1. It uses exec_parse_message and exec_bind_message and allocate query resource twice in parse and bind phases accordingly when using jdbc to call the function: SELECT public.fn_debug(). Thus query resource is allocated twice in function call through jdbc.

2. It uses exec_simple_query and allocate query resource there only once when using psql/libpq to call the function: SELECT public.fn_debug().

The resolution is to do not allocate query resource in parse, and only allocate query resource in bind.