### PR TITLE
HAWQ-812. only hdfs file/dir can be skipped at recovery PASS3

### DIFF
--- a/src/backend/cdb/cdbmirroredbufferpool.c
+++ b/src/backend/cdb/cdbmirroredbufferpool.c
@@ -137,7 +137,7 @@ static void MirroredBufferPool_DoOpen(
 		if (segmentFileNum == 0)
 			sprintf(path, "%s/%u", dbPath, relFileNode->relNode);
 		else
-			sprintf(path, "%s/%u.%u", dbPath, relFileNode->relNode, segmentFileNum);
+			sprintf(path, "%s/%u/%u", dbPath, relFileNode->relNode, segmentFileNum);
 
 		errno = 0;
 		
@@ -469,7 +469,7 @@ static void MirroredBufferPool_DoDrop(
 		if (segmentFileNum == 0)
 			sprintf(path, "%s/%u", dbPath, relFileNode->relNode);
 		else
-			sprintf(path, "%s/%u.%u", dbPath, relFileNode->relNode, segmentFileNum);
+			sprintf(path, "%s/%u/%u", dbPath, relFileNode->relNode, segmentFileNum);
 
 		errno = 0;
 		


### PR DESCRIPTION
The defect was introduced by the fix for https://issues.apache.org/jira/browse/HAWQ-232. mmxlog not only include hdfs file/dir xlog, but also include heap xlog for standby node. Only hdfs file/dir can be skipped at recovery PASS3.

Moreover as for the relfile's path changed from hawq1.x to hawq2.x,  there are some code forgot to change accordingly.