### PR TITLE
HAWQ-1149. Fixed bug gp_persistent_build_all loses data in gp_relfile…

### DIFF
--- a/src/backend/cdb/cdbpersistentbuild.c
+++ b/src/backend/cdb/cdbpersistentbuild.c
@@ -222,6 +222,7 @@ static void PersistentBuild_PopulateGpRelationNode(
 
 		ItemPointerData persistentTid;
 		int64 persistentSerialNum;
+		Relation	rd;
 
 		if (dbInfoRel->reltablespace == GLOBALTABLESPACE_OID &&
 			info->database != TemplateDbOid)
@@ -417,6 +418,11 @@ static void PersistentBuild_PopulateGpRelationNode(
 								persistentSerialNum);
 			}
 		}
+		// reset Relation->rd_relationnodeinfo.isPresent, so that next time persistentid and serial# can be refetched
+		rd = RelationIdGetRelation(relFileNode.relNode);
+		rd->rd_relationnodeinfo.isPresent = false;
+		RelationClose(rd);
+
 		(*count)++;
 	}
 

--- a/src/include/cdb/cdbpersistentrelation.h
+++ b/src/include/cdb/cdbpersistentrelation.h
@@ -68,6 +68,7 @@ extern void PersistentRelation_AddCreated(
 		RelFileNode *relFileNode,
 					/* The tablespace, database, and relation OIDs for the create. */
 		ItemPointer persistentTid,
+		int64 *persistentSerialNum,
 		bool flushToXLog);
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
…_node&gp_persistent_relfile_node

Internally there are 3 bugs:
1) hawq2.0 changed the file path of relation file on hdfs from filespace/db/relfile.filenum to filespace/db/table/relfile/filenum. When we scan relfile on hdfs, we should change scan logic correspondingly.
2) Fetched dummy persistentTid & persistentSerialNum to PersistentRelation_MarkCreatePending() .
3) Need to reset Relation->rd_relationnodeinfo.isPresent, so that next time persistentid and serial# can be refetched during PersistentBuild_BuildDb().