### PR TITLE
HAWQ-1007. Add the pgcrypto code into hawq

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,7 @@
               <exclude>src/timezone/**/*</exclude>
               <exclude>doc/src/sgml/fixrtf</exclude>
               <exclude>doc/**/*.sgml</exclude>
+              <exclude>contrib/pgcrypto/*</exclude>
 
               <!-- Files which are not easy to have license headers. -->
               <exclude>depends/libhdfs3/test/data/*</exclude>


### PR DESCRIPTION
Avoid maven license check for the pgcrypto code since it comes from upstream postgres.