### PR TITLE
HAWQ-871. HAWQ CHECK looking for wrong YARN HA parameters

### DIFF
--- a/tools/bin/gpcheck
+++ b/tools/bin/gpcheck
@@ -965,8 +965,7 @@ def testHDFSConfig(host):
         yarn_property_exist_list = ['yarn.resourcemanager.address', 'yarn.resourcemanager.scheduler.address']
 
     if options.yarn_ha:
-        yarn_property_exist_list = ['yarn.resourcemanager.address.rm1', 'yarn.resourcemanager.address.rm2', 'yarn.resourcemanager.scheduler.address.rm1', \
-                                    'yarn.resourcemanager.scheduler.address.rm2']
+        yarn_property_exist_list = ['yarn.resourcemanager.hostname.rm1', 'yarn.resourcemanager.hostname.rm2']
 
     if yarn_enabled:
         for item in yarn_property_exist_list:


### PR DESCRIPTION
When YARN HA is enabled in HDP, the following four params don't actually exist. However, hawq check has been hard-coded to look for them, causing a failure. 
yarn.resourcemanager.address.rm1
yarn.resourcemanager.address.rm2
yarn.resourcemanager.scheduler.address.rm1
yarn.resourcemanager.scheduler.address.rm2
*Correct params:*
yarn.resourcemanager.hostname.rm1
yarn.resourcemanager.hostname.rm2
yarn.resourcemanager.scheduler.address (apparently, there is no rm1/rm2 specified for scheduler)