### PR TITLE
HAWQ-1083

### DIFF
--- a/src/backend/access/external/libchurl.c
+++ b/src/backend/access/external/libchurl.c
@@ -326,11 +326,13 @@ CHURL_HANDLE churl_init(const char* url, CHURL_HEADERS headers)
 		char* after_host = pstrdup(url + (start - url) + strlen(LocalhostIpV4));
 		//construct replaced url using loopback interface ip
 		sprintf(replaced_url, "%s%s%s", before_host, loopback_addr, after_host);
+		set_curl_option(context, CURLOPT_URL, replaced_url);
+
 		//release memory
 		pfree(before_host);
 		pfree(after_host);
-
-		set_curl_option(context, CURLOPT_URL, replaced_url);
+		pfree(replaced_url);
+		pfree(loopback_addr);
 	} else
 		set_curl_option(context, CURLOPT_URL, url);
 

--- a/src/backend/access/external/libchurl.c
+++ b/src/backend/access/external/libchurl.c
@@ -313,16 +313,22 @@ CHURL_HANDLE churl_init(const char* url, CHURL_HEADERS headers)
 
 	/* needed to resolve localhost */
 	if (strstr(url, LocalhostIpV4) != NULL) {
+		//get loopback interface ip address
 		char* loopback_addr = get_loopback_ip_addr();
-		char* start = strstr(url, LocalhostIpV4);
-		char* replaced_url = palloc(strlen(url) + strlen(loopback_addr) - strlen(LocalhostIpV4) + 1);
-
 		elog(DEBUG1, "Loopback interface IP address: %s", loopback_addr);
-
+		//find host start position in url
+		char* start = strstr(url, LocalhostIpV4);
+		//allocate new url with replaced host
+		char* replaced_url = palloc(strlen(url) + strlen(loopback_addr) - strlen(LocalhostIpV4) + 1);
+		//token before host
 		char* before_host = pnstrdup(url, start - url);
+		//token after host
 		char* after_host = pstrdup(url + (start - url) + strlen(LocalhostIpV4));
-
+		//construct replaced url using loopback interface ip
 		sprintf(replaced_url, "%s%s%s", before_host, loopback_addr, after_host);
+		//release memory
+		pfree(before_host);
+		pfree(after_host);
 
 		set_curl_option(context, CURLOPT_URL, replaced_url);
 	} else

