### PR TITLE
HAWQ-1130. Make HCatalog integration work with non-superusers.

### DIFF
--- a/src/backend/access/transam/varsup.c
+++ b/src/backend/access/transam/varsup.c
@@ -17,6 +17,7 @@
 #include "access/subtrans.h"
 #include "access/transam.h"
 #include "catalog/catquery.h"
+#include "executor/spi.h"
 #include "miscadmin.h"
 #include "postmaster/autovacuum.h"
 #include "storage/pmsignal.h"
@@ -408,6 +409,9 @@ GetNewExternalObjectId(void)
 	/*
 	 * must perform check on External Oid range on
 	 * initial access of NextExternalOid
+	 *
+	 * It's needed for upgrade scenario from old version
+	 * of HAWQ which doesn't support dedicated oid pool for HCatalog objects
 	 */
 	if (!IsExternalOidInitialized)
 	{
@@ -479,13 +483,18 @@ ResetExternalObjectId(void)
 
 /*
  * master_highest_used_oid
- * 		Uses CAQL to find the highest used Oid by
+ * 		Uses CAQL and SPI to find the highest used Oid among user and catalog tables
+ *
+ * 		Uses CAQL to query catalog tables
+ * 		Uses SPI to query user tables, because CAQL supports tables from CatCoreRelation array only
  * 		1) Find all the relations that has Oids
  * 		2) Find max oid from those relations
  */
 Oid
 master_highest_used_oid(void)
 {
+	Oid oidMaxCatalog = InvalidOid;
+	Oid oidMaxUser = InvalidOid;
 	Oid oidMax = InvalidOid;
 	Oid currentOid;
 	Form_pg_class classForm;
@@ -493,8 +502,11 @@ master_highest_used_oid(void)
 	cqContext *pcqInnerCtx;
 	HeapTuple outerTuple;
 	HeapTuple innerTuple;
+	/* number of user tables having oids*/
+	int userTablesNum = 0;
+	int ret;
 
-	pcqOuterCtx = caql_beginscan(NULL, cql("SELECT relhasoids FROM pg_class where relhasoids = :1", BoolGetDatum(true)));
+	pcqOuterCtx = caql_beginscan(NULL, cql("SELECT * FROM pg_class WHERE relhasoids = :1", BoolGetDatum(true)));
 
 	outerTuple = caql_getnext(pcqOuterCtx);
 
@@ -506,42 +518,92 @@ master_highest_used_oid(void)
 	}
 
 	/* construct query to get max oid from all tables with oids */
-	StringInfo sqlstr = makeStringInfo();
+	StringInfo sqlstrCatalog = makeStringInfo();
+	StringInfo sqlstrUser = makeStringInfo();
+	appendStringInfo(sqlstrUser, "SELECT max(oid) FROM (");
 	while (HeapTupleIsValid(outerTuple))
 	{
 		classForm = (Form_pg_class) GETSTRUCT(outerTuple);
-		appendStringInfo(sqlstr,
-				"SELECT oid FROM %s WHERE oid > :1 ORDER BY oid",
-				classForm->relname.data);
 
-		pcqInnerCtx = caql_beginscan(NULL,
-				cql1(sqlstr->data, __FILE__, __LINE__,
-						ObjectIdGetDatum(oidMax)));
-
-		innerTuple = caql_getnext(pcqInnerCtx);
-
-		currentOid = InvalidOid;
-
-		while (HeapTupleIsValid(innerTuple))
+		/* use CAQL for accessing catalog tables*/
+		if (classForm->relnamespace == PG_CATALOG_NAMESPACE)
 		{
-			currentOid = HeapTupleGetOid(innerTuple);
+			appendStringInfo(sqlstrCatalog,
+					"SELECT oid FROM %s WHERE oid > :1 ORDER BY oid",
+					classForm->relname.data);
+
+			pcqInnerCtx = caql_beginscan(NULL,
+					cql1(sqlstrCatalog->data, __FILE__, __LINE__,
+							ObjectIdGetDatum(oidMaxCatalog)));
+
 			innerTuple = caql_getnext(pcqInnerCtx);
+
+			currentOid = InvalidOid;
+
+			while (HeapTupleIsValid(innerTuple))
+			{
+				currentOid = HeapTupleGetOid(innerTuple);
+				innerTuple = caql_getnext(pcqInnerCtx);
+			}
+
+			elog(DEBUG1, "Max Oid in catalog table %s: %d", classForm->relname.data, currentOid);
+
+			caql_endscan(pcqInnerCtx);
+
+			oidMaxCatalog = currentOid > oidMaxCatalog ? currentOid : oidMaxCatalog;
+
+			resetStringInfo(sqlstrCatalog);
+		}
+		else
+		/* use SPI for user tables*/
+		{
+			userTablesNum++;
+			{
+				if (userTablesNum > 1)
+				{
+					appendStringInfo(sqlstrUser, " UNION ALL ");
+				}
+				appendStringInfo(sqlstrUser, "SELECT MAX(oid) AS oid FROM %s", classForm->relname.data);
+			}
 		}
 
-		elog(DEBUG1, "Max Oid in table %s: %d", classForm->relname.data, currentOid);
-
-		caql_endscan(pcqInnerCtx);
-
-		oidMax = currentOid > oidMax ? currentOid : oidMax;
-
 		outerTuple = caql_getnext(pcqOuterCtx);
-
-		resetStringInfo(sqlstr);
 	}
 
 	caql_endscan(pcqOuterCtx);
 
-	pfree(sqlstr->data);
+	if (userTablesNum) {
+
+		appendStringInfo(sqlstrUser, ") AS x");
+
+		if (SPI_OK_CONNECT != SPI_connect())
+		{
+			ereport(ERROR, (errcode(ERRCODE_CDB_INTERNAL_ERROR),
+					errmsg("Unable to connect to execute internal query for HCatalog.")));
+		}
+
+		ret = SPI_execute(sqlstrUser->data, true, 1);
+
+		if (ret > 0 && NULL != SPI_tuptable) {
+			TupleDesc tupdesc = SPI_tuptable->tupdesc;
+			SPITupleTable *tuptable = SPI_tuptable;
+			HeapTuple tuple = tuptable->vals[0];
+			char *oidString = SPI_getvalue(tuple, tupdesc, 1);
+			if (NULL != oidString)
+			{
+				oidMaxUser = DatumGetObjectId(DirectFunctionCall1(oidin, CStringGetDatum(oidString)));
+			}
+		}
+	}
+
+	pfree(sqlstrCatalog->data);
+	pfree(sqlstrUser->data);
+	SPI_finish();
+
+	elog(DEBUG1, "Highest Oid currently in use among catalog tables: %u", oidMaxCatalog);
+	elog(DEBUG1, "Highest Oid currently in use among user tables having oid: %u", oidMaxUser);
+
+	oidMax = oidMaxCatalog > oidMaxUser ? oidMaxCatalog : oidMaxUser;
 
 	elog(DEBUG1, "Highest Oid currently in use: %u", oidMax);
 


### PR DESCRIPTION
Changed master_highest_used_oid logic to use CAQL instead of SPI, because some of tables require super-user access(pg_catalog.pg_authid and pg_catalog.pg_user_mapping).

@hornn 