### PR TITLE
HAWQ-841. Running "make -j8 unittest-check" under src/backend will throw "File exists" error

### DIFF
--- a/src/test/unit/mock/mocker.py
+++ b/src/test/unit/mock/mocker.py
@@ -129,7 +129,10 @@ class MockFile(object):
         out_dir = os.path.join(out_dir, os.path.dirname(relpath))
         (stem, ext) = os.path.splitext(os.path.basename(relpath))
         if not os.path.exists(out_dir):
-            os.makedirs(out_dir)
+            try:
+                os.makedirs(out_dir)
+            except OSError:
+                pass
         return os.path.join(out_dir, '{stem}_mock.c'.format(stem=stem))
 
     def mock(self):


### PR DESCRIPTION
Typical race condition issue.