### PR TITLE
HAWQ-1336. Travis CI "brew" updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,27 +7,30 @@ compiler:
   - clang
 
 before_install:
+  - brew --version
   - "brew update 2>&1 > /tmp/brew-update.txt || (cat /tmp/brew-update.txt && false)"
+  - brew list --versions
 
 install:
-  - brew install
+  - brew reinstall
+    Gsasl
+    bison
+    ccache
+    cpanm
+    libevent
+    maven
+    openssl
     protobuf
     protobuf-c
-    Gsasl
-    openssl
-    thrift
-    ccache
+    python
     snappy
-    libevent
-    bison
-    cpanm
-    maven
-  - brew reinstall python
+    thrift
   - brew outdated libyaml || brew upgrade libyaml
-  - brew outdated json-c || brew upgrade json-c
-  - brew outdated boost || brew upgrade boost
-  - brew outdated maven || brew upgrade maven
+  - brew outdated json-c  || brew upgrade json-c
+  - brew outdated boost   || brew upgrade boost
+  - brew outdated maven   || brew upgrade maven
   - brew install iproute2mac
+  - brew list --versions
   - sudo pip install pycrypto
   - sudo cpanm install JSON
 


### PR DESCRIPTION
* Display installed brew components and version after brew update.
* Remove libevent installation.

I am not sure this will fix the Travis build issue.  This will give us insight to what components are installed in the base brew installation.