### PR TITLE
HAWQ-779 support pxf filter pushdwon at the 'CREATE PLAN' stage ,and …

### DIFF
--- a/pxf/pxf-api/src/main/java/org/apache/hawq/pxf/api/FilterParser.java
+++ b/pxf/pxf-api/src/main/java/org/apache/hawq/pxf/api/FilterParser.java
@@ -61,7 +61,8 @@ public class FilterParser {
         HDOP_GE,
         HDOP_EQ,
         HDOP_NE,
-        HDOP_AND
+        HDOP_AND,
+        HDOP_LIKE
     }
 
     /**
@@ -392,6 +393,7 @@ public class FilterParser {
         operatorTranslationMap.put(5, Operation.HDOP_EQ);
         operatorTranslationMap.put(6, Operation.HDOP_NE);
         operatorTranslationMap.put(7, Operation.HDOP_AND);
+        operatorTranslationMap.put(8, Operation.HDOP_LIKE);
         return operatorTranslationMap;
     }
 }

--- a/pxf/pxf-api/src/test/java/org/apache/hawq/pxf/api/FilterParserTest.java
+++ b/pxf/pxf-api/src/test/java/org/apache/hawq/pxf/api/FilterParserTest.java
@@ -218,7 +218,7 @@ public class FilterParserTest {
         
         filter = "a1c2o8";
         op = Operation.HDOP_LIKE;
-        runParseOneOperation("this filter was build from HDOP_LIKE", filter, op);
+        runParseOneOperation("this filter was built from HDOP_LIKE", filter, op);
     }
 
     @Test

--- a/pxf/pxf-api/src/test/java/org/apache/hawq/pxf/api/FilterParserTest.java
+++ b/pxf/pxf-api/src/test/java/org/apache/hawq/pxf/api/FilterParserTest.java
@@ -215,6 +215,10 @@ public class FilterParserTest {
         filter = "a1c2o7";
         op = Operation.HDOP_AND;
         runParseOneOperation("this filter was build from HDOP_AND", filter, op);
+        
+        filter = "a1c2o8";
+        op = Operation.HDOP_LIKE;
+        runParseOneOperation("this filter was build from HDOP_LIKE", filter, op);
     }
 
     @Test
@@ -247,6 +251,10 @@ public class FilterParserTest {
         filter = "c2a1o7";
         op = Operation.HDOP_AND;
         runParseOneOperation("this filter was build from HDOP_AND using reverse!", filter, op);
+        
+        filter = "c2a1o8";
+        op = Operation.HDOP_LIKE;
+        runParseOneOperation("this filter was build from HDOP_LIKE using reverse!", filter, op);
     }
 
     @Test

--- a/pxf/pxf-hbase/src/main/java/org/apache/hawq/pxf/plugins/hbase/HBaseFilterBuilder.java
+++ b/pxf/pxf-hbase/src/main/java/org/apache/hawq/pxf/plugins/hbase/HBaseFilterBuilder.java
@@ -166,7 +166,7 @@ public class HBaseFilterBuilder implements FilterParser.FilterBuilder {
                 constant.constant());
 
         if(operatorsMap.get(opId) == null){
-            //HBase not support HDOP_LIKE, use 'NOT NULL' Comarator
+            //HBase does not support HDOP_LIKE, use 'NOT NULL' comparator
             return new SingleColumnValueFilter(hbaseColumn.columnFamilyBytes(),
                     hbaseColumn.qualifierBytes(),
                     CompareFilter.CompareOp.NOT_EQUAL,

--- a/pxf/pxf-hbase/src/main/java/org/apache/hawq/pxf/plugins/hbase/HBaseFilterBuilder.java
+++ b/pxf/pxf-hbase/src/main/java/org/apache/hawq/pxf/plugins/hbase/HBaseFilterBuilder.java
@@ -165,6 +165,14 @@ public class HBaseFilterBuilder implements FilterParser.FilterBuilder {
         ByteArrayComparable comparator = getComparator(hbaseColumn.columnTypeCode(),
                 constant.constant());
 
+        if(operatorsMap.get(opId) == null){
+            //HBase not support HDOP_LIKE, use 'NOT NULL' Comarator
+            return new SingleColumnValueFilter(hbaseColumn.columnFamilyBytes(),
+                    hbaseColumn.qualifierBytes(),
+                    CompareFilter.CompareOp.NOT_EQUAL,
+                    new NullComparator());
+        }
+
         /**
          * If row key is of type TEXT, allow filter in start/stop row key API in
          * HBaseAccessor/Scan object.

--- a/src/backend/access/external/pxffilters.c
+++ b/src/backend/access/external/pxffilters.c
@@ -78,6 +78,7 @@ dbop_pxfop_map pxf_supported_opr[] =
 	{665 /* text_le */, PXFOP_LE},
 	{667 /* text_ge */, PXFOP_GE},
 	{531 /* textlt  */, PXFOP_NE},
