### PR TITLE
HAWQ-1141: Bump PXF and default HDB Stack version.

### DIFF
--- a/contrib/hawq-ambari-plugin/build.properties
+++ b/contrib/hawq-ambari-plugin/build.properties
@@ -5,4 +5,4 @@ pxf.common.services.version=3.0.0
 hawq.repo.prefix=hawq
 hawq.addons.repo.prefix=hawq-add-ons
 repository.version=2.0.1.0
-default.stack=HDP-2.4
+default.stack=HDP-2.5

--- a/contrib/hawq-ambari-plugin/build.properties
+++ b/contrib/hawq-ambari-plugin/build.properties
@@ -1,6 +1,6 @@
 hawq.release.version=2.0.1
 hawq.common.services.version=2.0.0
-pxf.release.version=3.0.1
+pxf.release.version=3.1.0
 pxf.common.services.version=3.0.0
 hawq.repo.prefix=hawq
 hawq.addons.repo.prefix=hawq-add-ons

--- a/pxf/gradle.properties
+++ b/pxf/gradle.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-version=3.0.2.0
+version=3.1.0.0
 license=ASL 2.0
 vendor=Apache HAWQ Incubating
 hadoopVersion=2.7.1


### PR DESCRIPTION
Update PXF (3.1.0), HDB Ambari plugin (2.1.0.0) and default Ambari default stack version (HDP-2.5).