### PR TITLE
HAWQ-1150. Fix Travis build issue (brona/iproute2mac).

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,6 @@ install:
   - brew outdated json-c || brew upgrade json-c
   - brew outdated boost || brew upgrade boost
   - brew outdated maven || brew upgrade maven
-  - brew tap brona/iproute2mac
   - brew install iproute2mac
   - sudo pip install pycrypto
   - sudo cpanm install JSON


### PR DESCRIPTION
* Remove the "brew tap brona/iproute2mac" command as an update to "brew"
  has revealed an issue with the "tap".  We will be able to install the
  component (iproute2mac) directory from the main repository.