### PR TITLE
Hawq-970. Provide More Accurate Information When LibYARN Meets an Exception

### DIFF
--- a/depends/libyarn/sample/Makefile
+++ b/depends/libyarn/sample/Makefile
@@ -16,8 +16,8 @@
 # under the License.
 #
 CC=gcc
-CPPFLAGS=-g -Wall -std=gnu99 -I../dist/include
-LDFLAGS=-L../dist/lib -L/Users/yjin/greenplum-db-devel/lib -lyarn
+CPPFLAGS=-g -Wall -std=gnu99 -I/usr/local/hawq/include
+LDFLAGS=-L/usr/local/hawq/lib -lyarn
 #bin = c_client_main_profile
 bin = c_client_main
 

--- a/depends/libyarn/sample/c_client_main.c
+++ b/depends/libyarn/sample/c_client_main.c
@@ -36,7 +36,7 @@ int main() {
 
 		//0. new client
 		LibYarnClient_t *client = NULL;
-		int result = newLibYarnClient(rmHost, rmPort, schedHost, schedPort,
+		int result = newLibYarnClient("postgres", rmHost, rmPort, schedHost, schedPort,
 						amHost, amPort, am_tracking_url,&client,heartbeatInterval);
 		printf("newLibYarnClient Result Code:%d\n",result);
 

--- a/depends/libyarn/src/libyarnclient/LibYarnClient.cpp
+++ b/depends/libyarn/src/libyarnclient/LibYarnClient.cpp
@@ -895,7 +895,7 @@ int LibYarnClient::getApplicationReport(string &jobId,ApplicationReport &applica
                     applicationReport.getCurrentAppAttemptId().getAttemptId());
 
         return FR_SUCCEEDED;
-	} catch (std::exception& e) {
+    } catch (std::exception& e) {
         stringstream errorMsg;
         errorMsg << "LibYarnClient::getApplicationReport, Catch the Exception:"
                 << e.what();
@@ -925,7 +925,7 @@ int LibYarnClient::getContainerReports(string &jobId,list<ContainerReport> &cont
         return FR_SUCCEEDED;
     } catch (std::exception& e) {
         stringstream errorMsg;
-        errorMsg << "LibYarnClient::getContainerReports, Catch the Exception:" << e.what();
+        errorMsg << "LibYarnClient::getContainerReports, catch the Exception:" << e.what();
         setErrorMessage(errorMsg.str());
         return FR_FAILED;
     } catch (...) {

--- a/depends/libyarn/src/libyarnserver/ApplicationClientProtocol.cpp
+++ b/depends/libyarn/src/libyarnserver/ApplicationClientProtocol.cpp
@@ -93,16 +93,9 @@ GetNewApplicationResponse ApplicationClientProtocol::getNewApplication(
         GetNewApplicationRequestProto requestProto = request.getProto();
         invoke(RpcCall(true, "getNewApplication", &requestProto, &responseProto));
         return GetNewApplicationResponse(responseProto);
-    } catch (const YarnFailoverException & e) {
-         throw;
     } catch (const YarnRpcServerException & e) {
         UnWrapper<UnresolvedLinkException, YarnIOException> unwrapper(e);
         unwrapper.unwrap(__FILE__, __LINE__);
-    } catch (...) {
-        THROW(YarnIOException,
-              "Unexpected exception: when calling "
-              "ApplicationClientProtocol::getNewApplication in %s: %d",
-              __FILE__, __LINE__);
     }
 }
 
@@ -123,16 +116,9 @@ void ApplicationClientProtocol::submitApplication(
         SubmitApplicationResponseProto responseProto;
         SubmitApplicationRequestProto requestProto = request.getProto();
         invoke(RpcCall(true, "submitApplication", &requestProto, &responseProto));
-    } catch (const YarnFailoverException & e) {
-         throw;
     } catch (const YarnRpcServerException & e) {
         UnWrapper<UnresolvedLinkException, YarnIOException> unwrapper(e);
         unwrapper.unwrap(__FILE__, __LINE__);
-    } catch (...) {
-        THROW(YarnIOException,
-              "Unexpected exception: when calling "
-              "ApplicationClientProtocol::submitApplication in %s: %d",
-              __FILE__, __LINE__);
     }
 }
 /*
@@ -153,18 +139,11 @@ GetApplicationReportResponse ApplicationClientProtocol::getApplicationReport(
         GetApplicationReportRequestProto requestProto = request.getProto();
         invoke(RpcCall(true, "getApplicationReport", &requestProto, &responseProto));
         return GetApplicationReportResponse(responseProto);
-    } catch (const YarnFailoverException & e) {
-         throw;
     } catch (const YarnRpcServerException & e) {
         UnWrapper<UnresolvedLinkException, YarnIOException> unwrapper(e);
         unwrapper.unwrap(__FILE__, __LINE__);
-    } catch (...) {
-        THROW(YarnIOException,
-              "Unexpected exception: when calling "
-              "ApplicationClientProtocol::getApplicationReport in %s: %d",
-              __FILE__, __LINE__);
     }
-    }
+}
 
 /*
  rpc getContainers (GetContainersRequestProto) returns (GetContainersResponseProto);
@@ -183,16 +162,9 @@ GetContainersResponse ApplicationClientProtocol::getContainers(GetContainersRequ
         GetContainersRequestProto requestProto = request.getProto();
         invoke(RpcCall(true, "getContainers", &requestProto,&responseProto));
         return GetContainersResponse(responseProto);
-    } catch (const YarnFailoverException & e) {
-         throw;
     } catch (const YarnRpcServerException & e) {
         UnWrapper<UnresolvedLinkException, YarnIOException> unwrapper(e);
         unwrapper.unwrap(__FILE__, __LINE__);
-    } catch (...) {
-        THROW(YarnIOException,
-              "Unexpected exception: when calling "
-              "ApplicationClientProtocol::getContainers in %s: %d",
-              __FILE__, __LINE__);
     }
 }
 
@@ -214,16 +186,9 @@ GetClusterNodesResponse ApplicationClientProtocol::getClusterNodes(
         GetClusterNodesRequestProto requestProto = request.getProto();
         invoke(RpcCall(true, "getClusterNodes", &requestProto, &responseProto));
         return GetClusterNodesResponse(responseProto);
-    } catch (const YarnFailoverException & e) {
-         throw;
     } catch (const YarnRpcServerException & e) {
         UnWrapper<UnresolvedLinkException, YarnIOException> unwrapper(e);
         unwrapper.unwrap(__FILE__, __LINE__);
-    } catch (...) {
-        THROW(YarnIOException,
-              "Unexpected exception: when calling "
-              "ApplicationClientProtocol::getClusterNodes in %s: %d",
-              __FILE__, __LINE__);
     }
 }
 
@@ -258,24 +223,17 @@ GetQueueInfoResponse ApplicationClientProtocol::getQueueInfo(
         GetQueueInfoRequestProto requestProto = request.getProto();
         invoke(RpcCall(true, "getQueueInfo", &requestProto, &responseProto));
         return GetQueueInfoResponse(responseProto);
-    } catch (const YarnFailoverException & e) {
-         throw;
     } catch (const YarnRpcServerException & e) {
         UnWrapper<UnresolvedLinkException, YarnIOException> unwrapper(e);
         unwrapper.unwrap(__FILE__, __LINE__);
-    } catch (...) {
-        THROW(YarnIOException,
-              "Unexpected exception: when calling "
-              "ApplicationClientProtocol::getQueueInfo in %s: %d",
-              __FILE__, __LINE__);
     }
 }
 
-//rpc getClusterMetrics (GetClusterMetricsRequestProto) returns (GetClusterMetricsResponseProto);
-
-//message GetClusterMetricsRequestProto {
-//}
-
+/*
+ rpc getClusterMetrics (GetClusterMetricsRequestProto) returns (GetClusterMetricsResponseProto);
+ message GetClusterMetricsRequestProto {
+ }
+ */
 GetClusterMetricsResponse ApplicationClientProtocol::getClusterMetrics(
         GetClusterMetricsRequest &request) {
     try {
@@ -283,16 +241,9 @@ GetClusterMetricsResponse ApplicationClientProtocol::getClusterMetrics(
         GetClusterMetricsRequestProto requestProto = request.getProto();
         invoke(RpcCall(true, "getClusterMetrics", &requestProto, &responseProto));
         return GetClusterMetricsResponse(responseProto);
-    } catch (const YarnFailoverException & e) {
-         throw;
     } catch (const YarnRpcServerException & e) {
         UnWrapper<UnresolvedLinkException, YarnIOException> unwrapper(e);
         unwrapper.unwrap(__FILE__, __LINE__);
-    } catch (...) {
-        THROW(YarnIOException,
-              "Unexpected exception: when calling "
-              "ApplicationClientProtocol::getClusterMetrics in %s: %d",
-              __FILE__, __LINE__);
     }
 }
 
@@ -301,20 +252,12 @@ KillApplicationResponse ApplicationClientProtocol::forceKillApplication(
     try {
         KillApplicationResponseProto responseProto;
         KillApplicationRequestProto requestProto = request.getProto();
-        invoke(
-                RpcCall(true, "forceKillApplication", &requestProto,
+        invoke(RpcCall(true, "forceKillApplication", &requestProto,
                         &responseProto));
         return KillApplicationResponse(responseProto);
-    } catch (const YarnFailoverException & e) {
-         throw;
     } catch (const YarnRpcServerException & e) {
         UnWrapper<UnresolvedLinkException, YarnIOException> unwrapper(e);
         unwrapper.unwrap(__FILE__, __LINE__);
-    } catch (...) {
-        THROW(YarnIOException,
-              "Unexpected exception: when calling "
-              "ApplicationClientProtocol::forceKillApplication in %s: %d",
-              __FILE__, __LINE__);
     }
 }
 
@@ -325,16 +268,9 @@ GetApplicationsResponse ApplicationClientProtocol::getApplications(
         GetApplicationsRequestProto requestProto = request.getProto();
         invoke(RpcCall(true, "getApplications", &requestProto, &responseProto));
         return GetApplicationsResponse(responseProto);
-    } catch (const YarnFailoverException & e) {
-         throw;
     } catch (const YarnRpcServerException & e) {
         UnWrapper<UnresolvedLinkException, YarnIOException> unwrapper(e);
         unwrapper.unwrap(__FILE__, __LINE__);
-    } catch (...) {
-        THROW(YarnIOException,
-              "Unexpected exception: when calling "
-              "ApplicationClientProtocol::getApplications in %s: %d",
-              __FILE__, __LINE__);
     }
 }
 
@@ -345,16 +281,9 @@ GetQueueUserAclsInfoResponse ApplicationClientProtocol::getQueueAclsInfo(
         GetQueueUserAclsInfoRequestProto requestProto = request.getProto();
         invoke(RpcCall(true, "getQueueUserAcls", &requestProto, &responseProto));
         return GetQueueUserAclsInfoResponse(responseProto);
-    } catch (const YarnFailoverException & e) {
-         throw;
     } catch (const YarnRpcServerException & e) {
         UnWrapper<UnresolvedLinkException, YarnIOException> unwrapper(e);
         unwrapper.unwrap(__FILE__, __LINE__);
-    } catch (...) {
-        THROW(YarnIOException,
-              "Unexpected exception: when calling "
-              "ApplicationClientProtocol::getQueueAclsInfo in %s: %d",
-              __FILE__, __LINE__);
     }
 }
 

--- a/depends/libyarn/src/libyarnserver/ApplicationMasterProtocol.cpp
+++ b/depends/libyarn/src/libyarnserver/ApplicationMasterProtocol.cpp
@@ -60,14 +60,10 @@ RegisterApplicationMasterResponse ApplicationMasterProtocol::registerApplication
         RegisterApplicationMasterRequestProto requestProto = request.getProto();
         invoke(RpcCall(true, "registerApplicationMaster", &requestProto, &responseProto));
         return RegisterApplicationMasterResponse(responseProto);
-    } catch (const YarnFailoverException & e) {
-         throw;
-    } catch (...) {
-        THROW(YarnIOException,
-              "Unexpected exception: when calling "
-              "ApplicationMasterProtocol::registerApplicationMaster in %s: %d",
-              __FILE__, __LINE__);
-	}
+    } catch (const YarnRpcServerException & e) {
+        UnWrapper<ApplicationMasterNotRegisteredException, YarnIOException> unwrapper(e);
+        unwrapper.unwrap(__FILE__, __LINE__);
+    }
 }
 
 
