### PR TITLE
HAWQ-1243. Add suffix name for ranger restful service.

### DIFF
--- a/src/backend/libpq/rangerrest.c
+++ b/src/backend/libpq/rangerrest.c
@@ -426,24 +426,15 @@ int call_ranger_rest(CURL_HANDLE curl_handle, const char* request)
 	curl_easy_setopt(curl_handle->curl_handle, CURLOPT_TIMEOUT, 30L);
 
 	/* specify URL to get */
-	//curl_easy_setopt(curl_handle->curl_handle, CURLOPT_URL, "http://localhost:8089/checkprivilege");
 	StringInfoData tname;
 	initStringInfo(&tname);
 	appendStringInfo(&tname, "http://");
 	appendStringInfo(&tname, "%s", rps_addr_host);
 	appendStringInfo(&tname, ":");
 	appendStringInfo(&tname, "%d", rps_addr_port);
-	appendStringInfo(&tname, "/rps");
+	appendStringInfo(&tname, "/");
+	appendStringInfo(&tname, "%s", rps_addr_suffix);
 	curl_easy_setopt(curl_handle->curl_handle, CURLOPT_URL, tname.data);
-
-	/* specify format */
-	// struct curl_slist *plist = curl_slist_append(NULL, "Content-Type:application/json;charset=UTF-8");
-	// curl_easy_setopt(curl_handle, CURLOPT_HTTPHEADER, plist);
-
-
-	//curl_easy_setopt(curl_handle->curl_handle, CURLOPT_POSTFIELDSIZE_LARGE, 1000);
-	//curl_easy_setopt(curl_handle->curl_handle, CURLOPT_HTTPGET, 0);
-	//curl_easy_setopt(curl_handle->curl_handle, CURLOPT_CUSTOMREQUEST, "POST");
 
 	struct curl_slist *headers = NULL;
 	//curl_slist_append(headers, "Accept: application/json");

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -780,6 +780,7 @@ bool gp_plpgsql_clear_cache_always = false;
 bool gp_called_by_pgdump = false;
 
 char   *rps_addr_host;
+char   *rps_addr_suffix;
 int     rps_addr_port;
 
 /*
@@ -6268,7 +6269,7 @@ static struct config_int ConfigureNamesInt[] =
       NULL
     },
     &rps_addr_port,
-    1, 1, 65535, NULL, NULL
+    8080, 1, 65535, NULL, NULL
   },
 
 	{
@@ -8182,6 +8183,15 @@ static struct config_string ConfigureNamesString[] =
     },
     &rps_addr_host,
     "localhost", NULL, NULL
+  },
+
+  {
+    {"hawq_rps_address_suffix", PGC_POSTMASTER, PRESET_OPTIONS,
+      gettext_noop("ranger plugin server suffix of restful service address"),
+      NULL
+    },
+    &rps_addr_suffix,
+    "hawq", NULL, NULL
   },
 
 	{

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -454,6 +454,7 @@ extern bool	optimizer_partition_selection_log;
  * rps host and port
  */
 extern char   *rps_addr_host;
+extern char   *rps_addr_suffix;
 extern int     rps_addr_port;
 /*
  * During insertion in a table with parquet partitions,


### PR DESCRIPTION
Except rps_addr_host and rps_addr_port, we also need rps_addr_suffix to
We will use this GUC to construct rest service address:
http://rps_addr_host:rps_addr_port/rps_addr_suffix