### PR TITLE
HAWQ-1387. Add support for CentOS/RHEL 7 in HAWQ Ambari plugin.

### DIFF
--- a/contrib/hawq-ambari-plugin/src/main/resources/utils/add-hawq.py
+++ b/contrib/hawq-ambari-plugin/src/main/resources/utils/add-hawq.py
@@ -30,7 +30,7 @@ from optparse import OptionParser
 
 PLUGIN_VERSION = '${release}'
 DEFAULT_STACK = '${default.stack}'
-SUPPORTED_OS_LIST = ['redhat6']
+SUPPORTED_OS_LIST = ['redhat6', 'redhat7']
 HAWQ_LIB_STAGING_DIR = '${hawq.lib.staging.dir}'
 REPO_VERSION = '${repository.version}'
 HAWQ_REPO = '${hawq.repo.prefix}'


### PR DESCRIPTION
The HAWQ Ambari is only registering systems running CentOS/RHEL 6 platforms. We have identified this minor fix which will register CentOS/RHEL 7 systems as well.