### PR TITLE
HAWQ-741. Set system login user as default when PGUSER is not set.

### DIFF
--- a/src/test/feature/lib/sql-util.cpp
+++ b/src/test/feature/lib/sql-util.cpp
@@ -1,5 +1,7 @@
 #include "sql-util.h"
 
+#include <pwd.h>
+#include <sys/types.h>
 #include <unistd.h>
 
 #include <fstream>
@@ -77,8 +79,15 @@ void SQLUtility::execSQLFile(const std::string &sqlFile,
 }
 
 std::unique_ptr<PSQL> SQLUtility::getConnection() {
+  std::string user = HAWQ_USER;
+  if(user == ""){
+    struct passwd *pw;
+    uid_t uid = geteuid();
+    pw = getpwuid(uid);
+    user.assign(pw->pw_name);;
+  }
   std::unique_ptr<PSQL> psql(
-      new PSQL(HAWQ_DB, HAWQ_HOST, HAWQ_PORT, HAWQ_USER, HAWQ_PASSWORD));
+      new PSQL(HAWQ_DB, HAWQ_HOST, HAWQ_PORT, user, HAWQ_PASSWORD));
   return std::move(psql);
 }
 

--- a/src/test/feature/lib/sql-util.h
+++ b/src/test/feature/lib/sql-util.h
@@ -9,7 +9,7 @@
 #define HAWQ_DB (getenv("PGDATABASE") ? getenv("PGDATABASE") : "postgres")
 #define HAWQ_HOST (getenv("PGHOST") ? getenv("PGHOST") : "localhost")
 #define HAWQ_PORT (getenv("PGPORT") ? getenv("PGPORT") : "5432")
-#define HAWQ_USER (getenv("PGUSER") ? getenv("PGUSER") : "gpadmin")
+#define HAWQ_USER (getenv("PGUSER") ? getenv("PGUSER") : "")
 #define HAWQ_PASSWORD (getenv("PGPASSWORD") ? getenv("PGPASSWORD") : "")
 
 struct FilePath {


### PR DESCRIPTION
in SQLUtility we use getenv("PGUSER") as the user to connect to DB. But if PGUSER is not set, we need to use system login user instead of gpadmin.