### PR TITLE
HAWQ-1243. Add suffix name for ranger restful service.

### DIFF
--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -8202,7 +8202,7 @@ static struct config_string ConfigureNamesString[] =
       NULL
     },
     &rps_addr_suffix,
-    "hawq", NULL, NULL
+    "rps", NULL, NULL
   },
 
 	{


### PR DESCRIPTION
change the default RPS RESTFUL service suffix to rps