### PR TITLE
HAWQ-1286. Reduce unnecessary calls of namespace check when run \d

### DIFF
--- a/src/backend/catalog/namespace.c
+++ b/src/backend/catalog/namespace.c
@@ -48,8 +48,10 @@
 #include "utils/memutils.h"
 #include "utils/syscache.h"
 #include "utils/guc.h"
+#include "utils/hsearch.h"
 #include "cdb/cdbvars.h"
 #include "tcop/utility.h"
+
 
 /*
  * The namespace search path is a possibly-empty list of namespace OIDs.
@@ -113,6 +115,8 @@
  * namespaceUser is the userid the path has been computed for.
  */
 
+extern const char *debug_query_string;
+
 static List *namespaceSearchPath = NIL;
 
 static Oid	namespaceUser = InvalidOid;
@@ -128,6 +132,9 @@ static bool tempCreationPending = false;
 
 /* The above five values are valid only if namespaceSearchPathValid */
 static bool namespaceSearchPathValid = true;
+
+/* store the query sign on the last call of recomputeNamespacePath(), and used the sign to judge cache invalidation */
+static uint32 last_query_sign = 0;
 
 /*
  * myTempNamespace is InvalidOid until and unless a TEMP namespace is set up
@@ -178,6 +185,11 @@ Datum		pg_my_temp_schema(PG_FUNCTION_ARGS);
 Datum		pg_is_other_temp_schema(PG_FUNCTION_ARGS);
 Datum       pg_objname_to_oid(PG_FUNCTION_ARGS);
 
+void
+reset_query_sign()
+{
+	last_query_sign = 0;
+}
 
 /*
  * GetCatalogId
@@ -1935,9 +1947,20 @@ recomputeNamespacePath(void)
 	if (namespaceSearchPathValid && namespaceUser == roleid)
 	{
 		if (!enable_ranger)
+		{
 			return;
+		}
 		else
+		{
+			uint32 current_query_sign = 0;
+			if (debug_query_string != NULL)
+				current_query_sign = string_hash(debug_query_string, strlen(debug_query_string));
+
+			if (current_query_sign == last_query_sign)
+				return;
+			last_query_sign = current_query_sign;
 			elog(DEBUG3, "recompute search_path[%s] when enable_ranger", namespace_search_path);
+		}
 	}
 
 	/* Need a modifiable copy of namespace_search_path string */

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -115,6 +115,7 @@
 #include "cdb/cdbinmemheapam.h"
 
 #include "utils/rangerrest.h"
+#include "catalog/namespace.h"
 
 #include "resourcemanager/dynrm.h"
 #include "resourcemanager/envswitch.h"
@@ -591,6 +592,9 @@ ReadCommand(StringInfo inBuf)
 		result = SocketBackend(inBuf);
 	else
 		result = InteractiveBackend(inBuf);
+
+	/* reset last_query_sign to 0 when running a new sql */
+	reset_query_sign();
 	return result;
 }
 

--- a/src/include/catalog/namespace.h
+++ b/src/include/catalog/namespace.h
@@ -90,9 +90,13 @@ extern void AtEOXact_Namespace(bool isCommit);
 extern void AtEOSubXact_Namespace(bool isCommit, SubTransactionId mySubid,
 					  SubTransactionId parentSubid);
 
+extern List *fetch_search_path(bool includeImplicit);
+
+extern void reset_query_sign();
+
 /* stuff for search_path GUC variable */
 extern char *namespace_search_path;
 
-extern List *fetch_search_path(bool includeImplicit);
+
 
 #endif   /* NAMESPACE_H */


### PR DESCRIPTION
## Backgroud:
After HAWQ-1279 is done, current schema is no cached in current session.
But it cause too many calls of namespace check to send in run \d , most of them are unnecessary.

## Example
```
\d:
    select version()
    SELECT n.nspname as \"Schema\",\n  c.relname as \"Name\",\n  CASE c.relkind WHEN 'r' THEN 'table' WHEN 'v' THEN 'view' WHEN 'i' THEN 'index' WHEN 'S' THEN 'sequence' WHEN 's' THEN 'special' END as \"Type\",\n  pg_catalog.pg_get_userbyid(c.relowner) as \"Owner\"\nFROM pg_catalog.pg_class c\n     LEFT JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace\nWHERE c.relkind IN ('r','v','S','')\n      AND n.nspname <> 'pg_catalog'\n      AND n.nspname <> 'information_schema'\n      AND n.nspname !~ '^pg_toast'\n  AND pg_catalog.pg_table_is_visible(c.oid)\nORDER BY 1,2;
        recomputeNamespacePath()
        recomputeNamespacePath()
        .... recompute many times in this long select sql
```

## Solution
Store the last sql query, only recompute if the query is changed.
