### PR TITLE
HAWQ-1275. Check build-in catalogs, tables and functions in native aclcheck.

### DIFF
--- a/src/backend/catalog/aclchk.c
+++ b/src/backend/catalog/aclchk.c
@@ -2669,6 +2669,13 @@ List *getActionName(AclMode mask)
 
 bool fallBackToNativeCheck(AclObjectKind objkind, Oid obj_oid, Oid roleid)
 {
+  /* get the latest information_schema_namespcace_oid. Since caql access heap table
+   * directly without aclcheck, this function will not be called recursively
+   */
+  if (information_schema_namespcace_oid == 0)
+  {
+	  information_schema_namespcace_oid = (int)get_namespace_oid("information_schema");
+  }
   /*for heap table, we fall back to native check.*/
   if (objkind == ACL_KIND_CLASS)
   {
@@ -2681,7 +2688,7 @@ bool fallBackToNativeCheck(AclObjectKind objkind, Oid obj_oid, Oid roleid)
   else if (objkind == ACL_KIND_NAMESPACE)
   {
 	/*native check build-in schemas.*/
-    if (obj_oid == PG_CATALOG_NAMESPACE || obj_oid == PG_INFORMATION_SCHEMA_NAMESPACE
+    if (obj_oid == PG_CATALOG_NAMESPACE || obj_oid == information_schema_namespcace_oid
     		|| obj_oid == PG_AOSEGMENT_NAMESPACE || obj_oid == PG_TOAST_NAMESPACE
 			|| obj_oid == PG_BITMAPINDEX_NAMESPACE)
     {
@@ -2692,7 +2699,7 @@ bool fallBackToNativeCheck(AclObjectKind objkind, Oid obj_oid, Oid roleid)
   {
 	/*native check functions under build-in schemas.*/
     Oid namespaceid = get_func_namespace(obj_oid);
-    if (namespaceid == PG_CATALOG_NAMESPACE || namespaceid == PG_INFORMATION_SCHEMA_NAMESPACE
+    if (namespaceid == PG_CATALOG_NAMESPACE || namespaceid == information_schema_namespcace_oid
 			|| namespaceid == PG_AOSEGMENT_NAMESPACE || namespaceid == PG_TOAST_NAMESPACE
 			|| namespaceid == PG_BITMAPINDEX_NAMESPACE)
     {

--- a/src/backend/catalog/aclchk.c
+++ b/src/backend/catalog/aclchk.c
@@ -2669,7 +2669,7 @@ List *getActionName(AclMode mask)
 
 bool fallBackToNativeCheck(AclObjectKind objkind, Oid obj_oid, Oid roleid)
 {
-  //for heap table, we fall back to native check.
+  /*for heap table, we fall back to native check.*/
   if (objkind == ACL_KIND_CLASS)
   {
     char relstorage = get_rel_relstorage(obj_oid);
@@ -2680,7 +2680,7 @@ bool fallBackToNativeCheck(AclObjectKind objkind, Oid obj_oid, Oid roleid)
   }
   else if (objkind == ACL_KIND_NAMESPACE)
   {
-	//native check build-in schemas.
+	/*native check build-in schemas.*/
     if (obj_oid == PG_CATALOG_NAMESPACE || obj_oid == PG_INFORMATION_SCHEMA_NAMESPACE
     		|| obj_oid == PG_AOSEGMENT_NAMESPACE || obj_oid == PG_TOAST_NAMESPACE
 			|| obj_oid == PG_BITMAPINDEX_NAMESPACE)
@@ -2690,7 +2690,7 @@ bool fallBackToNativeCheck(AclObjectKind objkind, Oid obj_oid, Oid roleid)
   }
   else if (objkind == ACL_KIND_PROC)
   {
-	//native check functions under build-in schemas.
+	/*native check functions under build-in schemas.*/
     Oid namespaceid = get_func_namespace(obj_oid);
     if (namespaceid == PG_CATALOG_NAMESPACE || namespaceid == PG_INFORMATION_SCHEMA_NAMESPACE
 			|| namespaceid == PG_AOSEGMENT_NAMESPACE || namespaceid == PG_TOAST_NAMESPACE
@@ -2705,7 +2705,7 @@ bool fallBackToNativeCheck(AclObjectKind objkind, Oid obj_oid, Oid roleid)
 
 bool fallBackToNativeChecks(AclObjectKind objkind, List* table_list, Oid roleid)
 {
-  //we only have range table here
+  /*we only have range table here*/
   if (objkind == ACL_KIND_CLASS)
   {
     ListCell   *l;

--- a/src/backend/utils/cache/lsyscache.c
+++ b/src/backend/utils/cache/lsyscache.c
@@ -3248,6 +3248,30 @@ get_namespace_name(Oid nspid)
 	return result;
 }
 
+/*
+ * get_namespace_oid
+ *		Returns the oid of a namespace given its name
+ *
+ */
+Oid
+get_namespace_oid(const char* npname)
+{
+	Oid			result;
+	int			fetchCount;
+
+	result = caql_getoid_plus(
+			NULL,
+			&fetchCount,
+			NULL,
+			cql("SELECT oid FROM pg_namespace "
+				" WHERE nspname = :1 ",
+				PointerGetDatum((char *) npname)));
+
+	if (!fetchCount)
+		return InvalidOid;
+
+	return result;
+}
 /*				---------- PG_AUTHID CACHE ----------					 */
 
 /*

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -769,6 +769,8 @@ bool		optimizer_prefer_scalar_dqa_multistage_agg;
 bool		optimizer_parallel_union;
 bool		optimizer_array_constraints;
 
+int information_schema_namespcace_oid;
+
 /* Security */
 bool		gp_reject_internal_tcp_conn = true;
 
@@ -6192,6 +6194,15 @@ static struct config_int ConfigureNamesInt[] =
 		},
 		&optimizer_join_order_threshold,
 		10, 0, INT_MAX, NULL, NULL
+	},
+
+	{
+		{"information_schema_namespcace_oid", PGC_USERSET, DEVELOPER_OPTIONS,
+			gettext_noop("the oid of information_schema namespace"),
+			NULL
+		},
+		&information_schema_namespcace_oid,
+		0, 0, INT_MAX, NULL, NULL
 	},
 
 	{

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -6280,7 +6280,7 @@ static struct config_int ConfigureNamesInt[] =
       NULL
     },
     &rps_addr_port,
-    8080, 1, 65535, NULL, NULL
+    8432, 1, 65535, NULL, NULL
   },
 
 	{

--- a/src/include/catalog/pg_namespace.h
+++ b/src/include/catalog/pg_namespace.h
@@ -123,7 +123,7 @@ DESCR("Standard public schema");
 DATA(insert OID = 6104 ( "pg_aoseg" PGUID _null_ 0));
 DESCR("Reserved schema for Append Only segment list and eof tables");
 #define PG_AOSEGMENT_NAMESPACE 6104
-
+#define PG_INFORMATION_SCHEMA_NAMESPACE 10671
 
 #define IsBuiltInNameSpace(namespaceId) \
 	(namespaceId == PG_CATALOG_NAMESPACE || \

--- a/src/include/catalog/pg_namespace.h
+++ b/src/include/catalog/pg_namespace.h
@@ -123,7 +123,6 @@ DESCR("Standard public schema");
 DATA(insert OID = 6104 ( "pg_aoseg" PGUID _null_ 0));
 DESCR("Reserved schema for Append Only segment list and eof tables");
 #define PG_AOSEGMENT_NAMESPACE 6104
-#define PG_INFORMATION_SCHEMA_NAMESPACE 10671
 
 #define IsBuiltInNameSpace(namespaceId) \
 	(namespaceId == PG_CATALOG_NAMESPACE || \

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -445,6 +445,9 @@ extern bool optimizer_prefer_scalar_dqa_multistage_agg;
 extern bool optimizer_parallel_union;
 extern bool optimizer_array_constraints;
 
+
+extern int information_schema_namespcace_oid;
+
 /**
  * Enable logging of DPE match in optimizer.
  */

--- a/src/include/utils/lsyscache.h
+++ b/src/include/utils/lsyscache.h
@@ -148,6 +148,7 @@ extern void free_attstatsslot(Oid atttype,
 				  Datum *values, int nvalues,
 				  float4 *numbers, int nnumbers);
 extern char *get_namespace_name(Oid nspid);
+extern Oid get_namespace_oid(const char* npname);
 extern Oid	get_roleid(const char *rolname);
 extern char *get_rolname(Oid roleid);
 extern char get_relation_storage_type(Oid relid);


### PR DESCRIPTION
We plan to do privilege check in hawq side for build-in catalogs, tables and functions. The reason is that Ranger mainly manage the user data, but build-in catalogs and tables are not related to user data(note that some of them contain statistics information of user data such as catalog table pg_aoseg_*).