### PR TITLE
HAWQ-1357. Super user also need to check create privilege of public schema from Ranger.

### DIFF
--- a/src/include/utils/acl.h
+++ b/src/include/utils/acl.h
@@ -316,7 +316,7 @@ extern List *pg_rangercheck_batch(List *);
 extern AclResult
 pg_rangercheck(AclObjectKind objkind, Oid table_oid, Oid roleid,
          AclMode mask, AclMaskHow how);
-extern bool fallBackToNativeCheck(AclObjectKind objkind, Oid table_oid, Oid roleid);
+extern bool fallBackToNativeCheck(AclObjectKind objkind, Oid table_oid, Oid roleid, AclMode mode);
 extern bool fallBackToNativeChecks(AclObjectKind objkind, List* table_list, Oid roleid);
 extern char *getNameFromOid(AclObjectKind objkind, Oid object_oid);
 extern char *getClassNameFromOid(Oid object_oid);


### PR DESCRIPTION
HAWQ-1318 add create|usage privilege of public schema to superuser to fix hawq stop BUG caused by Resource Manager. 
But RM only need the usage privilege of public schema to query HAWQ, So create privilege need to be removed.