### PR TITLE
HAWQ-850. Planner supports refineCachedPlan interface.

### DIFF
--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -342,7 +342,7 @@ PlannedStmt *refineCachedPlan(PlannedStmt * plannedstmt,
     * then fall back to the planner.
     * TODO: caragg 11/08/2013: Enable ORCA when running in utility mode (MPP-21841)
     */
-    if (optimizer && AmIMaster() && (GP_ROLE_UTILITY != Gp_role) && isDispatchParallel)
+    if (optimizer && AmIMaster() && (GP_ROLE_UTILITY != Gp_role) && plannedstmt->planTree->dispatch == DISPATCH_PARALLEL)
     {
       if (gp_log_optimization_time)
       {

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -328,6 +328,11 @@ PlannedStmt *refineCachedPlan(PlannedStmt * plannedstmt,
     ppResult->saResult = *allocResult;
     pfree(allocResult);
   } else {
+    if ((ppResult != NULL))
+    {
+      pfree(ppResult);
+      ppResult = NULL;
+    }
     return plannedstmt;
   }
 

--- a/src/include/optimizer/planner.h
+++ b/src/include/optimizer/planner.h
@@ -36,6 +36,11 @@ extern PlannedStmt *planner(Query *parse,
 							ParamListInfo boundParams,
 							QueryResourceLife resourceLife);
 
+extern PlannedStmt *refineCachedPlan(PlannedStmt * plannedstmt,
+              Query *parse,
+              int cursorOptions,
+              ParamListInfo boundParams);
+
 extern Plan *subquery_planner(PlannerGlobal *glob,
 							  Query *parse,
 							  PlannerInfo *parent_root,


### PR DESCRIPTION
in PBE(prepare bind execution) cases, plan will be cached, and only be generated once in postgres.
But in HAWQ since resource is dynamic or elastic, the plan maybe changed during the different execution of PBE. Also, the file split allocation result which is stored in plan is dynamically too, so the split-vseg mapping may also be changed.

For example, We call a plpgsql function which do "insert into t select * from t".
in Prepare we cache the plan, with fixed split-vseg mapping(e.g. 10 blocks), but after insert, there would be 20 blocks so the old  split-vseg mapping is invalid. We need to update it. Also when we call this function again and again, the data size of t may request more resource to handle it than the first call, so we should recalculate the entire plan with the new vseg number.

This function is implemented in a interface called refineCachedPlan.
[Link to Jira](https://issues.apache.org/jira/browse/HAWQ-850)