### PR TITLE
HAWQ-1277. Fix build problem on CentOS 7, with --with-plperl.

### DIFF
--- a/src/pl/plperl/GNUmakefile
+++ b/src/pl/plperl/GNUmakefile
@@ -56,6 +56,9 @@ endif
 # where to find psql for running the tests
 PSQLDIR = $(bindir)
 
+# where to find xsubpp for building XS.
+XSUBPPDIR = $(shell $(PERL) -e 'use List::Util qw(first); print first { -r "$$_/ExtUtils/xsubpp" } @INC')
+
 include $(top_srcdir)/src/Makefile.shlib
 
 plperl.o: perlchunks.h plperl_opmask.h
@@ -69,10 +72,10 @@ perlchunks.h: $(PERLCHUNKS)
 all: all-lib
 
 SPI.c: SPI.xs
-	$(PERL) $(perl_privlibexp)/ExtUtils/xsubpp -typemap $(perl_privlibexp)/ExtUtils/typemap $< >$@
-	
+	$(PERL) $(XSUBPPDIR)/ExtUtils/xsubpp -typemap $(perl_privlibexp)/ExtUtils/typemap $< >$@
+
 Util.c: Util.xs
-	$(PERL) $(perl_privlibexp)/ExtUtils/xsubpp -typemap $(perl_privlibexp)/ExtUtils/typemap $< >$@
+	$(PERL) $(XSUBPPDIR)/ExtUtils/xsubpp -typemap $(perl_privlibexp)/ExtUtils/typemap $< >$@
 
 install: all installdirs install-lib
 


### PR DESCRIPTION
Please see HAWQ-1277 for additional details.

This fix was originally backported from PostgreSQL to the Greenplum DB master branch a year ago by Heikki Linnakangas<https://github.com/hlinnaka> (Original PostgreSQL committer Andrew Dunstan <andrew@dunslane.net<mailto:andrew@dunslane.net>>):

https://github.com/greenplum-db/gpdb/commit/f493756a5ac8a90ff1d5e3b84f38a153c9f80b9c#diff-97d34e5e3684082069b6c85876df9107

See earlier discussion on this on pgsql-hackers, message-id
9B946296-A2EB-4B45-A190-153F06662F8B@kineticode.com. We'd get this fix
eventually as we merge with later PostgreSQL versions, but let's make life
easier for people hitting this issue now.

This is a backpatch of the following upstream commit, sans the MSVC build
parts, as I have no environment to test that and we don't support Windows
anyway. We'll get the MSVC parts later, as we merge.

commit ba00ab0b111a0cbbac612e8ea8b0d5f96534102e
Author: Andrew Dunstan <andrew@dunslane.net>
Date:   Sat Nov 26 15:22:32 2011 -0500

    Use the preferred version of xsubpp, not necessarily the one that came with the
    distro version of perl.

    David Wheeler and Alex Hunsaker.

    Backpatch to 9.1 where it applies cleanly. A simple workaround is available for earlier
    branches, and further effort doesn't seem warranted.