@@ -77,16 +73,9 @@ AllocateResponse ApplicationMasterProtocol::allocate(AllocateRequest &request) {
         AllocateResponseProto responseProto;
         invoke(RpcCall(true, "allocate", &requestProto, &responseProto));
         return AllocateResponse(responseProto);
-    } catch (const YarnFailoverException & e) {
-         throw;
     } catch (const YarnRpcServerException & e) {
         UnWrapper<ApplicationMasterNotRegisteredException, YarnIOException> unwrapper(e);
         unwrapper.unwrap(__FILE__, __LINE__);
-    } catch (...) {
-        THROW(YarnIOException,
-              "Unexpected exception: when calling "
-              "ApplicationMasterProtocol::allocate in %s: %d",
-              __FILE__, __LINE__);
     }
 }
 
@@ -97,16 +86,9 @@ FinishApplicationMasterResponse ApplicationMasterProtocol::finishApplicationMast
         FinishApplicationMasterResponseProto responseProto;
         invoke(RpcCall(true, "finishApplicationMaster", &requestProto, &responseProto));
         return FinishApplicationMasterResponse(responseProto);
-    } catch (const YarnFailoverException & e) {
-         throw;
     } catch (const YarnRpcServerException & e) {
         UnWrapper<ApplicationMasterNotRegisteredException, YarnIOException> unwrapper(e);
         unwrapper.unwrap(__FILE__, __LINE__);
-    } catch (...) {
-        THROW(YarnIOException,
-              "Unexpected exception: when calling "
-              "ApplicationMasterProtocol::finishApplicationMaster in %s: %d",
-              __FILE__, __LINE__);
     }
 }
 

