### PR TITLE
HAWQ-1169. HAWQ Bridge incorrectly pushes T_BoolExpr predicates with …

### DIFF
--- a/src/backend/access/external/pxffilters.c
+++ b/src/backend/access/external/pxffilters.c
@@ -184,7 +184,6 @@ Oid pxf_supported_types[] =
 	VARCHAROID,
 	BPCHAROID,
 	CHAROID,
-	BYTEAOID,
 	BOOLOID,
 	DATEOID,
 	TIMESTAMPOID
@@ -434,15 +433,23 @@ pxf_serialize_filter_list(List *expressionItems)
 			{
 				elog(DEBUG1, "pxf_serialize_filter_list: node tag %d (T_NullTest)", tag);
 				NullTest *expr = (NullTest *) node;
+				Var *var = (Var *) expr->arg;
+
+				//TODO: add check for supported operation
+				if (!supported_filter_type(var->vartype))
+				{
+					elog(DEBUG1, "Query will not be optimized to use filter push-down.");
+					return NULL;
+				}
 
 				/* filter expression for T_NullTest will not have any constant value */
 				if (expr->nulltesttype == IS_NULL)
 				{
-					appendStringInfo(resbuf, "%c%d%c%d", PXF_ATTR_CODE, ((Var *) expr->arg)->varattno - 1, PXF_OPERATOR_CODE, PXFOP_IS_NULL);
+					appendStringInfo(resbuf, "%c%d%c%d", PXF_ATTR_CODE, var->varattno - 1, PXF_OPERATOR_CODE, PXFOP_IS_NULL);
 				}
 				else if (expr->nulltesttype == IS_NOT_NULL)
 				{
-					appendStringInfo(resbuf, "%c%d%c%d", PXF_ATTR_CODE, ((Var *) expr->arg)->varattno - 1, PXF_OPERATOR_CODE, PXFOP_IS_NOTNULL);
+					appendStringInfo(resbuf, "%c%d%c%d", PXF_ATTR_CODE, var->varattno - 1, PXF_OPERATOR_CODE, PXFOP_IS_NOTNULL);
 				}
 				else
 				{

--- a/src/backend/access/external/test/pxffilters_test.c
+++ b/src/backend/access/external/test/pxffilters_test.c
@@ -43,7 +43,6 @@ test__supported_filter_type(void **state)
 		VARCHAROID,
 		BPCHAROID,
 		CHAROID,
-		BYTEAOID,
 		BOOLOID,
 		DATEOID,
 		CIRCLEOID /* unsupported type */
@@ -65,7 +64,7 @@ test__supported_filter_type(void **state)
 
 	/* go over pxf_supported_types array */
 	int nargs = sizeof(pxf_supported_types) / sizeof(Oid);
-	assert_int_equal(nargs, 14);
+	assert_int_equal(nargs, 13);
 	for (i = 0; i < nargs; ++i)
 	{
 		assert_true(supported_filter_type(pxf_supported_types[i]));


### PR DESCRIPTION
…byte arrays.