### PR TITLE
HAWQ-1000: Set dummy workfile pointer to NULL after calling ExecWork…

### DIFF
--- a/src/backend/utils/sort/tuplesort.c
+++ b/src/backend/utils/sort/tuplesort.c
@@ -915,11 +915,13 @@ tuplesort_end(Tuplesortstate *state)
 	if (state->tapeset)
 	{
 		LogicalTapeSetClose(state->tapeset, NULL /* workset */);
+		state->tapeset = NULL;
 
 		if (state->pfile_rwfile_state)
         {
 			workfile_mgr_close_file(NULL /* workset */, state->pfile_rwfile_state, true);
         }
+		state->pfile_rwfile_state = NULL;
 	}
 
 	tuplesort_finalize_stats(state);

--- a/src/backend/utils/sort/tuplesort_mk.c
+++ b/src/backend/utils/sort/tuplesort_mk.c
@@ -984,6 +984,7 @@ tuplesort_end_mk(Tuplesortstate_mk *state)
         {
         	workfile_mgr_close_file(state->work_set, state->tapeset_state_file, true);
         }
+        state->tapeset_state_file = NULL;
     }
 
 


### PR DESCRIPTION
…File_Close()

The root cause of defect GPSQL-3288 maybe:
the parameter workfile for ExecWorkFile_Close() is freed in this function, but in the calling function outside, the pointer variable still exists, we need to set it to NULL pointer immediately. I checked all valid functions cascade calling this function, only find 2 occurrence of suspect. 