### PR TITLE
HAWQ-999. Treat hash table as random when file count is not in propor…

### DIFF
--- a/src/backend/cdb/cdbdatalocality.c
+++ b/src/backend/cdb/cdbdatalocality.c
@@ -3792,8 +3792,11 @@ run_allocation_algorithm(SplitAllocResult *result, List *virtual_segments, Query
 		bool isRelationHash = is_relation_hash(targetPolicy);
 
 		int fileCountInRelation = list_length(rel_data->files);
-		bool FileCountBucketNumMismatch = fileCountInRelation %
+		bool FileCountBucketNumMismatch = false;
+		if (targetPolicy->bucketnum > 0) {
+		  FileCountBucketNumMismatch = fileCountInRelation %
 		    targetPolicy->bucketnum == 0 ? false : true;
+		}
 		if (FileCountBucketNumMismatch && !allow_file_count_bucket_num_mismatch) {
 		  elog(ERROR, "file count in catalog is not in proportion to the bucket number "
 		      "of hash table with oid=%u, some data maybe lost, if you still want to "

--- a/src/backend/cdb/cdbdatalocality.c
+++ b/src/backend/cdb/cdbdatalocality.c
@@ -3798,11 +3798,11 @@ run_allocation_algorithm(SplitAllocResult *result, List *virtual_segments, Query
 		    targetPolicy->bucketnum == 0 ? false : true;
 		}
 		if (FileCountBucketNumMismatch && !allow_file_count_bucket_num_mismatch) {
-		  elog(ERROR, "file count in catalog is not in proportion to the bucket number "
-		      "of hash table with oid=%u, some data maybe lost, if you still want to "
-		      "continue the query by considering the table as random, set GUC "
+		  elog(ERROR, "file count %d in catalog is not in proportion to the bucket "
+		      "number %d of hash table with oid=%u, some data may be lost, if you "
+		      "still want to continue the query by considering the table as random, set GUC "
 		      "allow_file_count_bucket_num_mismatch to on and try again.",
-		      myrelid);
+		      fileCountInRelation, targetPolicy->bucketnum, myrelid);
 		}
 		/* change the virtual segment order when keep hash.
 		 * order of idMap should also be changed.

--- a/src/backend/cdb/cdbdatalocality.c
+++ b/src/backend/cdb/cdbdatalocality.c
@@ -3829,7 +3829,7 @@ run_allocation_algorithm(SplitAllocResult *result, List *virtual_segments, Query
 		  /*
 		   * if file count of the table is not equal to or multiple of
 		   * bucket number, we should process it as random table.
-	     */
+		   */
 			if (context->keep_hash
 			    && assignment_context.virtual_segment_num== targetPolicy->bucketnum
 			    && fileCountInRelation % targetPolicy->bucketnum == 0) {

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -3179,7 +3179,7 @@ static struct config_bool ConfigureNamesBool[] =
 	{
 	    {"allow_file_count_bucket_num_mismatch", PGC_POSTMASTER, CLIENT_CONN_LOCALE,
 	          gettext_noop("allow hash table to be treated as random when file count and"
-	              " bucket number are mismathced"),
+	              " bucket number are mismatched"),
 	          NULL,
 	          GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 	    },

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -450,6 +450,7 @@ char       *Debug_dtm_action_protocol_str;
 
 /* Enable check for compatibility of encoding and locale in createdb */
 bool		gp_encoding_check_locale_compatibility;
+bool  allow_file_count_bucket_num_mismatch;
 
 char	   *pgstat_temp_directory;
 
@@ -3173,6 +3174,17 @@ static struct config_bool ConfigureNamesBool[] =
 		},
 		&gp_encoding_check_locale_compatibility,
 		true, NULL, NULL
+	},
+
+	{
+	    {"allow_file_count_bucket_num_mismatch", PGC_POSTMASTER, CLIENT_CONN_LOCALE,
+	          gettext_noop("allow hash table to be treated as random when file count and"
+	              " bucket number are mismathced"),
+	          NULL,
+	          GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+	    },
+	    &allow_file_count_bucket_num_mismatch,
+	    false, NULL, NULL
 	},
 
 	{

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -310,6 +310,7 @@ extern int hawq_rm_nvseg_for_analyze_nopart_perquery_perseg_limit;
 extern int hawq_rm_nvseg_for_analyze_part_perquery_perseg_limit;
 extern int hawq_rm_nvseg_for_analyze_nopart_perquery_limit;
 extern int hawq_rm_nvseg_for_analyze_part_perquery_limit;
+extern bool allow_file_count_bucket_num_mismatch;
 
 extern char *ConfigFileName;
 extern char *HbaFileName;


### PR DESCRIPTION
…tion to bucket number of table.
By definition, file count of a hash table should be equal to or a multiple of the bucket number of the table. So if mismatch happens, we should not treat it as hash table in data locality algorithm.
