### PR TITLE
HAWQ-984. hawq config is too slow.

### DIFF
--- a/tools/bin/gppylib/util/ssh_utils.py
+++ b/tools/bin/gppylib/util/ssh_utils.py
@@ -115,7 +115,7 @@ class HostList():
     def checkSSH(self):
         '''Check that ssh to hostlist is okay.'''
 
-        pool = WorkerPool()
+        pool = WorkerPool(min(len(self.list), 16))
 
         for h in self.list:
             cmd = Echo('ssh test', '', ctxt=REMOTE, remoteHost=h)
@@ -135,7 +135,7 @@ class HostList():
         '''For multiple host that is of the same node, keep only one in the hostlist.'''
         unique = {}
 
-        pool = WorkerPool()
+        pool = WorkerPool(min(len(self.list), 16))
         for h in self.list:
             cmd = Hostname('hostname', ctxt=REMOTE, remoteHost=h)
             pool.addCommand(cmd)
@@ -159,7 +159,7 @@ class HostList():
     def removeBadHosts(self):
         ''' Update list of host to include only the host on which SSH was successful'''
 
-        pool = WorkerPool()
+        pool = WorkerPool(min(len(self.list), 16))
 
         for h in self.list:
             cmd = Echo('ssh test', '', ctxt=REMOTE, remoteHost=h)

--- a/tools/bin/hawqpylib/hawqlib.py
+++ b/tools/bin/hawqpylib/hawqlib.py
@@ -586,7 +586,7 @@ def get_host_status(hostlist):
     if not isinstance(hostlist, list):
         raise Exception("Input parameter should be of type list")
 
-    pool = WorkerPool()
+    pool = WorkerPool(min(len(hostlist), 16))
 
     for host in hostlist:
         cmd = Echo('ssh test', '', ctxt=REMOTE, remoteHost=host)


### PR DESCRIPTION
Further code change for the issue. Limit the worker thread number
if the queue entry number is less than the default
worker thread number (i.e. 16) since more worker thread number is
totally wasteful.