### PR TITLE
HAWQ-1282. Shared Input Scan may result in endless loop.

### DIFF
--- a/src/backend/executor/nodeShareInputScan.c
+++ b/src/backend/executor/nodeShareInputScan.c
@@ -883,7 +883,6 @@ writer_wait_for_acks(ShareInput_Lk_Context *pctxt, int share_id, int xslice)
 	mpp_fd_set rset;
 	struct timeval tval;
 	char b;
-	int timeout_times = 0;
 
 	while(ack_needed > 0)
 	{
@@ -918,10 +917,6 @@ writer_wait_for_acks(ShareInput_Lk_Context *pctxt, int share_id, int xslice)
 		}
 		else if(numReady==0)
 		{
-			/*If timeout times reach the max_retry_times, we need to return to avoid endless loop*/
-			if(timeout_times++ > MAX_RETRY_TIMES){
-				return;
-			}
 			elog(DEBUG1, "SISC WRITER (shareid=%d, slice=%d): Notify ready time out once ... ",
 					share_id, currentSliceId);
 		}

--- a/src/include/executor/nodeShareInputScan.h
+++ b/src/include/executor/nodeShareInputScan.h
@@ -31,7 +31,6 @@
 
 #include "nodes/execnodes.h"
 
-#define MAX_RETRY_TIMES 5
 extern int ExecCountSlotsShareInputScan(ShareInputScan* node);
 extern ShareInputScanState *ExecInitShareInputScan(ShareInputScan *node, EState *estate, int eflags);
 extern TupleTableSlot *ExecShareInputScan(ShareInputScanState *node);

--- a/src/include/executor/nodeShareInputScan.h
+++ b/src/include/executor/nodeShareInputScan.h
@@ -30,6 +30,8 @@
 #define NODESHAREINPUTSCAN_H
 
 #include "nodes/execnodes.h"
+
+#define MAX_RETRY_TIMES 5
 extern int ExecCountSlotsShareInputScan(ShareInputScan* node);
 extern ShareInputScanState *ExecInitShareInputScan(ShareInputScan *node, EState *estate, int eflags);
 extern TupleTableSlot *ExecShareInputScan(ShareInputScanState *node);

--- a/src/include/executor/nodeShareInputScan.h
+++ b/src/include/executor/nodeShareInputScan.h
@@ -30,7 +30,6 @@
 #define NODESHAREINPUTSCAN_H
 
 #include "nodes/execnodes.h"
-
 extern int ExecCountSlotsShareInputScan(ShareInputScan* node);
 extern ShareInputScanState *ExecInitShareInputScan(ShareInputScan *node, EState *estate, int eflags);
 extern TupleTableSlot *ExecShareInputScan(ShareInputScanState *node);


### PR DESCRIPTION
There are residual process after running some queries. Through the call stack, we find that there is an endless loop in function writer_wait_for_acks() in shared input scan.
This PR includes:
1 add max retry times to avoid this problem.
2 fix file handler leak in retry_read() and retry_write() of shared input scan.