--- a/depends/libyarn/src/libyarnserver/ContainerManagementProtocol.cpp
+++ b/depends/libyarn/src/libyarnserver/ContainerManagementProtocol.cpp
@@ -34,77 +34,62 @@ using namespace Yarn;
 namespace libyarn {
 
 ContainerManagementProtocol::ContainerManagementProtocol(std::string & nmHost,
-		std::string & nmPort, const std::string & tokenService,
-		const SessionConfig & c, const RpcAuth & a) :
-		auth(a), client(RpcClient::getClient()), conf(c), protocol(
-		CONTAINER_MANAGEMENT_VERSION, CONTAINER_MANAGEMENT_PROTOCOL,
-		NM_TOKEN_KIND), server(tokenService, nmHost, nmPort) {
+        std::string & nmPort, const std::string & tokenService,
+        const SessionConfig & c, const RpcAuth & a) :
+        auth(a), client(RpcClient::getClient()), conf(c), protocol(
+        CONTAINER_MANAGEMENT_VERSION, CONTAINER_MANAGEMENT_PROTOCOL,
+        NM_TOKEN_KIND), server(tokenService, nmHost, nmPort) {
 }
 
 ContainerManagementProtocol::~ContainerManagementProtocol() {
 }
 
 void ContainerManagementProtocol::invoke(const RpcCall & call) {
-	try {
-		channel = &client.getChannel(auth, protocol, server, conf);
-		channel->invoke(call);
-		channel->close(false);
-	} catch (...) {
-		channel->close(false);
-		throw;
-	}
+    try {
+        channel = &client.getChannel(auth, protocol, server, conf);
+        channel->invoke(call);
+        channel->close(false);
+    } catch (...) {
+        channel->close(false);
+        throw;
+    }
 }
 
 
 StartContainersResponse ContainerManagementProtocol::startContainers(StartContainersRequest &request) {
-	try {
-		StartContainersResponseProto responseProto;
-		StartContainersRequestProto requestProto = request.getProto();
-		invoke(RpcCall(true, "startContainers", &requestProto, &responseProto));
-		return StartContainersResponse(responseProto);
-	} catch (const YarnRpcServerException & e) {
-		UnWrapper<UnresolvedLinkException, YarnIOException> unwrapper(e);
-		unwrapper.unwrap(__FILE__, __LINE__);
-	} catch (...) {
-		THROW(YarnIOException,
-			  "Unexpected exception: when calling "
-			  "ContainerManagementProtocol::startContainers in %s: %d",
-			  __FILE__, __LINE__);
-	}
+    try {
+        StartContainersResponseProto responseProto;
+        StartContainersRequestProto requestProto = request.getProto();
+        invoke(RpcCall(true, "startContainers", &requestProto, &responseProto));
+        return StartContainersResponse(responseProto);
+    } catch (const YarnRpcServerException & e) {
+        UnWrapper<UnresolvedLinkException, YarnIOException> unwrapper(e);
+        unwrapper.unwrap(__FILE__, __LINE__);
+    }
 }
 
 StopContainersResponse ContainerManagementProtocol::stopContainers(StopContainersRequest &request) {
-	try {
-		StopContainersRequestProto requestProto = request.getProto();
-		StopContainersResponseProto responseProto;
-		invoke(RpcCall(true, "stopContainers", &requestProto, &responseProto));
-		return StopContainersResponse(responseProto);
-	} catch (const YarnRpcServerException & e) {
-		UnWrapper<UnresolvedLinkException, YarnIOException> unwrapper(e);
-		unwrapper.unwrap(__FILE__, __LINE__);
-	} catch (...) {
-		THROW(YarnIOException,
-			  "Unexpected exception: when calling "
-			  "ContainerManagementProtocol::stopContainers in %s: %d",
-			  __FILE__, __LINE__);
-	}
+    try {
+        StopContainersRequestProto requestProto = request.getProto();
+        StopContainersResponseProto responseProto;
+        invoke(RpcCall(true, "stopContainers", &requestProto, &responseProto));
+        return StopContainersResponse(responseProto);
+    } catch (const YarnRpcServerException & e) {
+        UnWrapper<UnresolvedLinkException, YarnIOException> unwrapper(e);
+        unwrapper.unwrap(__FILE__, __LINE__);
+    }
 }
 
 GetContainerStatusesResponse ContainerManagementProtocol::getContainerStatuses(GetContainerStatusesRequest &request){
-	try {
-		GetContainerStatusesRequestProto requestProto = request.getProto();
-		GetContainerStatusesResponseProto responseProto;
-		invoke(RpcCall(true, "getContainerStatuses", &requestProto, &responseProto));
-		return GetContainerStatusesResponse(responseProto);
-	} catch (const YarnRpcServerException & e) {
-		UnWrapper<UnresolvedLinkException, YarnIOException> unwrapper(e);
-		unwrapper.unwrap(__FILE__, __LINE__);
-	} catch (...) {
-		THROW(YarnIOException,
-			  "Unexpected exception: when calling "
-			  "ContainerManagementProtocol::getContainerStatuses in %s: %d",
-			  __FILE__, __LINE__);
-	}
+    try {
+        GetContainerStatusesRequestProto requestProto = request.getProto();
+        GetContainerStatusesResponseProto responseProto;
+        invoke(RpcCall(true, "getContainerStatuses", &requestProto, &responseProto));
+        return GetContainerStatusesResponse(responseProto);
+    } catch (const YarnRpcServerException & e) {
+        UnWrapper<UnresolvedLinkException, YarnIOException> unwrapper(e);
+        unwrapper.unwrap(__FILE__, __LINE__);
+    }
 }
 
 } /* namespace libyarn */

