### PR TITLE
HAWQ-1063. HAWQ Python library missing import

### DIFF
--- a/tools/bin/hawqpylib/hawqlib.py
+++ b/tools/bin/hawqpylib/hawqlib.py
@@ -23,6 +23,7 @@ import Queue
 from xml.dom import minidom
 from xml.etree.ElementTree import ElementTree
 import shutil
+from pygresql.pg import DatabaseError
 from gppylib.db import dbconn
 from gppylib.commands.base import WorkerPool, REMOTE
 from gppylib.commands.unix import Echo


### PR DESCRIPTION
Fixing missing import for DatabaseError exception, referenced [here](https://github.com/apache/incubator-hawq/blob/master/tools/bin/hawqpylib/hawqlib.py#L555).
