### PR TITLE
HAWQ-911. Optimize and refactor makefiles for feature test framework.

### DIFF
--- a/src/test/feature/Makefile
+++ b/src/test/feature/Makefile
@@ -13,16 +13,20 @@ override LIBS := $(LIBS) -lgtest -lpq -lxml2 -ltest
 override LDFLAGS += -L/usr/local/lib -L/usr/lib -L$(abs_top_srcdir)/src/test/feature/ -L$(abs_top_srcdir)/src/test/feature/lib/ -L$(abs_top_srcdir)/src/interfaces/libpq -L$(gtest_lib_path) -L$(gmock_lib_path)
 
 PROG = test_main.cpp $(wildcard */*.cpp)
+OBJS = $(patsubst %.cpp,%.o,$(PROG))
 RM = rm -rf
 
 .PHONY: all sharelib sharelibclean distclean clean doc
 
-all: sharelib
+all: $(OBJS) sharelib
 	$(MAKE) -C lib all
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(PROG) $(LDFLAGS) $(LIBS) -o feature-test
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(OBJS) $(LDFLAGS) $(LIBS) -o feature-test
+
+%.o: %.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $? -o $@
 
 sharelib:
-	cd UDF/lib || exit 1; $(MAKE) || exit 2; $(MAKE) clean || exit 3
+	cd UDF/lib || exit 1; $(MAKE) || exit 2
 
 sharelibclean:
 	cd UDF/lib || exit 1; $(RM) *.o *.so || exit 2
@@ -35,4 +39,4 @@ clean distclean: sharelibclean
 	$(RM) feature-test.dSYM
 	$(RM) doc
 	$(MAKE) -C lib clean
-	
+	$(RM) $(OBJS)

--- a/src/test/feature/lib/Makefile
+++ b/src/test/feature/lib/Makefile
@@ -8,18 +8,21 @@ gtest_lib_path = $(top_builddir)/depends/thirdparty/googletest/build/googlemock
 gmock_lib_path = $(top_builddir)/depends/thirdparty/googletest/build/googlemock/gtest
 
 override CXX = g++
-override CXXFLAGS = -Wall -O0 -g -c -std=c++11
+override CXXFLAGS = -Wall -O0 -g -std=c++11
 override CPPFLAGS := -I/usr/include -I/usr/local/include -I/usr/include/libxml2 -I$(top_builddir)/src/interfaces/libpq -I$(top_builddir)/src/interfaces -I$(top_builddir)/src/include -I$(gtest_include) -I$(gmock_include)
 override LIBS := $(LIBS) -lpq -lxml2
 override LDFLAGS += -L/usr/local/lib -L/usr/lib -L$(gtest_lib_path) -L$(gmock_lib_path)
 
 PROG = $(abspath $(wildcard *.cpp))
+OBJS := $(patsubst %.cpp,%.o,$(PROG))
 AR = ar -r
 RM = rm -rf
 
-all:
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(PROG) 
-	$(AR) libtest.a  *.o
+all: $(OBJS)
+	$(AR) libtest.a $?
+
+%.o: %.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $? -o $@
 
 distclean clean:
 	$(RM) libtest.a


### PR DESCRIPTION
This pull request contains below modifications:
1. Fix a bug in building UDF/lib.
2. Refactor feature test make system to avoid duplicate compiles.
3. Split generating `feature-test` binary into generating objects and linking. Optimize compiling time in parallel mode.