### PR TITLE
HAWQ-1028. Add '-d' option for hawq state

### DIFF
--- a/tools/bin/hawqstate
+++ b/tools/bin/hawqstate
@@ -37,6 +37,9 @@ def parseargs():
                       help="Execute without prompt.")
     parser.add_option("-l", "--logdir", dest="logDir",
                       help="Sets the directory for log files")
+    # None used option, keep it to be compatible with Ambari.
+    parser.add_option("-d", "--datadir", dest="master_dir",
+                      help="Sets HAWQ Master data directory.")
     (options, args) = parser.parse_args()
     return (options, args)
 


### PR DESCRIPTION
This option is not used at all, just add it to be compatible with Ambari since Ambari is using this option.

After Ambari removed it, we will remove it again.