### PR TITLE
HAWQ-861. Wrong logerror position in insert into hashtable select * f…

### DIFF
--- a/src/backend/cdb/cdbdatalocality.c
+++ b/src/backend/cdb/cdbdatalocality.c
@@ -739,8 +739,6 @@ static void check_keep_hash_and_external_table(
 		{
 			context->keep_hash = true;
 			context->resultRelationHashSegNum = targetPolicy->bucketnum;
-			pfree(targetPolicy);
-			return;
 		}
 		pfree(targetPolicy);
 	}
@@ -752,7 +750,6 @@ static void check_keep_hash_and_external_table(
 	{
 		context->keep_hash = true;
 		context->resultRelationHashSegNum = intoPolicy->bucketnum;
-		return;
 	}
 
 	foreach(lc, context->rtc_context.range_tables)


### PR DESCRIPTION
…rom gpfdist external table.

For statement insert into hashtable select * from gpfdist external table,
when hashtable bucket number is less than location number of gpfdist external table, error should be reported in cdbdatalocality module, with error message like this:
ERROR:  Could not allocate enough memory! bucket number of result hash table and external table should match each other (cdbdatalocality.c:4222)