### PR TITLE
HAWQ-1230. Introduce macro __MAYBE_UNUSED_FUNC to surpress "unused fu…

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -3038,11 +3038,9 @@ renamerel(Oid myrelid, const char *newrelname, RenameStmt *stmt)
 	char			oldrelname[NAMEDATALEN];
 	bool			relhastriggers;
 	Form_pg_class	form;
-	bool			isSystemRelation;
+	bool __MAYBE_UNUSED	isSystemRelation;
 	cqContext		cqc;
 	cqContext	   *pcqCtx;
-
-	POSSIBLE_UNUSED_VAR(isSystemRelation);
 
 	/* if this is a child table of a partitioning configuration, complain */
 	if (stmt && rel_is_child_partition(myrelid) && !stmt->bAllowPartn)
@@ -14516,14 +14514,12 @@ ATPExecPartExchange(AlteredTableInfo *tab, Relation rel, AlterPartitionCmd *pc)
 		AttrMap			*newmap;
 		AttrMap			*oldmap;
 		List			*newcons;
-		bool			 ok;
+		bool __MAYBE_UNUSED	 ok;
 		bool			 validate	= intVal(pc2->arg1) ? true : false;
 		Oid				 oldnspid	= InvalidOid;
 		Oid				 newnspid	= InvalidOid;
 		char			*newNspName = NULL;
 		char			*oldNspName = NULL;
-
-		POSSIBLE_UNUSED_VAR(ok);
 
 		newrel = heap_open(newrelid, AccessExclusiveLock);
 		oldrel = heap_open(oldrelid, AccessExclusiveLock);

--- a/src/backend/libpq/be-secure.c
+++ b/src/backend/libpq/be-secure.c
@@ -318,8 +318,7 @@ rloop:
  * This function holds an interrupt before reporting this error to avoid
  * a self deadlock situation, see MPP-13718 for more info.
  */
-/* here is a warning on gcc 4.8.5 */
-static void
+static void __MAYBE_UNUSED
 report_commerror(const char *err_msg)
 {
 	HOLD_INTERRUPTS();

--- a/src/include/postgres.h
+++ b/src/include/postgres.h
@@ -513,12 +513,8 @@ extern void gp_set_thread_sigmasks(void);
 
 extern void OnMoveOutCGroupForQE(void);
 
-#ifndef POSSIBLE_UNUSED_VAR
-#define POSSIBLE_UNUSED_VAR(x)	((void)x)
-#endif
-
-#ifndef POSSIBLE_UNUSED_ARG
-#define POSSIBLE_UNUSED_ARG(x)	((void)x)
+#ifndef __MAYBE_UNUSED
+#define __MAYBE_UNUSED __attribute__((unused))
 #endif
 
 #ifndef UNUSED_ARG


### PR DESCRIPTION
…ntion" warnings.