### PR TITLE
HAWQ-1226. fix compile error under gcc 4.8.2

### DIFF
--- a/src/backend/libpq/be-secure.c
+++ b/src/backend/libpq/be-secure.c
@@ -318,8 +318,6 @@ rloop:
  * This function holds an interrupt before reporting this error to avoid
  * a self deadlock situation, see MPP-13718 for more info.
  */
-
-/* no used now, avoid compile warnning
 static void
 report_commerror(const char *err_msg)
 {
@@ -331,7 +329,6 @@ report_commerror(const char *err_msg)
 
 	RESUME_INTERRUPTS();
 }
-*/
 
 /*
  *	Write data to a secure connection.

--- a/src/backend/libpq/be-secure.c
+++ b/src/backend/libpq/be-secure.c
@@ -318,6 +318,7 @@ rloop:
  * This function holds an interrupt before reporting this error to avoid
  * a self deadlock situation, see MPP-13718 for more info.
  */
+/* here is a warning on gcc 4.8.5 */
 static void
 report_commerror(const char *err_msg)
 {


### PR DESCRIPTION
When use gcc version **4.8.5** 20150623 (Red Hat 4.8.5-4) (GCC), there is a warning:
```
be-secure.c:323:1: warning: 'report_commerror' defined but not used [-Wunused-function]
 report_commerror(const char *err_msg)
 ^
```

But it will cause gcc 4.8.2 to make error if we remove this function. So let's keep it as before.
