### PR TITLE
HAWQ-1328. Add deny and exclude policy template for hawq service in ranger

### DIFF
--- a/ranger-plugin/conf/ranger-servicedef-hawq.json
+++ b/ranger-plugin/conf/ranger-servicedef-hawq.json
@@ -4,6 +4,7 @@
   "label": "HAWQ",
   "description": "HAWQ",
   "guid": "1ebb27ee-549a-401d-85ab-818342ca54af",
+  "options": {"enableDenyAndExceptionsInPolicies": "true”},
   "resources":
   [
     {

--- a/ranger-plugin/conf/ranger-servicedef-hawq.json
+++ b/ranger-plugin/conf/ranger-servicedef-hawq.json
@@ -4,7 +4,7 @@
   "label": "HAWQ",
   "description": "HAWQ",
   "guid": "1ebb27ee-549a-401d-85ab-818342ca54af",
-  "options": {"enableDenyAndExceptionsInPolicies": "true”},
+  "options": {"enableDenyAndExceptionsInPolicies": "true"},
   "resources":
   [
     {


### PR DESCRIPTION
add option "enableDenyAndExceptionsInPolicies": "true" in ranger-servicedef-hawq.json to open deny and exclude policy template by default.