+	{1209 /* textlike  */, PXFOP_LIKE},
 
 	/* int2 to int4 */
 	{Int24EqualOperator /* int24eq */, PXFOP_EQ},
@@ -125,7 +126,15 @@ dbop_pxfop_map pxf_supported_opr[] =
 	{1871 /* int82gt */, PXFOP_GT},
 	{1872 /* int82le */, PXFOP_LE},
 	{1873 /* int82ge */, PXFOP_GE},
-	{1869 /* int82ne */, PXFOP_NE}
+	{1869 /* int82ne */, PXFOP_NE},
+
+	/* date */
+	{DateEqualOperator  /* eq */, PXFOP_EQ},
+	{1095  /* date_lt */, PXFOP_LT},
+	{1097 /* date_gt */, PXFOP_GT},
+	{1096 /* date_le */, PXFOP_LE},
+	{1098 /* date_ge */, PXFOP_GE},
+	{1094 /* date_ne */, PXFOP_NE}
 
 };
 
@@ -142,7 +151,8 @@ Oid pxf_supported_types[] =
 	BPCHAROID,
 	CHAROID,
 	BYTEAOID,
-	BOOLOID
+	BOOLOID,
+	DATEOID
 };
 
 /*
@@ -513,6 +523,7 @@ const_to_str(Const *constval, StringInfo buf)
 		case BPCHAROID:
 		case CHAROID:
 		case BYTEAOID:
+		case DATEOID:
 			appendStringInfo(buf, "\\\"%s\\\"", extval);
 			break;
 

--- a/src/backend/access/external/test/pxffilters_test.c
+++ b/src/backend/access/external/test/pxffilters_test.c
@@ -42,6 +42,7 @@ test__supported_filter_type(void **state)
 		CHAROID,
 		BYTEAOID,
 		BOOLOID,
+		DATEOID,
 		CIRCLEOID /* unsupported type */
 	};
 
@@ -61,7 +62,7 @@ test__supported_filter_type(void **state)
 
 	/* go over pxf_supported_types array */
 	int nargs = sizeof(pxf_supported_types) / sizeof(Oid);
-	assert_int_equal(nargs, 12);
+	assert_int_equal(nargs, 13);
 	for (i = 0; i < nargs; ++i)
 	{
 		assert_true(supported_filter_type(pxf_supported_types[i]));
@@ -184,6 +185,7 @@ test__const_to_str__text(void **state)
 	verify__const_to_str(false, "isn't", BPCHAROID, "\\\"isn't\\\"");
 	verify__const_to_str(false, "funny", CHAROID, "\\\"funny\\\"");
 	verify__const_to_str(false, "anymore", BYTEAOID, "\\\"anymore\\\"");
+	verify__const_to_str(false, "iamdate", DATEOID, "\\\"iamdate\\\"");
 }
 
 void
