### PR TITLE
HAWQ-1174. double type core counter of container set has precision issue

### DIFF
--- a/src/backend/resourcemanager/include/resourcepool.h
+++ b/src/backend/resourcemanager/include/resourcepool.h
@@ -715,6 +715,7 @@ SimpStringPtr build_segment_status_description(SegStat segstat);
 #define EPSILON 1e-7
 #define IS_DOUBLE_ZERO(d)       (fabs(d) < EPSILON)
 #define IS_DOUBLE_EQ(x, y)      ((fabs((x) - (y))) <= (EPSILON))
+#define IS_DOUBLE_EQGREATER(x, y)  (((x) + EPSILON) >= (y))
 
 void validateResourcePoolStatus(bool refquemgr);
 

--- a/src/backend/resourcemanager/include/resourcepool.h
+++ b/src/backend/resourcemanager/include/resourcepool.h
@@ -715,7 +715,7 @@ SimpStringPtr build_segment_status_description(SegStat segstat);
 #define EPSILON 1e-7
 #define IS_DOUBLE_ZERO(d)       (fabs(d) < EPSILON)
 #define IS_DOUBLE_EQ(x, y)      ((fabs((x) - (y))) <= (EPSILON))
-#define IS_DOUBLE_EQGREATER(x, y)  (((x) + EPSILON) >= (y))
+#define IS_DOUBLE_GE(x, y)      (((x) + EPSILON) >= (y))
 
 void validateResourcePoolStatus(bool refquemgr);
 

--- a/src/backend/resourcemanager/resourcepool.c
+++ b/src/backend/resourcemanager/resourcepool.c
@@ -3650,11 +3650,10 @@ void timeoutIdleGRMResourceToRBByRatio(int 		 ratioindex,
 		GRMContainer retcont = getGRMContainerSetContainerFirst(containerset);
 
 		if ( containerset->Available.MemoryMB >= retcont->MemoryMB &&
-			 IS_DOUBLE_EQGREATER(containerset->Available.Core,
-					             retcont->Core ) )
+		     IS_DOUBLE_GE(containerset->Available.Core, retcont->Core ) )
 		{
 			Assert(resource->Available.MemoryMB >= retcont->MemoryMB);
-			Assert(IS_DOUBLE_EQGREATER(resource->Available.Core, retcont->Core));
+			Assert(IS_DOUBLE_GE(resource->Available.Core, retcont->Core));
 
 			retcont = popGRMContainerSetContainerList(containerset);
 
@@ -3669,12 +3668,12 @@ void timeoutIdleGRMResourceToRBByRatio(int 		 ratioindex,
 			Assert( resource->Allocated.MemoryMB >= 0 );
 			Assert( resource->Allocated.Core >= 0  );
 			Assert( resource->Available.MemoryMB >= 0 );
-			Assert( IS_DOUBLE_EQGREATER(resource->Available.Core, 0) );
+			Assert( IS_DOUBLE_GE(resource->Available.Core, 0) );
 
 			Assert( containerset->Allocated.MemoryMB >= 0 );
 			Assert( containerset->Allocated.Core >= 0   );
 			Assert( containerset->Available.MemoryMB >= 0 );
-			Assert( IS_DOUBLE_EQGREATER(containerset->Available.Core, 0) );
+			Assert( IS_DOUBLE_GE(containerset->Available.Core, 0) );
 
 			reorderSegResourceAllocIndex(resource, ratio);
 			reorderSegResourceAvailIndex(resource, ratio);

--- a/src/backend/resourcemanager/resourcepool.c
+++ b/src/backend/resourcemanager/resourcepool.c
@@ -3650,11 +3650,11 @@ void timeoutIdleGRMResourceToRBByRatio(int 		 ratioindex,
 		GRMContainer retcont = getGRMContainerSetContainerFirst(containerset);
 
 		if ( containerset->Available.MemoryMB >= retcont->MemoryMB &&
-			 containerset->Available.Core     >= retcont->Core )
+			 IS_DOUBLE_EQGREATER(containerset->Available.Core,
+					             retcont->Core ) )
 		{
-
 			Assert(resource->Available.MemoryMB >= retcont->MemoryMB);
-			Assert(resource->Available.Core     >= retcont->Core);
+			Assert(IS_DOUBLE_EQGREATER(resource->Available.Core, retcont->Core));
 
 			retcont = popGRMContainerSetContainerList(containerset);
 
@@ -3669,12 +3669,12 @@ void timeoutIdleGRMResourceToRBByRatio(int 		 ratioindex,
 			Assert( resource->Allocated.MemoryMB >= 0 );
 			Assert( resource->Allocated.Core >= 0  );
 			Assert( resource->Available.MemoryMB >= 0 );
-			Assert( resource->Available.Core >= 0  );
+			Assert( IS_DOUBLE_EQGREATER(resource->Available.Core, 0) );
 
 			Assert( containerset->Allocated.MemoryMB >= 0 );
 			Assert( containerset->Allocated.Core >= 0   );
 			Assert( containerset->Available.MemoryMB >= 0 );
-			Assert( containerset->Available.Core >= 0   );
+			Assert( IS_DOUBLE_EQGREATER(containerset->Available.Core, 0) );
 
 			reorderSegResourceAllocIndex(resource, ratio);
 			reorderSegResourceAvailIndex(resource, ratio);

--- a/src/backend/resourcemanager/resqueuemanager.c
+++ b/src/backend/resourcemanager/resqueuemanager.c
@@ -3267,6 +3267,10 @@ void minusResourceBundleData(ResourceBundle detail, int32_t mem, double core)
 {
 	detail->MemoryMB -= mem;
 	detail->Core -= core;
+	if (IS_DOUBLE_EQ(detail->Core, 0)) {
+		// this setting is to avoid accumulating double precision problem
+		detail->Core = 0.0;
+	}
 }
 
 void resetResourceBundleDataByBundle(ResourceBundle detail, ResourceBundle source)


### PR DESCRIPTION
This fix is to avoid double precision problem when counting available core resource for a container set.