### PR TITLE
HAWQ-1171. Support upgrade for hawq register.

### DIFF
--- a/src/backend/cdb/cdbpersistentbuild.c
+++ b/src/backend/cdb/cdbpersistentbuild.c
@@ -840,15 +840,17 @@ gp_persistent_build_all(PG_FUNCTION_ARGS)
 Datum
 gp_relfile_insert_for_register(PG_FUNCTION_ARGS)
 {
-	Oid		tablespace = PG_GETARG_OID(0);
-	Oid		database = PG_GETARG_OID(1);
-	Oid		relation = PG_GETARG_OID(2);
-	Oid		relfilenode = PG_GETARG_OID(3);
-	Oid		segfile = PG_GETARG_OID(4);
-	char           *relname = PG_GETARG_CSTRING(5);
-	char		relkind = PG_GETARG_CHAR(6);
-	char		relstorage = PG_GETARG_CHAR(7);
-	Oid		relam = PG_GETARG_OID(8);
+	Oid tablespace = PG_GETARG_OID(0);
+	Oid database = PG_GETARG_OID(1);
+	Oid relation = PG_GETARG_OID(2);
+	Oid relfilenode = PG_GETARG_OID(3);
+	Oid segfile = PG_GETARG_OID(4);
+	char* relname = PG_GETARG_CSTRING(5);
+	BpChar* vRelkind = PG_GETARG_BPCHAR_P(6);
+	char relkind = vRelkind->vl_dat[0];
+	BpChar* vRelStorage = PG_GETARG_BPCHAR_P(7);
+	char	 relstorage = vRelStorage->vl_dat[0];
+	Oid relam = PG_GETARG_OID(8);
 
 	Relation	gp_relfile_node;
 

--- a/src/include/catalog/pg_proc.h
+++ b/src/include/catalog/pg_proc.h
@@ -9925,7 +9925,7 @@ DATA(insert OID = 7182 ( gp_persistent_set_relation_bufpool_kind_all  PGNSP PGUI
 DESCR("Populate the gp_persistent_relation_node table's relation_bufpool_kind column for the whole database instance for upgrade from 4.0 to 4.1");
 
 /* gp_relfile_insert_for_register(Oid, Oid, Oid, Oid, Oid, cstring, char, char, Oid) => int4 */
-DATA(insert OID = 7185 ( gp_relfile_insert_for_register  PGNSP PGUID 12 f f f f v 9 23 f "26 26 26 26 26 2275 18 18 26" _null_ _null_ _null_ gp_relfile_insert_for_register - _null_ n ));
+DATA(insert OID = 7185 ( gp_relfile_insert_for_register  PGNSP PGUID 12 f f f f v 9 23 f "26 26 26 26 26 2275 1042 1042 26" _null_ _null_ _null_ gp_relfile_insert_for_register - _null_ n ));
 DESCR("insert record into gp_persistent_relfile_node and gp_relfile_node");
 
 

--- a/tools/bin/hawq
+++ b/tools/bin/hawq
@@ -184,6 +184,9 @@ def main():
             sys.exit(1)
         cmd = "%s; hawqregister %s" % (source_hawq_env, sub_args)
         result = local_run(cmd)
+    elif hawq_command == "upgrade":
+        cmd = "%s; hawqupgrade %s" % (source_hawq_env, sub_args)
+        result = local_run(cmd)
     elif hawq_command == "version" or hawq_command == "--version":
         print_version()
     else:

--- a/tools/bin/hawqupgrade
+++ b/tools/bin/hawqupgrade
@@ -87,9 +87,12 @@ def register_func(options, args):
                 existed_db_conn.close()
         utility_conn.close()
     except pg.DatabaseError as e:
-        print e
+        logger.error('%s', e)
+        logger.info('Hawq Upgrade Failed.')
+        return 1
     except pg.InternalError:
         logger.error('Fail to connect to database, this script can only be run when database is up.')
+        logger.info('Hawq Upgrade Failed.')
         return 1
     logger.info('Hawq Upgrade Succeed.')
 

--- a/tools/bin/hawqupgrade
+++ b/tools/bin/hawqupgrade
@@ -1,0 +1,105 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Usage1: hawq register [-h hostname] [-p port] [-U username] [-d database] [-f filepath] [-e eof] <tablename>
+# Usage2: hawq register [-h hostname] [-p port] [-U username] [-d database] [-c config] [--force] <tablename>
+
+import os
+import sys
+try:
+    from gppylib.commands.unix import getLocalHostname, getUserName
+    from gppylib.db import dbconn
+    from gppylib.gplog import get_default_logger, setup_tool_logging
+    from gppylib.gpparseopts import OptParser, OptChecker
+    from pygresql import pg
+    from hawqpylib.hawqlib import local_ssh, local_ssh_output
+except ImportError, e:
+    print e
+    sys.stderr.write('Cannot import module, please check that you have source greenplum_path.sh\n')
+    sys.exit(2)
+
+# setup logging
+logger = get_default_logger()
+EXECNAME = os.path.split(__file__)[-1]
+setup_tool_logging(EXECNAME, getLocalHostname(), getUserName())
+
+def option_parser():
+    '''option parser'''
+    parser = OptParser(option_class=OptChecker,
+                       usage='usage: %prog [options] table_name',
+                       version='%prog version $Revision: #1 $')
+    parser.remove_option('-h')
+    parser.add_option('-?', '--help', action='help')
+    parser.add_option('-h', '--host', help='host of the target DB')
+    parser.add_option('-p', '--port', help='port of the target DB', type='int', default=0)
+    parser.add_option('-U', '--user', help='username of the target DB')
+    parser.add_option('-d', '--database', default='template1', dest='database', help='database name')
+    return parser
+
+def register_func(options, args):
+    # connect db
+    try:
+        url = dbconn.DbURL(hostname=options.host, port=options.port,
+                           dbname=options.database, username=options.user)
+        utility_conn = pg.connect(dbname=url.pgdb, host=url.pghost, port=url.pgport,
+                                  user=url.pguser, passwd=url.pgpass, opt='-c gp_session_role=utility')
+
+
+        # register function for template1
+        create_func_query = """
+            CREATE FUNCTION gp_relfile_insert_for_register(Oid, Oid, Oid, Oid, Oid, cstring, char, char, Oid)
+            RETURNS int4 LANGUAGE internal VOLATILE AS 'gp_relfile_insert_for_register'
+            WITH (DESCRIPTION="insert record into gp_relfile_insert_for_register and gp_relfile_node");
+            """
+        drop_func_query = """
+            DROP FUNCTION IF EXISTS gp_relfile_insert_for_register
+            (Oid, Oid, Oid, Oid, Oid, cstring, char, char, Oid);
+            """
+
+        utility_conn.query(drop_func_query)
+        utility_conn.query(create_func_query)
+        logger.info('Function gp_relfile_insert_for_register successfully registered into database template1.')
+        # register function for other databases
+        query = """select datname from pg_database;"""
+        dbs = utility_conn.query(query).dictresult()
+        for cur_db in dbs:
+            if cur_db['datname'] not in ['template1', 'template0', 'hcatalog']:
+                url = dbconn.DbURL(hostname=options.host, port=options.port,
+                               dbname=options.database, username=options.user)
+                existed_db_conn = pg.connect(dbname=cur_db['datname'], host=url.pghost,
+                                         port=url.pgport, user=url.pguser, passwd=url.pgpass)
+                existed_db_conn.query(drop_func_query);
+                existed_db_conn.query(create_func_query);
+                logger.info('Function gp_relfile_insert_for_register successfully registered into database %s.',cur_db['datname'])
+                existed_db_conn.close()
+        utility_conn.close()
+    except pg.DatabaseError as e:
+        print e
+    except pg.InternalError:
+        logger.error('Fail to connect to database, this script can only be run when database is up.')
+        return 1
+    logger.info('Hawq Upgrade Succeed.')
+
+if __name__ == '__main__':
+    parser = option_parser()
+    options, args = parser.parse_args()
+    if len(args) != 0:
+        parser.print_help(sys.stderr)
+        sys.exit(1)
+    register_func(options, args)

--- a/tools/bin/hawqupgrade
+++ b/tools/bin/hawqupgrade
@@ -17,8 +17,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# Usage1: hawq register [-h hostname] [-p port] [-U username] [-d database] [-f filepath] [-e eof] <tablename>
-# Usage2: hawq register [-h hostname] [-p port] [-U username] [-d database] [-c config] [--force] <tablename>
+# Usage1: hawq upgrade [-h hostname] [-p port] [-U username]
 
 import os
 import sys
@@ -45,18 +44,16 @@ def option_parser():
                        usage='usage: %prog [options] table_name',
                        version='%prog version $Revision: #1 $')
     parser.remove_option('-h')
-    parser.add_option('-?', '--help', action='help')
     parser.add_option('-h', '--host', help='host of the target DB')
     parser.add_option('-p', '--port', help='port of the target DB', type='int', default=0)
     parser.add_option('-U', '--user', help='username of the target DB')
-    parser.add_option('-d', '--database', default='template1', dest='database', help='database name')
     return parser
 
 def register_func(options, args):
     # connect db
     try:
         url = dbconn.DbURL(hostname=options.host, port=options.port,
-                           dbname=options.database, username=options.user)
+                           dbname="template1", username=options.user)
         utility_conn = pg.connect(dbname=url.pgdb, host=url.pghost, port=url.pgport,
                                   user=url.pguser, passwd=url.pgpass, opt='-c gp_session_role=utility')
 
@@ -81,7 +78,7 @@ def register_func(options, args):
         for cur_db in dbs:
             if cur_db['datname'] not in ['template1', 'template0', 'hcatalog']:
                 url = dbconn.DbURL(hostname=options.host, port=options.port,
-                               dbname=options.database, username=options.user)
+                               dbname=cur_db['datname'], username=options.user)
                 existed_db_conn = pg.connect(dbname=cur_db['datname'], host=url.pghost,
                                          port=url.pgport, user=url.pguser, passwd=url.pgpass)
                 existed_db_conn.query(drop_func_query);


### PR DESCRIPTION
For Hawq register feature, we need to add some build-in functions to support some catalog changes. This could be done by a hawqupgrade script.

User interface integrated with hawq script, user just type the following command before using hawq register.
command: hawq upgrade