--- a/depends/libyarn/test/unit/TestLibYarnServer/TestApplicationClientProtocol.cpp
+++ b/depends/libyarn/test/unit/TestLibYarnServer/TestApplicationClientProtocol.cpp
@@ -139,7 +139,7 @@ TEST_F(TestApplicationClientProtocol, TestGetClusterNodesException){
 
 	EXPECT_THROW(macp.getClusterNodes(gcnreq), YarnFailoverException);
 	EXPECT_THROW(macp.getClusterNodes(gcnreq), YarnIOException);
-	EXPECT_THROW(macp.getClusterNodes(gcnreq), YarnIOException);
+	EXPECT_THROW(macp.getClusterNodes(gcnreq), YarnException);
 }
 
 TEST_F(TestApplicationClientProtocol, TestGetQueueInfoException){

--- a/depends/libyarn/test/unit/TestLibYarnServer/TestApplicationClientProtocol.cpp
+++ b/depends/libyarn/test/unit/TestLibYarnServer/TestApplicationClientProtocol.cpp
@@ -84,7 +84,7 @@ TEST_F(TestApplicationClientProtocol, TestGetNewApplicationException){
 
 	EXPECT_THROW(gnares = macp.getNewApplication(gnareq), YarnFailoverException);
 	EXPECT_THROW(gnares = macp.getNewApplication(gnareq), YarnIOException);
-	EXPECT_THROW(gnares = macp.getNewApplication(gnareq), YarnIOException);
+	EXPECT_THROW(gnares = macp.getNewApplication(gnareq), YarnException);
 }
 
 TEST_F(TestApplicationClientProtocol, TestSubmitApplicationException){
@@ -97,7 +97,7 @@ TEST_F(TestApplicationClientProtocol, TestSubmitApplicationException){
 
 	EXPECT_THROW(macp.submitApplication(sareq), YarnFailoverException);
 	EXPECT_THROW(macp.submitApplication(sareq), YarnIOException);
-	EXPECT_THROW(macp.submitApplication(sareq), YarnIOException);
+	EXPECT_THROW(macp.submitApplication(sareq), YarnException);
 }
 
 TEST_F(TestApplicationClientProtocol, TestGetApplicationReportException){
@@ -111,7 +111,7 @@ TEST_F(TestApplicationClientProtocol, TestGetApplicationReportException){
 
 	EXPECT_THROW(macp.getApplicationReport(garreq), YarnFailoverException);
 	EXPECT_THROW(macp.getApplicationReport(garreq), YarnIOException);
-	EXPECT_THROW(macp.getApplicationReport(garreq), YarnIOException);
+	EXPECT_THROW(macp.getApplicationReport(garreq), YarnException);
 }
 
 TEST_F(TestApplicationClientProtocol, TestGetContainersException){
@@ -125,7 +125,7 @@ TEST_F(TestApplicationClientProtocol, TestGetContainersException){
 
 	EXPECT_THROW(macp.getContainers(gcreq), YarnFailoverException);
 	EXPECT_THROW(macp.getContainers(gcreq), YarnIOException);
-	EXPECT_THROW(macp.getContainers(gcreq), YarnIOException);
+	EXPECT_THROW(macp.getContainers(gcreq), YarnException);
 }
 
 TEST_F(TestApplicationClientProtocol, TestGetClusterNodesException){
@@ -153,7 +153,7 @@ TEST_F(TestApplicationClientProtocol, TestGetQueueInfoException){
 
 	EXPECT_THROW(macp.getQueueInfo(gqireq), YarnFailoverException);
 	EXPECT_THROW(macp.getQueueInfo(gqireq), YarnIOException);
-	EXPECT_THROW(macp.getQueueInfo(gqireq), YarnIOException);
+	EXPECT_THROW(macp.getQueueInfo(gqireq), YarnException);
 }
 
 TEST_F(TestApplicationClientProtocol, TestGetClusterMetricsException){
@@ -167,7 +167,7 @@ TEST_F(TestApplicationClientProtocol, TestGetClusterMetricsException){
 
 	EXPECT_THROW(macp.getClusterMetrics(gcmreq), YarnFailoverException);
 	EXPECT_THROW(macp.getClusterMetrics(gcmreq), YarnIOException);
-	EXPECT_THROW(macp.getClusterMetrics(gcmreq), YarnIOException);
+	EXPECT_THROW(macp.getClusterMetrics(gcmreq), YarnException);
 }
 
 TEST_F(TestApplicationClientProtocol, TestForceKillApplicationException){
@@ -181,7 +181,7 @@ TEST_F(TestApplicationClientProtocol, TestForceKillApplicationException){
 
 	EXPECT_THROW(macp.forceKillApplication(kareq), YarnFailoverException);
 	EXPECT_THROW(macp.forceKillApplication(kareq), YarnIOException);
-	EXPECT_THROW(macp.forceKillApplication(kareq), YarnIOException);
+	EXPECT_THROW(macp.forceKillApplication(kareq), YarnException);
 }
 
 TEST_F(TestApplicationClientProtocol, TestGetApplicationsException){
@@ -195,7 +195,7 @@ TEST_F(TestApplicationClientProtocol, TestGetApplicationsException){
 
 	EXPECT_THROW(macp.getApplications(gareq), YarnFailoverException);
 	EXPECT_THROW(macp.getApplications(gareq), YarnIOException);
-	EXPECT_THROW(macp.getApplications(gareq), YarnIOException);
+	EXPECT_THROW(macp.getApplications(gareq), YarnException);
 }
 
 TEST_F(TestApplicationClientProtocol, TestGetQueueAclsInfoException){
@@ -209,5 +209,5 @@ TEST_F(TestApplicationClientProtocol, TestGetQueueAclsInfoException){
 
 	EXPECT_THROW(macp.getQueueAclsInfo(gquareq), YarnFailoverException);
 	EXPECT_THROW(macp.getQueueAclsInfo(gquareq), YarnIOException);
-	EXPECT_THROW(macp.getQueueAclsInfo(gquareq), YarnIOException);
+	EXPECT_THROW(macp.getQueueAclsInfo(gquareq), YarnException);
 }

--- a/depends/libyarn/test/unit/TestLibYarnServer/TestApplicationMasterProtocol.cpp
+++ b/depends/libyarn/test/unit/TestLibYarnServer/TestApplicationMasterProtocol.cpp
@@ -67,7 +67,7 @@ TEST_F(TestApplicationMasterProtocol, TestRegisterApplicationMasterException){
 
 	EXPECT_CALL(mamp, invoke(_)).Times(1).WillOnce(Throw(YarnException("", __FILE__, __LINE__, Yarn::Internal::PrintStack(1, STACK_DEPTH).c_str())));
 
-	EXPECT_THROW(ramres = mamp.registerApplicationMaster(ramreq), YarnIOException);
+	EXPECT_THROW(ramres = mamp.registerApplicationMaster(ramreq), YarnException);
 }
 
 TEST_F(TestApplicationMasterProtocol, TestAllocateException){
@@ -77,7 +77,7 @@ TEST_F(TestApplicationMasterProtocol, TestAllocateException){
 
 	EXPECT_CALL(mamp, invoke(_)).Times(1).WillOnce(Throw(YarnException("", __FILE__, __LINE__, Yarn::Internal::PrintStack(1, STACK_DEPTH).c_str())));
 
-	EXPECT_THROW(ares = mamp.allocate(areq), YarnIOException);
+	EXPECT_THROW(ares = mamp.allocate(areq), YarnException);
 }
 
 TEST_F(TestApplicationMasterProtocol, TestFinishApplicationMasterException){
@@ -92,5 +92,5 @@ TEST_F(TestApplicationMasterProtocol, TestFinishApplicationMasterException){
 
 	EXPECT_THROW(famres = mamp.finishApplicationMaster(famreq), YarnFailoverException);
 	EXPECT_THROW(famres = mamp.finishApplicationMaster(famreq), YarnIOException);
-	EXPECT_THROW(famres = mamp.finishApplicationMaster(famreq), YarnIOException);
+	EXPECT_THROW(famres = mamp.finishApplicationMaster(famreq), YarnException);
 }

--- a/depends/libyarn/test/unit/TestLibYarnServer/TestContainerManagementProtocol.cpp
+++ b/depends/libyarn/test/unit/TestLibYarnServer/TestContainerManagementProtocol.cpp
@@ -72,7 +72,7 @@ TEST_F(TestContainerManagementProtocol,TestStartContainersException){
 			.WillOnce(Throw(YarnException("", __FILE__, __LINE__, Yarn::Internal::PrintStack(1, STACK_DEPTH).c_str())));
 
 	EXPECT_THROW(scres = mcmp.startContainers(screq), YarnIOException);
-	EXPECT_THROW(scres = mcmp.startContainers(screq), YarnIOException);
+	EXPECT_THROW(scres = mcmp.startContainers(screq), YarnException);
 }
 
 TEST_F(TestContainerManagementProtocol,TestStopContainersException){
@@ -84,7 +84,7 @@ TEST_F(TestContainerManagementProtocol,TestStopContainersException){
 			.WillOnce(Throw(YarnException("", __FILE__, __LINE__, Yarn::Internal::PrintStack(1, STACK_DEPTH).c_str())));
 
 	EXPECT_THROW(scres = mcmp.stopContainers(screq), YarnIOException);
-	EXPECT_THROW(scres = mcmp.stopContainers(screq), YarnIOException);
+	EXPECT_THROW(scres = mcmp.stopContainers(screq), YarnException);
 }
 
 
@@ -97,5 +97,5 @@ TEST_F(TestContainerManagementProtocol,getContainerStatusesException){
 			.WillOnce(Throw(YarnException("", __FILE__, __LINE__, Yarn::Internal::PrintStack(1, STACK_DEPTH).c_str())));
 
 	EXPECT_THROW(gcsres = mcmp.getContainerStatuses(gcsreq), YarnIOException);
-	EXPECT_THROW(gcsres = mcmp.getContainerStatuses(gcsreq), YarnIOException);
+	EXPECT_THROW(gcsres = mcmp.getContainerStatuses(gcsreq), YarnException);
 }


### PR DESCRIPTION
The fix has removed catch(...) from ApplicationMasterProtocol, ApplicationClientProtocol, ContainerManagementProtocol, so when an exception is raised from RPC call(invoke() function), the exception will be thrown to outer, so that libyarn can display the exact exception information instead of "unexpected exception".

Please review. Thanks!