### PR TITLE
Hawq 1365. Print out detailed schema information for tables which the user doesn't have privileges

### DIFF
--- a/src/backend/catalog/namespace.c
+++ b/src/backend/catalog/namespace.c
@@ -1982,6 +1982,13 @@ recomputeNamespacePath(void)
 			elog(DEBUG3, "recompute search_path[%s] when acl_type is ranger", namespace_search_path);
 		}
 	}
+	else 
+	{
+		if (debug_query_string != NULL)
+		{
+			last_query_sign = string_hash(debug_query_string, strlen(debug_query_string));
+		}
+	}
 
 	/* Need a modifiable copy of namespace_search_path string */
 	rawname = pstrdup(namespace_search_path);
@@ -2118,11 +2125,6 @@ recomputeNamespacePath(void)
 	/* Mark the path valid. */
 	namespaceSearchPathValid = true;
 	namespaceUser = roleid;
-
-	if (debug_query_string != NULL)
-	{
-		last_query_sign = string_hash(debug_query_string, strlen(debug_query_string));
-	}
 
 	/* Clean up. */
 	pfree(rawname);

--- a/src/backend/catalog/namespace.c
+++ b/src/backend/catalog/namespace.c
@@ -1984,7 +1984,7 @@ recomputeNamespacePath(void)
 	}
 	else 
 	{
-		if (debug_query_string != NULL)
+		if (aclType == HAWQ_ACL_RANGER && debug_query_string != NULL)
 		{
 			last_query_sign = string_hash(debug_query_string, strlen(debug_query_string));
 		}

--- a/src/backend/parser/parse_relation.c
+++ b/src/backend/parser/parse_relation.c
@@ -2800,7 +2800,8 @@ ExecCheckRTPermsWithRanger(List *rangeTable)
 			/* collect all acl fail relations */
 			Oid relOid = result_ptr->relOid;
 			const char *rel_name = get_rel_name_partition(relOid);
-			appendStringInfo(&acl_fail_msg, "%s", rel_name);
+			const char *namespace_name = get_namespace_name(get_rel_namespace(relOid));
+			appendStringInfo(&acl_fail_msg, "%s.%s", namespace_name, rel_name);
 		}
 	}
 

--- a/src/test/feature/ManagementTool/test_hawq_register_usage1.cpp
+++ b/src/test/feature/ManagementTool/test_hawq_register_usage1.cpp
@@ -445,15 +445,15 @@ TEST_F(TestHawqRegister, TestUsage1EofFailure) {
 
 TEST_F(TestHawqRegister, TestUsage1FolderFailure) {
     SQLUtility util;
-    string folderName = "usage1tmp";
-    string folderNameNotExist = "usage1tmpNotExist";
+    string folderName = "usage1_folder_tmp";
+    string folderNameNotExist = "usage1_folder_tmpNotExist";
     string rootPath(util.getTestRootPath());
     string relativePath("/ManagementTool/test_hawq_register_hawq.paq");
     string filePath = rootPath + relativePath;
     string relativePath2("/ManagementTool/files_incomplete.yml");
     string filePath2 = rootPath + relativePath2;
 
-    auto cmd = hawq::test::stringFormat("hdfs dfs -mkdir %s/usage1tmp", getHdfsLocation().c_str(), "");
+    auto cmd = hawq::test::stringFormat("hdfs dfs -mkdir %s/%s", getHdfsLocation().c_str(), folderName.c_str());
     EXPECT_EQ(0, Command::getCommandStatus(cmd));
 
     util.execute("create table hawqregister(i int) with (appendonly=true, orientation=parquet);");


### PR DESCRIPTION
1. Print out detailed schema information for tables which the user doesn't have privileges.
2. Fixed duplicate tmp_folder name of TestUsage1FolderFailure of register test.
3. Refine the _last_query_sign_ logic of HAWQ-1355.

Detailed output information after modified is here:
https://issues.apache.org/jira/browse/HAWQ-1365