### PR TITLE
HAWQ-1162. Resource manager does not reference dynamic minimum water …

### DIFF
--- a/src/backend/resourcemanager/resourcepool.c
+++ b/src/backend/resourcemanager/resourcepool.c
@@ -3545,7 +3545,7 @@ void timeoutIdleGRMResourceToRB(void)
 			timeoutIdleGRMResourceToRBByRatio(i,
 										   	  retcontnum,
 											  &realretcontnum,
-											  mark->ClusterVCore > 0 ? 2 : 0 );
+											  mark->ClusterVCore > 0 ? PQUEMGR->ActualMinGRMContainerPerSeg : 0 );
 			if ( realretcontnum > 0 )
 			{
 				/* Notify resource queue manager to minus allocated resource.*/


### PR DESCRIPTION
…level of each segment when it times out YARN containers