### PR TITLE
HAWQ-1358. Refactor gpfdist library in featuretest.

### DIFF
--- a/src/test/feature/ExternalSource/test_errortbl.cpp
+++ b/src/test/feature/ExternalSource/test_errortbl.cpp
@@ -20,6 +20,7 @@
 
 #include "lib/sql_util.h"
 #include "lib/string_util.h"
+#include "lib/gpfdist.h"
 
 using hawq::test::SQLUtility;
 
@@ -32,48 +33,10 @@ class TestErrorTable : public ::testing::Test {
 TEST_F(TestErrorTable, TestErrorTableAll) {
   
   SQLUtility util;
-  auto init_gpfdist = [&] () {
-    auto sql = "CREATE EXTERNAL WEB TABLE gpfdist_status (x text) "
-        "execute E'( python %s/bin/lib/gppinggpfdist.py localhost:7070 2>&1 || echo) ' "
-        "on SEGMENT 0 "
-        "FORMAT 'text' (delimiter '|');";
-    auto GPHOME = getenv("GPHOME");
-    util.execute(hawq::test::stringFormat(sql, GPHOME));
 
-    sql = "CREATE EXTERNAL WEB TABLE gpfdist_start (x text) "
-        "execute E'((%s/bin/gpfdist -p 7070 -d %s  </dev/null >/dev/null 2>&1 &); sleep 2; echo \"starting\"...) ' "
-        "on SEGMENT 0 "
-        "FORMAT 'text' (delimiter '|');";
-    std::string path = util.getTestRootPath() + "/ExternalSource/data";
-    util.execute(hawq::test::stringFormat(sql, GPHOME, path.c_str()));
-  
-    util.execute(
-        "CREATE EXTERNAL WEB TABLE gpfdist_stop (x text) "
-        "execute E'(/bin/pkill gpfdist || killall gpfdist) > /dev/null 2>&1; echo stopping...' "
-        "on SEGMENT 0 "
-        "FORMAT 'text' (delimiter '|');");
-    util.execute("select * from gpfdist_stop;");
-    util.execute("select * from gpfdist_status;");
-    util.execute("select * from gpfdist_start;");
-    util.execute("select * from gpfdist_status;");
-  };
+  hawq::test::GPfdist gpdfist(&util);
 
-  auto finalize_gpfdist = [&] () {
-    util.execute("drop external table EXT_NATION_WITH_EXIST_ERROR_TABLE;");
-    util.execute("drop external table EXT_NATION1;");
-    util.execute("drop table EXT_NATION_ERROR1 CASCADE;");
-    util.execute("drop external table EXT_NATION2;");
-    util.execute("drop table EXT_NATION_ERROR2 CASCADE;");
-    util.execute("drop external table EXT_NATION3;");
-    util.execute("drop table EXT_NATION_ERROR3 CASCADE;");
-    util.execute("select * from gpfdist_stop;");
-    util.execute("select * from gpfdist_status;");
-    util.execute("drop external table gpfdist_status;");
-    util.execute("drop external table gpfdist_start;");
-    util.execute("drop external table gpfdist_stop;");
-  };
-
-  init_gpfdist();
+  gpdfist.init_gpfdist();
   
   // readable external table with error table
   util.execute(
@@ -139,5 +102,5 @@ TEST_F(TestErrorTable, TestErrorTableAll) {
       "LOG ERRORS INTO EXT_NATION_ERROR_WRITABLE SEGMENT REJECT LIMIT 5;",
       false);
 
-  finalize_gpfdist();
+  gpdfist.finalize_gpfdist();
 }

--- a/src/test/feature/lib/gpfdist.cpp
+++ b/src/test/feature/lib/gpfdist.cpp
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <fstream>
+#include "gpfdist.h"
+
+using std::string;
+
+namespace hawq {
+namespace test {
+void GPfdist::init_gpfdist() {
+	auto sql =
+			"CREATE EXTERNAL WEB TABLE gpfdist_status (x text) "
+					"execute E'( python %s/bin/lib/gppinggpfdist.py localhost:7070 2>&1 || echo) ' "
+					"on SEGMENT 0 "
+					"FORMAT 'text' (delimiter '|');";
+	auto GPHOME = getenv("GPHOME");
+	util->execute(hawq::test::stringFormat(sql, GPHOME));
+
+	sql =
+			"CREATE EXTERNAL WEB TABLE gpfdist_start (x text) "
+					"execute E'((%s/bin/gpfdist -p 7070 -d %s  </dev/null >/dev/null 2>&1 &); sleep 2; echo \"starting\"...) ' "
+					"on SEGMENT 0 "
+					"FORMAT 'text' (delimiter '|');";
+	std::string path = util->getTestRootPath() + "/ExternalSource/data";
+	util->execute(hawq::test::stringFormat(sql, GPHOME, path.c_str()));
+
+	util->execute(
+			"CREATE EXTERNAL WEB TABLE gpfdist_stop (x text) "
+					"execute E'(/bin/pkill gpfdist || killall gpfdist) > /dev/null 2>&1; echo stopping...' "
+					"on SEGMENT 0 "
+					"FORMAT 'text' (delimiter '|');");
+	util->execute("select * from gpfdist_stop;");
+	util->execute("select * from gpfdist_status;");
+	util->execute("select * from gpfdist_start;");
+	util->execute("select * from gpfdist_status;");
+}
+
+void GPfdist::finalize_gpfdist() {
+	util->execute("drop external table EXT_NATION_WITH_EXIST_ERROR_TABLE;");
+	util->execute("drop external table EXT_NATION1;");
+	util->execute("drop table EXT_NATION_ERROR1 CASCADE;");
+	util->execute("drop external table EXT_NATION2;");
+	util->execute("drop table EXT_NATION_ERROR2 CASCADE;");
+	util->execute("drop external table EXT_NATION3;");
+	util->execute("drop table EXT_NATION_ERROR3 CASCADE;");
+	util->execute("select * from gpfdist_stop;");
+	util->execute("select * from gpfdist_status;");
+	util->execute("drop external table gpfdist_status;");
+	util->execute("drop external table gpfdist_start;");
+	util->execute("drop external table gpfdist_stop;");
+
+}
+
+} // namespace test
+} // namespace hawq

--- a/src/test/feature/lib/gpfdist.h
+++ b/src/test/feature/lib/gpfdist.h
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef HAWQ_SRC_TEST_FEATURE_LIB_GPFDIST_H_
+#define HAWQ_SRC_TEST_FEATURE_LIB_GPFDIST_H_
+
+#include <string>
+
+#include "lib/sql_util.h"
+#include "lib/string_util.h"
+
+namespace hawq {
+namespace test {
+
+/**
+ *  Gpfdist common library.
+ * 	start gpfdist server and stop gpfdist server.
+ */
+class GPfdist {
+public:
+	explicit GPfdist(hawq::test::SQLUtility *sqlUtil_) : util(sqlUtil_) {}
+
+	~GPfdist() {}
+
+	void init_gpfdist();
+
+	void finalize_gpfdist();
+private:
+	hawq::test::SQLUtility *util = nullptr;
+};
+
+} // namespace test
+} // namespace hawq
+
+#endif


### PR DESCRIPTION
extract gpfdist code(which exists in exttable test case) as a common library, to be used by both exttable and ranger feature test.
Main functions: 
gpfdist_init: to setup gpfdist environment and start server.
gpfdist_finalize: to stop gpfdist server.