### PR TITLE
HAWQ-1258. segment resource manager does not switch back when it cannot resolve standby host name

### DIFF
--- a/src/backend/resourcemanager/communication/rmcomm_RMSEG2RM.c
+++ b/src/backend/resourcemanager/communication/rmcomm_RMSEG2RM.c
@@ -107,8 +107,10 @@ int sendIMAlive(int  *errorcode,
 	if ( res != FUNC_RETURN_OK )
 	{
 		rm_pfree(AsyncCommContext, context);
-		elog(WARNING, "Fail to register asynchronous connection for sending "
-					  "IMAlive message. %d", res);
+		elog(LOG, "failed to register asynchronous connection for sending "
+			      "IMAlive message. %d", res);
+		/* Always switch if fail to register connection here. */
+		switchIMAliveSendingTarget();
 		return res;
 	}
 
@@ -140,7 +142,7 @@ void receivedIMAliveResponse(AsyncCommMessageHandlerContext  context,
 		 buffersize != sizeof(RPCResponseIMAliveData) ) {
 		elog(WARNING, "Segment's resource manager received wrong response for "
 					  "heart-beat request.");
-		DRMGlobalInstance->SendToStandby = !DRMGlobalInstance->SendToStandby;
+		switchIMAliveSendingTarget();
 	}
 	else
 	{
@@ -165,7 +167,7 @@ void sentIMAliveError(AsyncCommMessageHandlerContext context)
 	else
 		elog(WARNING, "Segment's resource manager sending IMAlive message "
 					  "switches from master to standby");
-	DRMGlobalInstance->SendToStandby = !DRMGlobalInstance->SendToStandby;
+	switchIMAliveSendingTarget();
 }
 
 void sentIMAliveCleanUp(AsyncCommMessageHandlerContext context)

--- a/src/backend/resourcemanager/include/dynrm.h
+++ b/src/backend/resourcemanager/include/dynrm.h
@@ -322,4 +322,6 @@ int  initializeSocketServer_RMSEG(void);
 int  MainHandlerLoop_RMSEG(void);
 
 void checkAndBuildFailedTmpDirList(void);
+
+void switchIMAliveTarget(void);
 #endif //DYNAMIC_RESOURCE_MANAGEMENT_H

--- a/src/backend/resourcemanager/resourcemanager_RMSEG.c
+++ b/src/backend/resourcemanager/resourcemanager_RMSEG.c
@@ -275,3 +275,14 @@ void checkAndBuildFailedTmpDirList(void)
 			  "directory, which costs " UINT64_FORMAT " us",
 			  endtime - starttime);
 }
+
+void switchIMAliveSendingTarget(void)
+{
+	/* We switch to standby server only when it is correctly set. */
+	if (strcmp(standby_addr_host, "none") != 0)
+	{
+		DRMGlobalInstance->SendToStandby = !DRMGlobalInstance->SendToStandby;
+		elog(LOG, "segment will send heart-beat to %s from now on",
+				  DRMGlobalInstance->SendToStandby ? "standby" : "master");
+	}
+}

--- a/src/backend/resourcemanager/resourcemanager_RMSEG.c
+++ b/src/backend/resourcemanager/resourcemanager_RMSEG.c
@@ -279,7 +279,7 @@ void checkAndBuildFailedTmpDirList(void)
 void switchIMAliveSendingTarget(void)
 {
 	/* We switch to standby server only when it is correctly set. */
-	if (strcmp(standby_addr_host, "none") != 0)
+	if (pg_strcasecmp(standby_addr_host, "none") != 0)
 	{
 		DRMGlobalInstance->SendToStandby = !DRMGlobalInstance->SendToStandby;
 		elog(LOG, "segment will send heart-beat to %s from now on",

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -8200,7 +8200,7 @@ static struct config_string ConfigureNamesString[] =
 			NULL
 		},
 		&standby_addr_host,
-		"localhost", NULL, NULL
+		"none", NULL, NULL
 	},
 
 	{


### PR DESCRIPTION
If use does not configure standby host, segment will not switch to standby server; If segment cannot resolve target server no matter the master server or the standby server, the target server for sending IMAlive heart-beat is switched as well.