--- a/src/backend/access/external/pxfutils.c
+++ b/src/backend/access/external/pxfutils.c
@@ -139,7 +139,8 @@ static void process_request(ClientContext* client_context, char *uri)
 }
 
 /*
- * Finds ip address of any available loopback interface(ipv4/ipv6)
+ * Finds ip address of any available loopback interface(ipv4/ipv6).
+ * Returns ip for ipv4 addresses and [ip] for ipv6 addresses.
  *
  */
 char* get_loopback_ip_addr() {
@@ -170,7 +171,16 @@ char* get_loopback_ip_addr() {
 
 			//get loopback interface
 			if (ifa->ifa_flags & IFF_LOOPBACK) {
-				loopback_addr = host;
+				if (family == AF_INET)
+				{
+					loopback_addr = palloc(strlen(host) + 1);
+					sprintf(loopback_addr, "%s", host);
+				}
+				else
+				{
+					loopback_addr = palloc(strlen(host) + 3);
+					sprintf(loopback_addr, "[%s]", host);
+				}
 				break;
 			}
 		}

--- a/src/backend/access/external/pxfutils.c
+++ b/src/backend/access/external/pxfutils.c
@@ -139,8 +139,8 @@ static void process_request(ClientContext* client_context, char *uri)
 }
 
 /*
- * Finds ip address of any available loopback interface(ipv4/ipv6),
- * otherwise returns default value as 127.0.0.1
+ * Finds ip address of any available loopback interface(ipv4/ipv6)
+ *
  */
 char* get_loopback_ip_addr() {
 	struct ifaddrs *ifaddr, *ifa;
@@ -165,7 +165,7 @@ char* get_loopback_ip_addr() {
 							sizeof(struct sockaddr_in6), host, NI_MAXHOST,
 					NULL, 0, NI_NUMERICHOST);
 			if (s != 0) {
-				elog(ERROR, "Unable to get name information for interface, getnameinfo() failed: %s\n", gai_strerror(s));
+				elog(WARNING, "Unable to get name information for interface, getnameinfo() failed: %s\n", gai_strerror(s));
 			}
 
 			//get loopback interface

--- a/src/backend/access/external/pxfutils.c
+++ b/src/backend/access/external/pxfutils.c
@@ -203,15 +203,23 @@ char* get_loopback_ip_addr()
  */
 char* replace_string(const char* string, const char* replace, const char* replacement)
 {
+	char* replaced = NULL;
 	char* start = strstr(string, replace);
-	char* before_token = pnstrdup(string, start - string);
-	char* after_token = pstrdup(string + (start - string) + strlen(replace));
-	char* replaced = palloc0(strlen(before_token) + strlen(replacement) + strlen(after_token) + 1);
-	sprintf(replaced, "%s%s%s", before_token, replacement, after_token);
+	if (start)
+	{
+		char* before_token = pnstrdup(string, start - string);
+		char* after_token = pstrdup(string + (start - string) + strlen(replace));
+		replaced = palloc0(strlen(before_token) + strlen(replacement) + strlen(after_token) + 1);
+		sprintf(replaced, "%s%s%s", before_token, replacement, after_token);
 
-	//release memory
-	pfree(before_token);
-	pfree(after_token);
+		//release memory
+		pfree(before_token);
+		pfree(after_token);
+	} else
+	{
+		replaced = palloc0(strlen(string) + 1);
+		sprintf(replaced, "%s", string);
+	}
 
 	return replaced;
 

--- a/src/backend/access/external/pxfutils.c
+++ b/src/backend/access/external/pxfutils.c
@@ -189,7 +189,7 @@ char* get_loopback_ip_addr()
 
 	freeifaddrs(ifaddr);
 
-	if (loopback_addr == NULL)
+	if (loopback_addr == NULL || !loopback_addr[0])
 		elog(ERROR, "Unable to get loop back address");
 
 	return loopback_addr;

--- a/src/include/access/libchurl.h
+++ b/src/include/access/libchurl.h
@@ -141,7 +141,6 @@ void churl_cleanup(CHURL_HANDLE handle, bool after_error);
  */
 void print_http_headers(CHURL_HEADERS headers);
 
-
 #endif
 
 #define LocalhostIpV4Entry ":127.0.0.1"

--- a/src/include/access/pxfutils.h
+++ b/src/include/access/pxfutils.h
@@ -45,4 +45,6 @@ void get_hdfs_location_from_filespace(char** path);
 /* Parse the REST message and issue the libchurl call */
 void call_rest(GPHDUri *hadoop_uri, ClientContext *client_context, char* rest_msg);
 
+char* get_loopback_ip_addr();
+
 #endif	// _PXF_UTILS_H_

--- a/src/include/access/pxfutils.h
+++ b/src/include/access/pxfutils.h
@@ -45,6 +45,7 @@ void get_hdfs_location_from_filespace(char** path);
 /* Parse the REST message and issue the libchurl call */
 void call_rest(GPHDUri *hadoop_uri, ClientContext *client_context, char* rest_msg);
 
+/* get ip address of loopback interface*/
 char* get_loopback_ip_addr();
 
 #endif	// _PXF_UTILS_H_

--- a/src/include/access/pxfutils.h
+++ b/src/include/access/pxfutils.h
@@ -42,10 +42,13 @@ void port_to_str(char** port, int new_port);
 /* get hdfs location from current session's filespace entry */
 void get_hdfs_location_from_filespace(char** path);
 
-/* Parse the REST message and issue the libchurl call */
+/* parse the REST message and issue the libchurl call */
 void call_rest(GPHDUri *hadoop_uri, ClientContext *client_context, char* rest_msg);
 
-/* get ip address of loopback interface*/
-char* get_loopback_ip_addr();
+/* get ip address of loopback interface */
+char* get_loopback_ip_addr(void);
+
+/* replace first occurrence of replace in string with replacement*/
+char* replace_string(const char* string, const char* replace, const char* replacement);
 
 #endif	// _PXF_UTILS_H_


### PR DESCRIPTION
Changes in patch:

If url parameter ever has "localhost" string in it when using libchurl, HAWQ replaces "localhost" with actual ip address of any loopback interface(either ipv4 or ipv6).

I think we need loopback criteria to bypass firewall if any.