### PR TITLE
HAWQ-1338. Fixed writer process doesn't exit nicely in some case

### DIFF
--- a/src/backend/storage/ipc/ipc.c
+++ b/src/backend/storage/ipc/ipc.c
@@ -149,7 +149,7 @@ proc_exit_prepare(int code)
 	 * desirable bail-out, and whenever you should see this situation, you
 	 * should consider to resolve the actual programming error.
 	 */
-	if (CritSectionCount > 0)
+	if (CritSectionCount > 0 && !SuppressPanic)
 		elog(PANIC, "process is dying from critical section");
 
 	/*


### PR DESCRIPTION
(1) From the bt in the core file, it seems that SuppressPanic is true, we still report panic even at process exist function. We should suppress the panic if there is no side effect. 
(2) Now hawq stop utility stop standby after master stopped successfully or failed to stop with 10 minutes timeout, so it seems no need to change.