### PR TITLE
HAWQ-997. HAWQ doesn't send PXF data type with precision.

### DIFF
--- a/src/backend/access/external/pxfheaders.c
+++ b/src/backend/access/external/pxfheaders.c
@@ -172,7 +172,7 @@ static void add_tuple_desc_httpheader(CHURL_HEADERS headers, Relation rel)
 				case NUMERICOID:
 				{
 					resetStringInfo(&formatter);
-					appendStringInfo(&formatter, "X-GP-ATTR-TYPEMODX-COUNT");
+					appendStringInfo(&formatter, "X-GP-ATTR-TYPEMOD%u-COUNT", i);
 					pg_ltoa(2, long_number);
 					churl_headers_append(headers, formatter.data, long_number);
 
@@ -195,7 +195,7 @@ static void add_tuple_desc_httpheader(CHURL_HEADERS headers, Relation rel)
 				case VARCHAROID:
 				{
 					resetStringInfo(&formatter);
-					appendStringInfo(&formatter, "X-GP-ATTR-TYPEMODX-COUNT");
+					appendStringInfo(&formatter, "X-GP-ATTR-TYPEMOD%u-COUNT", i);
 					pg_ltoa(1, long_number);
 					churl_headers_append(headers, formatter.data, long_number);
 
@@ -213,7 +213,7 @@ static void add_tuple_desc_httpheader(CHURL_HEADERS headers, Relation rel)
 				case TIMETZOID:
 				{
 					resetStringInfo(&formatter);
-					appendStringInfo(&formatter, "X-GP-ATTR-TYPEMODX-COUNT");
+					appendStringInfo(&formatter, "X-GP-ATTR-TYPEMOD%u-COUNT", i);
 					pg_ltoa(1, long_number);
 					churl_headers_append(headers, formatter.data, long_number);
 
@@ -226,7 +226,7 @@ static void add_tuple_desc_httpheader(CHURL_HEADERS headers, Relation rel)
 				case INTERVALOID:
 				{
 					resetStringInfo(&formatter);
-					appendStringInfo(&formatter, "X-GP-ATTR-TYPEMODX-COUNT");
+					appendStringInfo(&formatter, "X-GP-ATTR-TYPEMOD%u-COUNT", i);
 					pg_ltoa(1, long_number);
 					churl_headers_append(headers, formatter.data, long_number);
 

--- a/src/backend/access/external/pxfheaders.c
+++ b/src/backend/access/external/pxfheaders.c
@@ -193,12 +193,17 @@ static void add_tuple_desc_httpheader(CHURL_HEADERS headers, Relation rel)
 				case BITOID:
 				case TIMESTAMPOID:
 				case TIMESTAMPTZOID:
-				//case INTERVALOID:
 				case TIMEOID:
 				case TIMETZOID:
 					resetStringInfo(&formatter);
 					appendStringInfo(&formatter, "X-GP-ATTR%u-TYPEMOD%u", i, 0);
 					pg_ltoa((tuple->attrs[i]->atttypmod), long_number);
+					churl_headers_append(headers, formatter.data, long_number);
+					break;
+				case INTERVALOID:
+					resetStringInfo(&formatter);
+					appendStringInfo(&formatter, "X-GP-ATTR%u-TYPEMOD%u", i, 0);
+					pg_ltoa(INTERVAL_PRECISION(tuple->attrs[i]->atttypmod), long_number);
 					churl_headers_append(headers, formatter.data, long_number);
 					break;
 				default:

--- a/src/backend/access/external/pxfheaders.c
+++ b/src/backend/access/external/pxfheaders.c
@@ -161,6 +161,32 @@ static void add_tuple_desc_httpheader(CHURL_HEADERS headers, Relation rel)
         resetStringInfo(&formatter);
         appendStringInfo(&formatter, "X-GP-ATTR-TYPENAME%u", i);
         churl_headers_append(headers, formatter.data, TypeOidGetTypename(tuple->attrs[i]->atttypid));
+
+        /* Add attribute type modifiers if any*/
+		switch (tuple->attrs[i]->atttypid)
+		{
+			case NUMERICOID:
+			{
+				if (tuple->attrs[i]->atttypmod > -1)
+
+					/* precision */
+					resetStringInfo(&formatter);
+					appendStringInfo(&formatter, "X-GP-ATTR%u-TYPEMOD%u", i, 0);
+					pg_ltoa((tuple->attrs[i]->atttypmod >> 16) & 0xffff, long_number);
+					churl_headers_append(headers, formatter.data, long_number);
+
+					/* scale */
+					resetStringInfo(&formatter);
+					appendStringInfo(&formatter, "X-GP-ATTR%u-TYPEMOD%u", i, 1);
+					pg_ltoa((tuple->attrs[i]->atttypmod) & 0xffff, long_number);
+					churl_headers_append(headers, formatter.data, long_number);
+
+				break;
+			}
+			default:
+				break;
+		}
+
     }
 	
 	pfree(formatter.data);

--- a/src/backend/access/external/pxfheaders.c
+++ b/src/backend/access/external/pxfheaders.c
@@ -207,6 +207,7 @@ static void add_tuple_desc_httpheader(CHURL_HEADERS headers, Relation rel)
 					churl_headers_append(headers, formatter.data, long_number);
 					break;
 				default:
+					elog(DEBUG5, "add_tuple_desc_httpheader: unsupported type %d ", tuple->attrs[i]->atttypid);
 					break;
 			}
 		}

--- a/src/backend/access/external/pxfheaders.c
+++ b/src/backend/access/external/pxfheaders.c
@@ -127,7 +127,7 @@ static void add_alignment_size_httpheader(CHURL_HEADERS headers)
  * X-GP-ATTR-NAMEX - attribute X's name 
  * X-GP-ATTR-TYPECODEX - attribute X's type OID (e.g, 16)
  * X-GP-ATTR-TYPENAMEX - attribute X's type name (e.g, "boolean")
- * optional - X-GP-ATTR-TYPEMODX-COUNT - total number of modifier for attribute X's modifiers
+ * optional - X-GP-ATTR-TYPEMODX-COUNT - total number of modifier for attribute X
  * optional - X-GP-ATTR-TYPEMODX-Y - attribute X's modifiers Y (types which have precision info, like numeric(p,s))
  */
 static void add_tuple_desc_httpheader(CHURL_HEADERS headers, Relation rel)

--- a/src/backend/access/external/pxfheaders.c
+++ b/src/backend/access/external/pxfheaders.c
@@ -168,7 +168,6 @@ static void add_tuple_desc_httpheader(CHURL_HEADERS headers, Relation rel)
 			switch (tuple->attrs[i]->atttypid)
 			{
 				case NUMERICOID: {
-
 					/* precision */
 					resetStringInfo(&formatter);
 					appendStringInfo(&formatter, "X-GP-ATTR%u-TYPEMOD%u", i, 0);
@@ -182,11 +181,24 @@ static void add_tuple_desc_httpheader(CHURL_HEADERS headers, Relation rel)
 					churl_headers_append(headers, formatter.data, long_number);
 					break;
 				}
-				case VARCHAROID:
+				case CHAROID:
 				case BPCHAROID:
+				case VARCHAROID:
 					resetStringInfo(&formatter);
 					appendStringInfo(&formatter, "X-GP-ATTR%u-TYPEMOD%u", i, 0);
 					pg_ltoa((tuple->attrs[i]->atttypmod - VARHDRSZ), long_number);
+					churl_headers_append(headers, formatter.data, long_number);
+					break;
+				case VARBITOID:
+				case BITOID:
+				case TIMESTAMPOID:
+				case TIMESTAMPTZOID:
+				//case INTERVALOID:
+				case TIMEOID:
+				case TIMETZOID:
+					resetStringInfo(&formatter);
+					appendStringInfo(&formatter, "X-GP-ATTR%u-TYPEMOD%u", i, 0);
+					pg_ltoa((tuple->attrs[i]->atttypmod), long_number);
 					churl_headers_append(headers, formatter.data, long_number);
 					break;
 				default:


### PR DESCRIPTION
With this change additional types modifiers are being added to http header so it looks like:

GET /pxf/v14/Fragmenter/getFragments?path=hive_orc_all_types HTTP/1.1
Host: localhost:51200
Accept: application/json
X-GP-FORMAT: GPDBWritable
X-GP-ATTRS: 10
X-GP-ATTR-NAME0: bit_c
X-GP-ATTR-TYPECODE0: 1560
X-GP-ATTR-TYPENAME0: bit
X-GP-ATTR-TYPEMOD0-COUNT: 1
X-GP-ATTR-TYPEMOD0-0: 4
X-GP-ATTR-NAME1: bit_var_c
X-GP-ATTR-TYPECODE1: 1562
X-GP-ATTR-TYPENAME1: varbit
X-GP-ATTR-TYPEMOD1-COUNT: 1
X-GP-ATTR-TYPEMOD1-0: 5
X-GP-ATTR-NAME2: char_c
X-GP-ATTR-TYPECODE2: 1042
X-GP-ATTR-TYPENAME2: bpchar
X-GP-ATTR-TYPEMOD2-COUNT: 1
X-GP-ATTR-TYPEMOD2-0: 6
X-GP-ATTR-NAME3: varchar_c
X-GP-ATTR-TYPECODE3: 1043
X-GP-ATTR-TYPENAME3: varchar
X-GP-ATTR-TYPEMOD3-COUNT: 1
X-GP-ATTR-TYPEMOD3-0: 7
X-GP-ATTR-NAME4: decimal_c
X-GP-ATTR-TYPECODE4: 1700
X-GP-ATTR-TYPENAME4: numeric
X-GP-ATTR-TYPEMOD4-COUNT: 2
X-GP-ATTR-TYPEMOD4-0: 14
X-GP-ATTR-TYPEMOD4-1: 2
X-GP-ATTR-NAME5: in_c
X-GP-ATTR-TYPECODE5: 1186
X-GP-ATTR-TYPENAME5: interval
X-GP-ATTR-TYPEMOD5-COUNT: 1
X-GP-ATTR-TYPEMOD5-0: 3
X-GP-ATTR-NAME6: tm_c
X-GP-ATTR-TYPECODE6: 1083
X-GP-ATTR-TYPENAME6: time
X-GP-ATTR-TYPEMOD6-COUNT: 1
X-GP-ATTR-TYPEMOD6-0: 5
X-GP-ATTR-NAME7: tm_tz_c
X-GP-ATTR-TYPECODE7: 1266
X-GP-ATTR-TYPENAME7: timetz
X-GP-ATTR-TYPEMOD7-COUNT: 1
X-GP-ATTR-TYPEMOD7-0: 4
X-GP-ATTR-NAME8: ts_c
X-GP-ATTR-TYPECODE8: 1114
X-GP-ATTR-TYPENAME8: timestamp
X-GP-ATTR-TYPEMOD8-COUNT: 1
X-GP-ATTR-TYPEMOD8-0: 5
X-GP-ATTR-NAME9: ts_tz_c
X-GP-ATTR-TYPECODE9: 1184
X-GP-ATTR-TYPENAME9: timestamptz
X-GP-ATTR-TYPEMOD9-COUNT: 1
X-GP-ATTR-TYPEMOD9-0: 3
X-GP-SEGMENT-ID: -100005432
X-GP-SEGMENT-COUNT: 0
X-GP-XID: 8294
X-GP-ALIGNMENT: 8
X-GP-URL-HOST: localhost
X-GP-URL-PORT: 51200
X-GP-DATA-DIR: hive_orc_all_types
X-GP-PROFILE: HiveORC
X-GP-delimiter: 
X-GP-URI: pxf://localhost:51200/hive_orc_all_types?PROFILE=HiveORC&delimiter=
X-GP-HAS-FILTER: 0