### PR TITLE
HAWQ-803. Enable filter in code coverage.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,7 @@ env.sh
 ext/
 plr.tgz
 autom4te.cache/
+
+# coverage
+*.gcda
+*.gcno

--- a/GNUmakefile.in
+++ b/GNUmakefile.in
@@ -166,7 +166,11 @@ distcheck: $(distdir).tar.gz
 	@echo "Distribution integrity checks out."
 
 coverage-show:
+ifneq ($(origin filter), undefined)
+	lcov --directory $(filter) --capture --output-file CodeCoverage.info
+else
 	lcov --directory . --capture --output-file CodeCoverage.info
+endif
 	lcov --remove CodeCoverage.info 'test/*' 'mock/*' '/usr/*' '/opt/*' '*ext/rhel5_x86_64*' '*ext/osx*' --output-file CodeCoverage.info.cleaned
 	genhtml -o CodeCoverageReport CodeCoverage.info.cleaned
 

--- a/GNUmakefile.in
+++ b/GNUmakefile.in
@@ -165,12 +165,12 @@ distcheck: $(distdir).tar.gz
 	-rm -rf $(distdir) $(dummy)
 	@echo "Distribution integrity checks out."
 
-coverage-show:
-ifneq ($(origin filter), undefined)
-	lcov --directory $(filter) --capture --output-file CodeCoverage.info
-else
-	lcov --directory . --capture --output-file CodeCoverage.info
+ifeq ($(origin filter), undefined)
+filter = .
 endif
+
+coverage-show:
+	lcov --directory $(filter) --capture --output-file CodeCoverage.info
 	lcov --remove CodeCoverage.info 'test/*' 'mock/*' '/usr/*' '/opt/*' '*ext/rhel5_x86_64*' '*ext/osx*' --output-file CodeCoverage.info.cleaned
 	genhtml -o CodeCoverageReport CodeCoverage.info.cleaned
 


### PR DESCRIPTION
For code coverage is time consuming, we want to filter some sub directories which we care about.
Syntax:
make coverage-show filter=./src/backend/executor
