### PR TITLE
HAWQ-978. Fixed deadlock in signal handler which call asynchronous un…

### DIFF
--- a/src/backend/storage/lmgr/proc.c
+++ b/src/backend/storage/lmgr/proc.c
@@ -1432,8 +1432,6 @@ CheckStatementTimeout(void)
 		/* Time to die */
 		statement_timeout_active = false;
 		cancel_from_timeout = true;
-		elog(LOG,"Issuing cancel signal (SIGINT) to my self (pid = %d) for statement timeout.",
-			 MyProcPid);
 #ifdef HAVE_SETSID
 		/* try to signal whole process group */
 		kill(-MyProcPid, SIGINT);


### PR DESCRIPTION
…safe functions elog()

(1) Can not call elog() in signal handler function, because elog() will cascade call some unsafe function. 
(2) When CheckStatementTimeout() called, "canceling statement due to statement timeout" will be printed out, so we don't need to re-print it.