### PR TITLE
HAWQ-1067. Append hawq version number to plr-hawq rpm pakcage install location

### DIFF
--- a/src/pl/plr.spec
+++ b/src/pl/plr.spec
@@ -2,7 +2,7 @@ Summary:        PL/R module for HAWQ
 Name:           plr-hawq_%{hawq_version_str}
 Version:        08.03.00.14.%{hawq_version}
 Release:		%{hawq_build_number}.el%{redhat_major_version}
-Prefix:         /usr/local/hawq
+Prefix:         /usr/local/hawq_%{hawq_version_str}
 License:		GPL
 BuildRequires:  R-core-devel
 Requires:       R
@@ -22,9 +22,9 @@ The PL/R modules provides Procedural language implementation of R for HAWQ.
 # 2. We build using the "configured" prefix at first and then install it using
 #    the new prefix.
 make -C %{plr_srcdir}
-make -C %{plr_srcdir} install prefix=%{buildroot}/usr/local/hawq
+make -C %{plr_srcdir} install prefix=%{buildroot}/usr/local/hawq_%{hawq_version_str}
 
 %files
-/usr/local/hawq/docs/contrib/README.plr
-/usr/local/hawq/lib/postgresql/plr.so*
-/usr/local/hawq/share/postgresql/contrib/plr.sql
+/usr/local/hawq_%{hawq_version_str}/docs/contrib/README.plr
+/usr/local/hawq_%{hawq_version_str}/lib/postgresql/plr.so*
+/usr/local/hawq_%{hawq_version_str}/share/postgresql/contrib/plr.sql


### PR DESCRIPTION
Previously it will get install to /usr/local/hawq, but it's possible that hawq is installed into '/usr/local/hawq_2_0_1_0.
@paul-guo- @xunzhang 