### PR TITLE
HAWQ-1279. Force to recompute namespace_path when enable_ranger

### DIFF
--- a/src/backend/catalog/namespace.c
+++ b/src/backend/catalog/namespace.c
@@ -1933,7 +1933,12 @@ recomputeNamespacePath(void)
 	 * Do nothing if path is already valid.
 	 */
 	if (namespaceSearchPathValid && namespaceUser == roleid)
-		return;
+	{
+		if (!enable_ranger)
+			return;
+		else
+			elog(DEBUG3, "recompute search_path[%s] when enable_ranger", namespace_search_path);
+	}
 
 	/* Need a modifiable copy of namespace_search_path string */
 	rawname = pstrdup(namespace_search_path);


### PR DESCRIPTION
If don't force to recompute, grant/revoke the rights of schema in ranger does not affect the **running** session. 
So for the new rights to take effect, must reconnect session, that's very inconvenient for users.

More details please see JIRA: https://issues.apache.org/jira/browse/HAWQ-1279