### PR TITLE
HAWQ-1345. Fixed relfile path bug: catalog and hdfs relfile have diff…

### DIFF
--- a/src/backend/access/appendonly/aomd.c
+++ b/src/backend/access/appendonly/aomd.c
@@ -101,12 +101,7 @@ FormatAOSegmentFileName(
 	
 	*fileSegNo = pseudoSegNo;
 
-	if (pseudoSegNo > 0)
-	{
-		sprintf(filepathname, "%s/%u", basepath, pseudoSegNo);
-	}
-	else
-		sprintf(filepathname, "%s", basepath);
+	sprintf(filepathname, "%s/%u", basepath, pseudoSegNo);
 }
 
 /*

--- a/src/backend/cdb/cdbmirroredbufferpool.c
+++ b/src/backend/cdb/cdbmirroredbufferpool.c
@@ -117,27 +117,18 @@ static void MirroredBufferPool_DoOpen(
 	open->create = create;
 	if (true)
 	{
-		char *dbPath;
 		char *path;
 
-		dbPath = (char*)palloc(MAXPGPATH + 1);
 		path = (char*)palloc(MAXPGPATH + 1);
 
 		/*
 		 * Do the primary work first so we don't leave files on the mirror or have an
 		 * open to clean up.
 		 */
-
-		FormDatabasePath(
-					dbPath,
-					filespaceLocation,
-					relFileNode->spcNode,
-					relFileNode->dbNode);
-		
-		if (segmentFileNum == 0)
-			sprintf(path, "%s/%u", dbPath, relFileNode->relNode);
-		else
-			sprintf(path, "%s/%u/%u", dbPath, relFileNode->relNode, segmentFileNum);
+		FormRelfilePath(path,
+						filespaceLocation,
+						relFileNode,
+						segmentFileNum);
 
 		errno = 0;
 		
@@ -148,7 +139,6 @@ static void MirroredBufferPool_DoOpen(
 			*primaryError = errno;
 		}
 
-		pfree(dbPath);
 		pfree(path);
 	}
 	
@@ -454,22 +444,14 @@ static void MirroredBufferPool_DoDrop(
 	
 	if (true)
 	{
-		char *dbPath; 
 		char *path;
 
-		dbPath = (char*)palloc(MAXPGPATH + 1);
 		path = (char*)palloc(MAXPGPATH + 1);
 
-		FormDatabasePath(
-						 dbPath,
-						 filespaceLocation,
-						 relFileNode->spcNode,
-						 relFileNode->dbNode);
-		
-		if (segmentFileNum == 0)
-			sprintf(path, "%s/%u", dbPath, relFileNode->relNode);
-		else
-			sprintf(path, "%s/%u/%u", dbPath, relFileNode->relNode, segmentFileNum);
+		FormRelfilePath(path,
+						filespaceLocation,
+						relFileNode,
+						segmentFileNum);
 
 		errno = 0;
 		
@@ -478,7 +460,6 @@ static void MirroredBufferPool_DoDrop(
 			*primaryError = errno;
 		}
 
-		pfree(dbPath);
 		pfree(path);
 	}
 	

--- a/src/include/catalog/catalog.h
+++ b/src/include/catalog/catalog.h
@@ -26,6 +26,7 @@ extern void CopyDatabasePath(char *target, int targetMaxLen, Oid dbNode, Oid spc
 extern void FormDatabasePath(char *databasePath, char *filespaceLocation, Oid tablespaceOid, Oid databaseOid);
 extern void FormTablespacePath(char *tablespacePath, char *filespaceLocation, Oid tablespaceOid);
 extern void FormRelationPath(char *relationPath, char *filespaceLocation, RelFileNode rnode);
+extern void FormRelfilePath(char *relfilePath, char *filespaceLocation, RelFileNode *rnode, int32 segmentFileNum);
 
 extern bool IsSystemRelation(Relation relation);
 extern bool IsToastRelation(Relation relation);


### PR DESCRIPTION
…erent rule

Add FormRelfilePath() to generate the rel file name which support not only catalog relfile but also relfile on hdfs, it can detect according :
- if is on hdfs (which has prefix "hdfs://"), the rel file rule is(relation_oid as directory):  relation_oid/seg_num  .
- if is on local disk, the rel file rule is (relation_oid as file name):  relation_oid.seg_num or relation_oid (when seg_num==0)