### PR TITLE
HAWQ-1397. Support Flex versions 2.6 and above.

### DIFF
--- a/config/programs.m4
+++ b/config/programs.m4
@@ -69,7 +69,7 @@ else
         echo '%%'  > conftest.l
         if $pgac_candidate -t conftest.l 2>/dev/null | grep FLEX_SCANNER >/dev/null 2>&1; then
           pgac_flex_version=`$pgac_candidate --version 2>/dev/null`
-          if echo "$pgac_flex_version" | sed ['s/[^0-9]/ /g'] | $AWK '{ if ([$]1 = 2 && [$]2 = 5 && [$]3 >= 4) exit 0; else exit 1;}'
+          if echo "$pgac_flex_version" | sed ['s/[.a-z]/ /g'] | $AWK '{ if ([$]1 == 2 && ([$]2 > 5 || ([$]2 == 5 && [$]3 >= 4))) exit 0; else exit 1;}'
           then
             pgac_cv_path_flex=$pgac_candidate
             break 2

--- a/config/tomcat.m4
+++ b/config/tomcat.m4
@@ -13,6 +13,8 @@ AC_DEFUN([PGAC_CATALINA_HOME],
   dnl /usr/lib/bigtop-tomcat
   if test -x "${CATALINA_HOME}/bin/catalina.sh"; then
     TOMCAT="${CATALINA_HOME}"
+  elif test -x "/usr/local/Cellar/tomcat@6/6.0.45/libexec/bin/catalina.sh"; then
+    TOMCAT="/usr/local/Cellar/tomcat@6/6.0.45/libexec/"
   elif test -x "/usr/lib/bigtop-tomcat/bin/catalina.sh"; then
     TOMCAT="/usr/lib/bigtop-tomcat/"
   else

--- a/configure
+++ b/configure
@@ -7488,7 +7488,7 @@ else
         echo '%%'  > conftest.l
         if $pgac_candidate -t conftest.l 2>/dev/null | grep FLEX_SCANNER >/dev/null 2>&1; then
           pgac_flex_version=`$pgac_candidate --version 2>/dev/null`
-          if echo "$pgac_flex_version" | sed 's/[^0-9]/ /g' | $AWK '{ if ($1 = 2 && $2 = 5 && $3 >= 4) exit 0; else exit 1;}'
+          if echo "$pgac_flex_version" | sed 's/[.a-z]/ /g' | $AWK '{ if ($1 == 2 && ($2 > 5 || ($2 == 5 && $3 >= 4))) exit 0; else exit 1;}'
           then
             pgac_cv_path_flex=$pgac_candidate
             break 2


### PR DESCRIPTION
* The FLEX configure snippet came from Postgres upstream in the form
  of two commits (see below).
* Misc change: commit tomcat version check for Mac OSX platform using
  brew. This change was out of sync with generated "configure" script.

commit 7d7b129277eb545286aecf29ec22b5bb7fdf46bd
Author: Tom Lane <tgl@sss.pgh.pa.us>
Date:   Mon May 2 11:18:10 2016 -0400

    Fix configure's incorrect version tests for flex and perl.

    awk's equality-comparison operator is "==" not "=".  We got this right
    in many places, but not in configure's checks for supported version
    numbers of flex and perl.  It hadn't been noticed because unsupported
    versions are so old as to be basically extinct in the wild, and because
    the only consequence is whether or not a WARNING flies by during
    configure.

    Daniel Gustafsson noted the problem with respect to the test for flex,
    I found the other by reviewing other awk calls.

commit 32f15d05c80044335f97347b5406f6736c06a033
Author: Tom Lane <tgl@sss.pgh.pa.us>
Date:   Wed Nov 18 17:45:05 2015 -0500

    Accept flex > 2.5.x in configure.

    Per buildfarm member anchovy, 2.6.0 exists in the wild now.
    Hopefully it works with Postgres; if not, we'll have to do something
    about that, but in any case claiming it's "too old" is pretty silly.

reviewers: @ictmalili @radarwave @paul-guo- 