@@ -523,6 +525,10 @@ test__pxf_serialize_filter_list__manyFilters(void **state)
 			PXF_ATTR_CODE, 5, NULL,
 			PXF_CONST_CODE, 0, "\"Winston\"",
 			PXFOP_GE);
+	PxfFilterDesc* filter5 = build_filter(
+			PXF_ATTR_CODE, 6, NULL,
+			PXF_CONST_CODE, 0, "\"Eric-%\"",
+			PXFOP_LIKE);
 
 	filter_list = lappend(filter_list, filter1);
 	filter_list = lappend(filter_list, filter2);
@@ -541,6 +547,12 @@ test__pxf_serialize_filter_list__manyFilters(void **state)
 
 	result = pxf_serialize_filter_list(filter_list);
 	assert_string_equal(result, "a1c1983o2a2c1985o1o7a3c\"George Orwell\"o5o7a4c\"Winston\"o4o7");
+	pfree(result);
+
+	filter_list = lappend(filter_list, filter5);
+
+	result = pxf_serialize_filter_list(filter_list);
+	assert_string_equal(result, "a1c1983o2a2c1985o1o7a3c\"George Orwell\"o5o7a4c\"Winston\"o4o7a5c\"Eric-%\"o8o7");
 	pfree(result);
 
 	pxf_free_filter_list(filter_list);

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -1144,9 +1144,15 @@ static char** create_pxf_plan(char **segdb_file_map, RelOptInfo *rel, int total_
 	
 	
 	Relation relation = RelationIdGetRelation(planner_rt_fetch(scan_relid, ctx->root)->relid);
-	segdb_work_map = map_hddata_2gp_segments(uri_str, 
+	if (pxf_enable_filter_pushdown){
+		segdb_work_map = map_hddata_2gp_segments(uri_str,
 											 total_segs, segs_participating,
 											 relation, ctx->root->parse->jointree->quals);
+	}else{
+		segdb_work_map = map_hddata_2gp_segments(uri_str,
+											 total_segs, segs_participating,
+											 relation, NULL);
+	}
 	Assert(segdb_work_map != NULL);
 	RelationClose(relation);
 	

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -1146,7 +1146,7 @@ static char** create_pxf_plan(char **segdb_file_map, RelOptInfo *rel, int total_
 	Relation relation = RelationIdGetRelation(planner_rt_fetch(scan_relid, ctx->root)->relid);
 	segdb_work_map = map_hddata_2gp_segments(uri_str, 
 											 total_segs, segs_participating,
-											 relation, NULL);
+											 relation, ctx->root->parse->jointree->quals);
 	Assert(segdb_work_map != NULL);
 	RelationClose(relation);
 	

--- a/src/include/access/pxffilters.h
+++ b/src/include/access/pxffilters.h
@@ -44,7 +44,8 @@ typedef enum PxfOperatorCode
 	PXFOP_GE,
 	PXFOP_EQ,
 	PXFOP_NE,
-	PXFOP_AND
+	PXFOP_AND,
+	PXFOP_LIKE
 
 } PxfOperatorCode;
 


### PR DESCRIPTION
1.support  pxf filter pushdwon at the 'CREATE PLAN' stage -- src/backend/optimizer/plan/createplan.c
2.Due to '1' causes produce HAWQ-953 error, modify HiveDataFragmenter.java
3.add 'Date type'  filter and  'HDOP_LIKE' op -- pxffilters.h,pxffilters.c,FilterParser.java , and update the corresponding test -- FilterParserTest.java,pxffilters_test.c
4.Due to '2' cause,modified HBaseFilterBuilder.java to handle 'HDOP_LIKE' op.
5. 'Date filter' and  'HDOP_LIKE' used in pxf-solr/pxf-jdbc(https://github.com/inspur-insight/pxf-plugin)
6.By this amendment, I think: 'PXF Filter' architecture coupling is too high, I just want to add new types and op, but had to modify other components .i hope to improve the architecture .

