### PR TITLE
HAWQ-1149. Fixed relcache reference leak when pg_class tuple is invalid

### DIFF
--- a/src/backend/utils/cache/relcache.c
+++ b/src/backend/utils/cache/relcache.c
@@ -1211,9 +1211,11 @@ RelationBuildDesc(Oid targetRelId, bool insertIt)
 	/*
 	 * if no such tuple exists, return NULL
 	 */
-	if (!HeapTupleIsValid(pg_class_tuple))
+	if (!HeapTupleIsValid(pg_class_tuple)){
+		if(RelationIsValid(pg_class_relation))
+			heap_close(pg_class_relation, AccessShareLock);
 		return NULL;
-
+	}
 	/*
 	 * get information from the pg_class_tuple
 	 */


### PR DESCRIPTION
Fixed below warning:
WARNING:  relcache reference leak: relation "pg_class" not closed

The test case exists when the meta tuple in pg_class in invalid.

This bug also exists in postgreSQL, although it doesn't called for some reason.