### PR TITLE
HAWQ-1032. Set bucket number of child partition to parent partition o…

### DIFF
--- a/src/backend/cdb/cdbpartition.c
+++ b/src/backend/cdb/cdbpartition.c
@@ -6623,7 +6623,7 @@ atpxPartAddList(Relation rel,
 				/* propagate owner */
 				((CreateStmt *)q->utilityStmt)->ownerid = ownerid;
 				/* child partition should have the same bucket number with parent partition */
-				if (parPolicy) {
+				if (parPolicy && parPolicy->ptype == POLICYTYPE_PARTITIONED) {
 				  ((CreateStmt *)q->utilityStmt)->policy->bucketnum = parPolicy->bucketnum;
 				}
 			}


### PR DESCRIPTION
…nly when policy type equals to POLICYTYPE_PARTITIONED.

policy type may be POLICYTYPE_ENTRY which should not be applied to reset child partition bucket number.