### PR TITLE
HAWQ-1032. Bucket number of new added partition is not consistent wit…

### DIFF
--- a/src/backend/cdb/cdbpartition.c
+++ b/src/backend/cdb/cdbpartition.c
@@ -6381,7 +6381,7 @@ atpxPartAddList(Relation rel,
 								NULL /*catalogname*/, 
 								get_namespace_name(RelationGetNamespace(par_rel)),
 								RelationGetRelationName(par_rel), -1);
-	
+
 	if (bOpenGap) /* might need a gap to insert the new partition */
 	{
 		AlterPartitionId 	 	 pid;
@@ -6417,6 +6417,8 @@ atpxPartAddList(Relation rel,
 								CurrentMemoryContext);
 	}
 	
+	GpPolicy * parPolicy = GpPolicyFetch(CurrentMemoryContext,
+	          RelationGetRelationName(par_rel));
 	{
 		List			*l1;
 		ListCell		*lc;
@@ -6546,8 +6548,7 @@ atpxPartAddList(Relation rel,
 				skipTableRelid = RangeVarGetRelid(t->relation, true, false /*allowHcatalog*/);
 			}
 		}
-		
-		
+
 		for_each_cell(lc, lnext(lc))
 		{
 			Query *q = lfirst(lc);
@@ -6621,6 +6622,10 @@ atpxPartAddList(Relation rel,
 			{
 				/* propagate owner */
 				((CreateStmt *)q->utilityStmt)->ownerid = ownerid;
+				/* child partition should have the same bucket number with parent partition */
+				if (parPolicy) {
+				  ((CreateStmt *)q->utilityStmt)->policy->bucketnum = parPolicy->bucketnum;
+				}
 			}
 			
 			/* normal case - add partitions using CREATE statements
@@ -6698,6 +6703,8 @@ atpxPartAddList(Relation rel,
 		} /* end for each cell */
 		
 	}
+	if(parPolicy)
+	  pfree(parPolicy);
 	
 	if (par_prule && par_prule->topRule)
 		heap_close(par_rel, NoLock);


### PR DESCRIPTION
…h parent table.
Failure Case
```
set deafult_hash_table_bucket_number = 12;
CREATE TABLE sales3 (id int, date date, amt decimal(10,2))         DISTRIBUTED BY (id)                                                           PARTITION BY RANGE (date)                                                     ( START (date '2008-01-01') INCLUSIVE                                            END (date '2009-01-01') EXCLUSIVE                                             EVERY (INTERVAL '1 day') );

set deafult_hash_table_bucket_number = 16;
ALTER TABLE sales3 ADD PARTITION                                   START (date '2009-03-01') INCLUSIVE                                           END (date '2009-04-01') EXCLUSIVE;
```
The newly added partition with buckcet number 16 is not consistent with parent partition.
