### PR TITLE
HAWQ-1242. hawq-site.xml default content has wrong guc variable names

### DIFF
--- a/src/backend/utils/misc/etc/hawq-site.xml
+++ b/src/backend/utils/misc/etc/hawq-site.xml
@@ -33,7 +33,7 @@ under the License.
 	</property>
 
 	<property>
-		<name>hawq_standby_address_host</name>
+		<name>standby_address_host</name>
 		<value>none</value>
 		<description>The host name of hawq standby master.</description>
 	</property>
@@ -45,19 +45,19 @@ under the License.
 	</property>
 
 	<property>
-		<name>hawq_dfs_url</name>
+		<name>dfs_url</name>
 		<value>localhost:8020/hawq_default</value>
 		<description>URL for accessing HDFS.</description>
 	</property>
 
 	<property>
-		<name>hawq_master_directory</name>
+		<name>master_directory</name>
 		<value>~/hawq-data-directory/masterdd</value>
 		<description>The directory of hawq master.</description>
 	</property>
 
 	<property>
-		<name>hawq_segment_directory</name>
+		<name>segment_directory</name>
 		<value>~/hawq-data-directory/segmentdd</value>
 		<description>The directory of hawq segment.</description>
 	</property> 

--- a/src/backend/utils/misc/etc/template-hawq-site.xml
+++ b/src/backend/utils/misc/etc/template-hawq-site.xml
@@ -33,7 +33,7 @@ under the License.
 	</property>
 
 	<property>
-		<name>hawq_standby_address_host</name>
+		<name>standby_address_host</name>
 		<value>%standby.host%</value>
 		<description>The host name of hawq standby master.</description>
 	</property>
@@ -45,19 +45,19 @@ under the License.
 	</property>
 
 	<property>
-		<name>hawq_dfs_url</name>
+		<name>dfs_url</name>
 		<value>%namenode.host%:%namenode.port%/%hawq.file.space%</value>
 		<description>URL for accessing HDFS.</description>
 	</property>
 
 	<property>
-		<name>hawq_master_directory</name>
+		<name>master_directory</name>
 		<value>%master.directory%</value>
 		<description>The directory of hawq master.</description>
 	</property>
 
 	<property>
-		<name>hawq_segment_directory</name>
+		<name>segment_directory</name>
 		<value>%segment.directory%</value>
 		<description>The directory of hawq segment.</description>
 	</property> 


### PR DESCRIPTION
Fixed the wrong names in hawq-site.xml and its template file.