### PR TITLE
HAWQ-1001. Implement HAWQ user ACL check through Ranger.

### DIFF
--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -349,7 +349,6 @@ bool		Debug_datumstream_write_use_small_initial_buffers = false;
 bool		gp_temporary_files_filespace_repair = false;
 bool		filesystem_support_truncate = true;
 bool		gp_allow_non_uniform_partitioning_ddl = true;
-bool  enable_ranger = false;
 
 int			explain_memory_verbosity = 0;
 char* 		memory_profiler_run_id = "none";
@@ -733,6 +732,7 @@ int hawq_rm_nvseg_for_analyze_nopart_perquery_perseg_limit;
 int hawq_rm_nvseg_for_analyze_part_perquery_perseg_limit;
 int hawq_rm_nvseg_for_analyze_nopart_perquery_limit;
 int hawq_rm_nvseg_for_analyze_part_perquery_limit;
+bool enable_ranger = false;
 double	  optimizer_cost_threshold;
 double  optimizer_nestloop_factor;
 double  locality_upper_bound;
@@ -4325,7 +4325,7 @@ static struct config_bool ConfigureNamesBool[] =
 
 	{
     {"enable_ranger", PGC_POSTMASTER, CONN_AUTH_SETTINGS,
-     gettext_noop("support to using ranger to manage hawq privilege."),
+     gettext_noop("Enable Apache Ranger for HAWQ privilege management."),
      NULL,
      GUC_SUPERUSER_ONLY
     },

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -349,6 +349,7 @@ bool		Debug_datumstream_write_use_small_initial_buffers = false;
 bool		gp_temporary_files_filespace_repair = false;
 bool		filesystem_support_truncate = true;
 bool		gp_allow_non_uniform_partitioning_ddl = true;
+bool  enable_ranger = false;
 
 int			explain_memory_verbosity = 0;
 char* 		memory_profiler_run_id = "none";
@@ -4321,6 +4322,16 @@ static struct config_bool ConfigureNamesBool[] =
 		&enable_secure_filesystem,
 		false, NULL, NULL
 	},
+
+	{
+    {"enable_ranger", PGC_POSTMASTER, CONN_AUTH_SETTINGS,
+     gettext_noop("support to using ranger to manage hawq privilege."),
+     NULL,
+     GUC_SUPERUSER_ONLY
+    },
+    &enable_ranger,
+    false, NULL, NULL
+  },
 
 	{
 		{"filesystem_support_truncate", PGC_USERSET, APPENDONLY_TABLES,

--- a/src/include/utils/acl.h
+++ b/src/include/utils/acl.h
@@ -288,6 +288,21 @@ extern AclResult pg_foreign_server_aclcheck(Oid srv_oid, Oid roleid, AclMode mod
 extern AclResult pg_extprotocol_aclcheck(Oid ptc_oid, Oid roleid, AclMode mode);
 extern AclResult pg_filesystem_aclcheck(Oid fsys_oid, Oid roleid, AclMode mode);
 
+extern AclResult pg_class_nativecheck(Oid table_oid, Oid roleid, AclMode mode);
+extern AclResult pg_database_nativecheck(Oid db_oid, Oid roleid, AclMode mode);
+extern AclResult pg_proc_nativecheck(Oid proc_oid, Oid roleid, AclMode mode);
+extern AclResult pg_language_nativecheck(Oid lang_oid, Oid roleid, AclMode mode);
+extern AclResult pg_namespace_nativecheck(Oid nsp_oid, Oid roleid, AclMode mode);
+extern AclResult pg_tablespace_nativecheck(Oid spc_oid, Oid roleid, AclMode mode);
+extern AclResult pg_foreign_data_wrapper_nativecheck(Oid fdw_oid, Oid roleid, AclMode mode);
+extern AclResult pg_foreign_server_nativecheck(Oid srv_oid, Oid roleid, AclMode mode);
+extern AclResult pg_extprotocol_nativecheck(Oid ptc_oid, Oid roleid, AclMode mode);
+extern AclResult pg_filesystem_nativecheck(Oid fsys_oid, Oid roleid, AclMode mode);
+
+extern AclResult
+pg_rangercheck(Oid table_oid, Oid roleid,
+         AclMode mask, AclMaskHow how);
+
 extern void aclcheck_error(AclResult aclerr, AclObjectKind objectkind,
 			   const char *objectname);
 

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -275,6 +275,7 @@ extern bool gp_plpgsql_clear_cache_always;
 extern bool gp_disable_catalog_access_on_segment;
 
 extern bool gp_called_by_pgdump;
+extern bool enable_ranger;
 
 /* Debug DTM Action */
 typedef enum


### PR DESCRIPTION
Along with HAWQ-1002. Implement a switch in hawq-site.xml to configure whether use Ranger or not for ACL.

I create a GUC enable_ranger to control whether hawq use ranger to do acl control.
Also, when client doing a acl check with ranger enabled, typically a select statement needs the privilege to access the range table, we call pg_rangercheck() to determine the whether access is allowed. 
 The content of pg_rangercheck() is just return ACLCHECK_OK temporarily, and should be changed to a call to ranger restful service in future.