### PR TITLE
HAWQ-1143. Libhdfs create semantic is not consistent with posix stand…

### DIFF
--- a/depends/libhdfs3/src/client/Hdfs.cpp
+++ b/depends/libhdfs3/src/client/Hdfs.cpp
@@ -646,9 +646,9 @@ hdfsFile hdfsOpenFile(hdfsFS fs, const char * path, int flags, int bufferSize,
         if ((flags & O_CREAT) || (flags & O_APPEND) || (flags & O_WRONLY)) {
             int internalFlags = 0;
 
-            if (flags & O_CREAT) {
+            if ((flags & O_CREAT) && (flags & O_EXCL)) {
                 internalFlags |= Hdfs::Create;
-            } else if ((flags & O_APPEND) && (flags & O_WRONLY)) {
+            } else if ((flags & O_CREAT) || ((flags & O_APPEND) && (flags & O_WRONLY))) {
                 internalFlags |= Hdfs::Create;
                 internalFlags |= Hdfs::Append;
             } else if (flags & O_WRONLY) {


### PR DESCRIPTION
…ard.
Open a file under posix standard, if o_create flag is set to true and the file exists, no side effect except O_EXCL is also be set true.
Open a file in HDFS with hdfs::create flag will report errors if file exists.
In libhdfs, the o_create flag is interpreted to hdfs::create, which leads to errors if file exists no matter O_EXCL is set or not.