### PR TITLE
HAWQ-1285. resource manager outputs uninitialized string as host name

### DIFF
--- a/src/backend/resourcemanager/resourcepool.c
+++ b/src/backend/resourcemanager/resourcepool.c
@@ -4697,10 +4697,10 @@ void adjustSegmentStatGRMCapacity(SegStat segstat)
 		if ( oldmemorymb != segstat->GRMTotalMemoryMB ||
 			 oldcore	 != segstat->GRMTotalCore )
 		{
-			elog(LOG, "Resource manager adjusts segment %s original global resource "
-					  "manager resource capacity from (%d MB, %d CORE) to "
-					  "(%d MB, %d CORE)",
-					  GET_SEGINFO_HOSTNAME(&(segstat->Info)),
+			elog(LOG, "Resource manager adjusts segment (GRM name) %s original "
+					  "global resource manager resource capacity from "
+					  "(%d MB, %d CORE) to (%d MB, %d CORE)",
+					  GET_SEGINFO_GRMHOSTNAME(&(segstat->Info)),
 					  oldmemorymb,
 					  oldcore,
 					  segstat->GRMTotalMemoryMB,

--- a/src/backend/resourcemanager/resourcepool.c
+++ b/src/backend/resourcemanager/resourcepool.c
@@ -4697,9 +4697,9 @@ void adjustSegmentStatGRMCapacity(SegStat segstat)
 		if ( oldmemorymb != segstat->GRMTotalMemoryMB ||
 			 oldcore	 != segstat->GRMTotalCore )
 		{
-			elog(LOG, "Resource manager adjusts segment (GRM name) %s original "
-					  "global resource manager resource capacity from "
-					  "(%d MB, %d CORE) to (%d MB, %d CORE)",
+			elog(LOG, "resource manager adjusts segment %s resource capacity "
+					  "from (%d MB, %d CORE) to (%d MB, %d CORE) from the "
+					  "cluster report of global resource manager",
 					  GET_SEGINFO_GRMHOSTNAME(&(segstat->Info)),
 					  oldmemorymb,
 					  oldcore,


### PR DESCRIPTION
When the segstat instance is created from YARN cluster report, the hostname field is not set, so should now output it directly into log. This bug causes unreadable string output in log file.