### PR TITLE
HAWQ-1090. Fixed build problem on macos sierra (10.12)

### DIFF
--- a/configure
+++ b/configure
@@ -9282,6 +9282,9 @@ fi
 fi
 
 if test "$with_openssl" = yes ; then
+    if test "$PORTNAME" == "darwin"; then
+	LDFLAGS = "$LDFLAGS -L/usr/local/opt/openssl/lib"
+  fi
     if test "$PORTNAME" != "win32"; then
      { $as_echo "$as_me:${as_lineno-$LINENO}: checking for CRYPTO_new_ex_data in -lcrypto" >&5
 $as_echo_n "checking for CRYPTO_new_ex_data in -lcrypto... " >&6; }
@@ -11011,6 +11014,9 @@ fi
 fi
 
 if test "$with_openssl" = yes ; then
+    if test "$PORTNAME" == "darwin"; then
+      CPPFLAGS="$CPPFLAGS -I/usr/local/opt/openssl/include"
+  fi
   ac_fn_c_check_header_mongrel "$LINENO" "openssl/ssl.h" "ac_cv_header_openssl_ssl_h" "$ac_includes_default"
 if test "x$ac_cv_header_openssl_ssl_h" = xyes; then :
 

--- a/configure.in
+++ b/configure.in
@@ -1118,6 +1118,10 @@ Don't use --with-krb5 if you don't want the Kerberos 5 support.])])
 fi
 
 if test "$with_openssl" = yes ; then
+  dnl workaround for 'brew link openssl --force' error on MacOS 10.12
+  if test "$PORTNAME" == "darwin"; then
+	LDFLAGS = "$LDFLAGS -L/usr/local/opt/openssl/lib"
+  fi
   dnl Order matters!
   if test "$PORTNAME" != "win32"; then
      AC_CHECK_LIB(crypto, CRYPTO_new_ex_data, [], [AC_MSG_ERROR([library 'crypto' is required for OpenSSL.
@@ -1295,6 +1299,10 @@ Don't use --with-krb5 if you don't want the Kerberos 5 support.])])
 fi
 
 if test "$with_openssl" = yes ; then
+  dnl workaround for 'brew link openssl --force' error on MacOS 10.12 
+  if test "$PORTNAME" == "darwin"; then
+      CPPFLAGS="$CPPFLAGS -I/usr/local/opt/openssl/include"
+  fi
   AC_CHECK_HEADER(openssl/ssl.h, [], [AC_MSG_ERROR([header file <openssl/ssl.h> is required for OpenSSL.
 Check config.log for details. It is possible the compiler isn't looking in the proper directory.
 Don't use --with-openssl if you don't want to the OpenSSL support.])])

--- a/src/bin/gpfdist/Makefile
+++ b/src/bin/gpfdist/Makefile
@@ -42,6 +42,13 @@ INCLUDES := $$($(APR_CFG) --includes) -I$(code_dir) -I$(CURDIR)/../../../src/inc
 CFLAGS   := $$($(APR_CFG) --cflags) -Wall $(GPFXDIST) $(CFLAGS)
 LIBS     := $$($(APR_CFG) --link-ld --libs) $(LIBS)
 
+# workaround for 'brew link openssl --force' error on MacOS 10.12
+UNAME = $(shell uname)
+ifeq (Darwin, $(UNAME))
+	INCLUDES := $(INCLUDES) -I/usr/local/opt/openssl/include
+	LIBS := $(LIBS) -L/usr/local/opt/openssl/lib
+endif
+
 sol10_sparc_32_CPPFLAGS = -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64
 sol9_sparc_32_CPPFLAGS  = -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64
 sol8_sparc_32_CPPFLAGS  = -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64
@@ -56,7 +63,7 @@ mkgpfdist: mkdir
 	@echo --- gpfdist --------------------------------------------------
 	cd src/gpfdist/ && \
 	  ln -sf ../../../../../src/backend/utils/misc/fstream/*.c . && ls ../../../../../src/backend/utils/misc/fstream/*.c
-	perl -p -i -e 's,^prefix=.*$$,prefix="$(APR_DIR)",' $(APR_CFG)
+	#perl -p -i -e 's,^prefix=.*$$,prefix="$(APR_DIR)",' $(APR_CFG)
 
 	for file in $(GPFDISTFILES); do \
 	    ( $(CC) $(INCLUDES) $(CFLAGS) $(LIBS) -c $(code_dir)$${file}); \


### PR DESCRIPTION
Fixed 2 problems here:
1) Report error: "'openssl/ssl.h' file not found", which is caused by running 'brew link openssl --force' error. Offer a workaround: appending the default installation directory to '-I' and '-L', even the directory not exists on the old macos, it just report warning.

Also fixed problem when running "./configure --with-openssl"

2) Report error: "'apr.h' file not found", which is caused by hard-coded modification of path fetched from 'apr-1-config --includes'.