### PR TITLE
HAWQ-1324. Fixed crash at query cancel, signal hanler cannot call uns…

### DIFF
--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -3608,8 +3608,6 @@ ProcessInterrupts(void)
 
 	if (QueryCancelPending)
 	{
-		elog(LOG,"Process interrupt for 'query cancel pending'.");
-
 		QueryCancelPending = false;
 			ImmediateInterruptOK = false;	/* not idle anymore */
 			DisableNotifyInterrupt();


### PR DESCRIPTION
…afe elog()

1) The fix cannot completely fix this kinds of crash, it just reduce the possibility of this kind of crash. The complete fix is to move ProcessInterrupts() calling out of StatementCancelHandler().
2) The log can be removed because afterward in all 3 branches, hawq will print out similar message using ereport().

Thanks.