### PR TITLE
HAWQ-1291. Fix the name of privilege when create temp table.

### DIFF
--- a/src/backend/catalog/aclchk.c
+++ b/src/backend/catalog/aclchk.c
@@ -2646,7 +2646,7 @@ char *getNameFromOid(AclObjectKind objkind, Oid object_oid)
 
 char actionName[12][12] = {"INSERT","SELECT","UPDATE", "DELETE",
     "TRUNCATE", "REFERENCES", "TRIGGER", "EXECUTE", "USAGE",
-    "CREATE", "CREATE_TEMP", "CONNECT"};
+    "CREATE", "TEMP", "CONNECT"};
 
 List *getActionName(AclMode mask)
 {


### PR DESCRIPTION
When we do ranger check of query "create temp table", we need to PASS privilege "TEMP" to RPS instead of "CREATE_TEMP". Or RPS can not recognise it.
