### PR TITLE
HAWQ-1370. Misuse of regular expressions in init_file of feature test.

### DIFF
--- a/src/test/feature/lib/global_init_file
+++ b/src/test/feature/lib/global_init_file
@@ -14,6 +14,6 @@
 # limitations under the License.
 #mask code line numbers
 -- start_matchsubs
-m/\(.*c[p]+:\d+\)/
-s/\(.*c[p]+:\d+\)/(file_and_line)/
+m/\(.*c[p]*:\d+\)/
+s/\(.*c[p]*:\d+\)/(file_and_line)/
 -- end_matchsubs


### PR DESCRIPTION
in global_init_file of feature test, we want to skip expressions which include file and line number, e.g.(aclchk.c:123), or (aclchk.cpp:134).
But currently, the regular expressions is `(.*c[p]+:\d+) `which need to be replaced by `(.*c[p]*:\d+) `
