### PR TITLE
HAWQ-326. Support RPM package for Apache HAWQ.

### DIFF
--- a/GNUmakefile.in
+++ b/GNUmakefile.in
@@ -45,6 +45,12 @@ distprep:
 	$(MAKE) -C config $@
 	$(MAKE) -C contrib $@
 
+rpm:
+	$(MAKE) -C contrib/hawq-package $@
+	$(MAKE) -C pxf $@
+	$(MAKE) -C ranger-plugin $@
+	$(MAKE) -C contrib/hawq-package rpm-tarball
+
 feature-test:
 	$(MAKE) -C src feature-test
 
@@ -63,6 +69,8 @@ clean:
 	$(MAKE) -C config $@
 	$(MAKE) -C contrib $@
 	$(MAKE) -C tools $@
+	$(MAKE) -C contrib/hawq-package $@
+	$(MAKE) -C pxf $@
 	$(MAKE) -C ranger-plugin $@
 	-$(MAKE) -C src feature-test-clean
 # Garbage from autoconf:

--- a/contrib/hawq-package/Makefile
+++ b/contrib/hawq-package/Makefile
@@ -1,0 +1,38 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------------------
+#
+# Makefile for the rpm package
+#
+#-------------------------------------------------------------------------
+
+subdir = contrib/hawq-package
+top_builddir = ../..
+
+all: rpm
+
+rpm:
+	@HAWQ_RELEASE_VERSION=$(HAWQ_RELEASE_VERSION) BUILD_MODE=$(BUILD_MODE) BUILD_NUMBER=$(BUILD_NUMBER) $(top_builddir)/$(subdir)/build_hawq_rpm.sh $@
+
+rpm-tarball:
+	@$(top_builddir)/$(subdir)/make_rpm_tarball.sh
+
+clean:
+	@rm -rf rpmbuild hawq_rpm_packages
+
+distclean: clean

--- a/contrib/hawq-package/README
+++ b/contrib/hawq-package/README
@@ -1,0 +1,36 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+Build HAWQ rpm package tarball steps:
+
+1. Prepare a HAWQ source code tarball for rpm building.
+   a) Make sure the source code tarball name format is: 
+      apache-hawq-src-%{hawq_version}-incubating.tar.gz
+   b) Make sure the extracted directory name format is:
+      apache-hawq-src-%{hawq_version}-incubating
+   c) Put the HAWQ source tarball to %{top_dir}/contrib/hawq-package folder.
+
+3. Install build dependencies of HAWQ, following instruction at:
+   https://cwiki.apache.org/confluence/display/HAWQ/Build+and+Install 
+
+4. Run 'make distclean' and './configure'.
+
+5. Run 'make rpm' in the top directory of the source code.
+
+6. You can find HAWQ/PXF/Ranger-plugin rpms tarball as:
+   %{top_dir}/contrib/hawq-package/apache-hawq-rpm-%{hawq_version}-incubating.tar.gz 

--- a/contrib/hawq-package/README
+++ b/contrib/hawq-package/README
@@ -24,13 +24,15 @@ Build HAWQ rpm package tarball steps:
    b) Make sure the extracted directory name format is:
       apache-hawq-src-%{hawq_version}-incubating
    c) Put the HAWQ source tarball to %{top_dir}/contrib/hawq-package folder.
+      Or use "HAWQ_SOURCE_TARBALL_PATH" to specify the find path of HAWQ source tarball.
 
-3. Install build dependencies of HAWQ, following instruction at:
+2. Install build dependencies of HAWQ, following instruction at:
    https://cwiki.apache.org/confluence/display/HAWQ/Build+and+Install 
 
-4. Run 'make distclean' and './configure'.
+3. Run 'make distclean' and './configure'.
 
-5. Run 'make rpm' in the top directory of the source code.
+4. Run 'make rpm' in the top directory of the source code.
+   You can set environment variable "HAWQ_RELEASE_VERSION" to specify HAWQ version.
 
-6. You can find HAWQ/PXF/Ranger-plugin rpms tarball as:
+5. You can find HAWQ/PXF/Ranger-plugin rpms tarball as:
    %{top_dir}/contrib/hawq-package/apache-hawq-rpm-%{hawq_version}-incubating.tar.gz 

--- a/contrib/hawq-package/build_hawq_rpm.sh
+++ b/contrib/hawq-package/build_hawq_rpm.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+CUR_DIR=$(pwd)
+
+if [ -f /etc/redhat-release ] ; then
+    DISTRO_VERSION=$(cat /etc/redhat-release | sed s/.*release\ // | sed s/\ .*//)
+    DISTRO_MAJOR_VERSION=$(echo ${DISTRO_VERSION} | awk -F '.' '{print $1}')
+    OS_TYPE="el${DISTRO_MAJOR_VERSION}"
+elif [ -f /etc/SuSE-release ] ; then
+    DISTRO_VERSION=$(cat /etc/SuSE-release | tr "\n" ' ' | sed s/.*=\ //)
+    DISTRO_MAJOR_VERSION=$(echo ${DISTRO_VERSION} |awk -F '.' '{print $1}')
+    OS_TYPE="suse${DISTRO_MAJOR_VERSION}"
+fi
+
+HAWQ_RELEASE_VERSION=$(cat ../../getversion| grep ^GP_VERSION | cut -d '=' -f2 | sed 's|"||g' | cut -d '-' -f1)
+
+echo "HAWQ_RELEASE_VERSION is $HAWQ_RELEASE_VERSION"
+
+if [ -d  rpmbuild ]; then
+    echo "Clean rpmbuild directory."
+    rm -rf rpmbuild
+fi
+
+echo "Make directories: rpmbuild/BUILD rpmbuild/RPMS rpmbuild/SOURCES rpmbuild/SPECS rpmbuild/SRPMS"
+mkdir -p rpmbuild/BUILD rpmbuild/RPMS rpmbuild/SOURCES rpmbuild/SPECS rpmbuild/SRPMS
+
+# Copy HAWQ RPM configuration file for the build
+cp hawq.spec rpmbuild/SPECS/
+
+HAWQ_SOURCE_TARBALL_FILE=apache-hawq-src-${HAWQ_RELEASE_VERSION}-incubating.tar.gz
+
+# Get PATH where to find HAWQ source code tarball
+if [ -z ${HAWQ_SOURCE_TARBALL_PATH} ]; then
+    HAWQ_SOURCE_TARBALL_PATH=${CUR_DIR}
+fi
+
+# Copy HAWQ source code tarball for rpm build
+if [ -f "${HAWQ_SOURCE_TARBALL_PATH}/${HAWQ_SOURCE_TARBALL_FILE}" ]; then
+    cp ${HAWQ_SOURCE_TARBALL_PATH}/${HAWQ_SOURCE_TARBALL_FILE} rpmbuild/SOURCES/
+else
+    echo "Can not find ${HAWQ_SOURCE_TARBALL_PATH}/${HAWQ_SOURCE_TARBALL_FILE} "
+    exit 1
+fi
+
+pushd rpmbuild > /dev/null
+RPM_TOP_DIR=$(pwd)
+
+echo 'rpmbuild --define "_topdir ${RPM_TOP_DIR}" \
+               --define "_hawq_version ${HAWQ_RELEASE_VERSION}" \
+               --define "_rpm_os_version ${OS_TYPE}" \
+               -bb SPECS/hawq.spec'
+rpmbuild --define "_topdir ${RPM_TOP_DIR}" \
+         --define "_hawq_version ${HAWQ_RELEASE_VERSION}" \
+         --define "_rpm_os_version ${OS_TYPE}" \
+         -bb SPECS/hawq.spec
+if [ $? != 0 ]; then
+    echo "Build HAWQ rpm package failed, exit..."
+    exit 0
+fi
+
+popd > /dev/null

--- a/contrib/hawq-package/build_hawq_rpm.sh
+++ b/contrib/hawq-package/build_hawq_rpm.sh
@@ -28,7 +28,9 @@ elif [ -f /etc/SuSE-release ] ; then
     OS_TYPE="suse${DISTRO_MAJOR_VERSION}"
 fi
 
-HAWQ_RELEASE_VERSION=$(cat ../../getversion| grep ^GP_VERSION | cut -d '=' -f2 | sed 's|"||g' | cut -d '-' -f1)
+if [ -z "${HAWQ_RELEASE_VERSION}" ]; then
+    HAWQ_RELEASE_VERSION=$(cat ../../getversion| grep ^GP_VERSION | cut -d '=' -f2 | sed 's|"||g' | cut -d '-' -f1)
+fi
 
 echo "HAWQ_RELEASE_VERSION is $HAWQ_RELEASE_VERSION"
 
@@ -61,10 +63,8 @@ fi
 pushd rpmbuild > /dev/null
 RPM_TOP_DIR=$(pwd)
 
-echo 'rpmbuild --define "_topdir ${RPM_TOP_DIR}" \
-               --define "_hawq_version ${HAWQ_RELEASE_VERSION}" \
-               --define "_rpm_os_version ${OS_TYPE}" \
-               -bb SPECS/hawq.spec'
+set -x
+
 rpmbuild --define "_topdir ${RPM_TOP_DIR}" \
          --define "_hawq_version ${HAWQ_RELEASE_VERSION}" \
          --define "_rpm_os_version ${OS_TYPE}" \
@@ -74,4 +74,5 @@ if [ $? != 0 ]; then
     exit 0
 fi
 
+set +x
 popd > /dev/null

--- a/contrib/hawq-package/hawq.spec
+++ b/contrib/hawq-package/hawq.spec
@@ -1,0 +1,98 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+%global    _enable_debug_package  0
+%global    debug_package          %{nil}
+%global    __os_install_post      /usr/lib/rpm/brp-compress %{nil}
+%define    hawq_version           %{_hawq_version}
+%define    rpm_os_version         %{_rpm_os_version}
+%define    arch                   x86_64
+%define    installdir             /usr/local/%{name}
+
+Name:       apache-hawq
+Summary:    Hadoop Native SQL powered by Apache HAWQ (incubating)
+Version:    %{hawq_version}
+Release:    %{rpm_os_version}
+License:    ASL 2.0
+Group:      Applications/Databases
+URL:        http://hawq.incubator.apache.org
+Prefix:     /usr/local
+BuildArch:  %{arch}
+SOURCE0 :   apache-hawq-src-%{hawq_version}-incubating.tar.gz
+Requires:   libgsasl, krb5-libs, libicu, protobuf >= 2.5.0, json-c >= 0.9, net-snmp-libs, thrift >= 0.9.1, boost >= 1.53.0
+%if %{rpm_os_version} == el6
+Requires: openssl
+%else
+Requires: openssl-libs
+%endif
+Requires(pre): shadow-utils
+
+AutoReqProv:    no
+
+%description
+Apache HAWQ (incubating) combines exceptional MPP-based analytics
+performance, robust ANSI SQL compliance, Hadoop ecosystem
+integration and manageability, and flexible data-store format
+support, all natively in Hadoop, no connectors required.
+
+Built from a decade’s worth of massively parallel
+processing (MPP) expertise developed through the creation of open
+source Greenplum® Database and PostgreSQL, HAWQ enables you to
+swiftly and interactively query Hadoop data, natively via HDFS.
+
+%prep
+%setup -n %{name}-src-%{version}-incubating
+
+%build
+export CFLAGS="-O3 -g"
+export CXXFLAGS="-O3 -g"
+./configure --prefix=%{installdir} --with-pgport=5432 --with-libedit-preferred --enable-snmp \
+            --with-perl --with-python --with-java --with-openssl --with-pam --without-krb5 \
+            --with-gssapi --with-ldap --with-pgcrypto --enable-orca
+core_count=$(grep -c 'core id' /proc/cpuinfo)
+make -j"${core_count}"
+
+%install
+export DONT_STRIP=1
+rm -rf %{buildroot}
+make install DESTDIR="%{buildroot}"
+# The buildroot directory should not exist in the binary file
+sed -i "s|%{buildroot}||g" %{buildroot}%{installdir}/lib/python/pygresql/_pg.so
+
+%pre
+# Add the default "gpadmin" user and group if it does not exist
+getent group  gpadmin >/dev/null || groupadd -r gpadmin
+getent passwd gpadmin >/dev/null || useradd -m -r -g gpadmin -c "Apache HAWQ account" gpadmin
+exit 0
+
+%post
+INSTDIR=$RPM_INSTALL_PREFIX0/%{name}
+# Update GPHOME in greenplum_path.sh
+sed "s|^GPHOME=.*|GPHOME=${INSTDIR}|g" -i ${INSTDIR}/greenplum_path.sh
+
+%postun
+
+%clean
+rm -rf %{buildroot}
+
+%files
+%defattr(-, gpadmin, gpadmin, 0755)
+%{installdir}
+%config(noreplace) %{installdir}/etc/hawq-site.xml
+%config(noreplace) %{installdir}/etc/hdfs-client.xml
+%config(noreplace) %{installdir}/etc/yarn-client.xml

--- a/contrib/hawq-package/make_rpm_tarball.sh
+++ b/contrib/hawq-package/make_rpm_tarball.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+CUR_DIR=$(pwd)
+SRC_TOP_DIR=../..
+
+HAWQ_RELEASE_VERSION=$(cat ../../getversion| grep ^GP_VERSION | cut -d '=' -f2 | sed 's|"||g' | cut -d '-' -f1)
+
+RPM_PKG_DIR=${CUR_DIR}/hawq_rpm_packages
+if [ -d ${RPM_PKG_DIR} ]; then
+    rm -rf ${RPM_PKG_DIR}
+fi
+
+mkdir -p ${RPM_PKG_DIR}
+if [ $? != 0 ]; then
+    echo "Create HAWQ rpm package directory: ${RPM_PKG_DIR} failed."
+    exit 1
+fi
+
+echo "Copying HAWQ rpm packages into directory: ${RPM_PKG_DIR}"
+
+# Copy hawq rpm packages
+cp ${SRC_TOP_DIR}/contrib/hawq-package/rpmbuild/RPMS/x86_64/apache-hawq-${HAWQ_RELEASE_VERSION}*.rpm ${RPM_PKG_DIR}/
+if [ $? != 0 ]; then
+    echo "Copy HAWQ rpm package failed."
+    exit 1
+fi
+
+# Copy apache tomcat rpm package for PXF
+cp ${SRC_TOP_DIR}/pxf/distributions/apache-tomcat*.rpm ${RPM_PKG_DIR}/
+if [ $? != 0 ]; then
+    echo "Copy Tomcat rpm package failed."
+    exit 1
+fi
+
+# Copy PXF rpm packages
+cp ${SRC_TOP_DIR}/pxf/build/distributions/pxf*.rpm ${RPM_PKG_DIR}/
+if [ $? != 0 ]; then
+    echo "Copy PXF rpm packages failed."
+    exit 1
+fi
+
+# Copy HAWQ Ranger rpm package
+cp ${SRC_TOP_DIR}/ranger-plugin/target/rpm/hawq-ranger-plugin_*/RPMS/noarch/hawq-ranger-plugin*.rpm ${RPM_PKG_DIR}/
+if [ $? != 0 ]; then
+    echo "Copy HAWQ Ranger plugin rpm package failed."
+    exit 1
+fi
+
+echo "Copied all the HAWQ/PXF/Range-plugin rpm packages."
+
+ls ${RPM_PKG_DIR}/
+
+# Make tarball for all the HAWQ/PXF/RANGER rpms
+tar czvf apache-hawq-rpm-${HAWQ_RELEASE_VERSION}-incubating.tar.gz  hawq_rpm_packages
+if [ $? != 0 ]; then
+    echo "Make HAWQ/PXF/Ranger-plugin rpm tarball failed."
+    exit 1
+else
+    echo "Make HAWQ/PXF/Ranger-plugin rpm tarball successful."
+fi
+
+ls -l apache-hawq-rpm-${HAWQ_RELEASE_VERSION}-incubating.tar.gz
+
+exit 0

--- a/pxf/Makefile
+++ b/pxf/Makefile
@@ -68,7 +68,7 @@ jar:
 tar:
 	./gradlew tar $(BUILD_PARAMS)
 
-rpm:
+rpm: tomcat
 	./gradlew rpm $(BUILD_PARAMS)
 	
 clean:

--- a/ranger-plugin/Makefile
+++ b/ranger-plugin/Makefile
@@ -25,6 +25,10 @@ MVN_OPTS="-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenT
 #
 .PHONY: all install distclean clean uninstall
 
+rpm:
+	@echo "Build rpm package for HAWQ ranger-plugin."
+	./scripts/build_ranger_rpm.sh
+
 ifeq ($(enable_rps), yes)
 
 all:
@@ -59,5 +63,10 @@ distclean: clean
 else
 
 all install distclean clean uninstall:
+
+clean:
+	rm -rf target/rpm/*
+
+distclean: clean
 
 endif

--- a/ranger-plugin/scripts/build_ranger_rpm.sh
+++ b/ranger-plugin/scripts/build_ranger_rpm.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+MVN_OPTS="-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -B -e"
+
+# Set HAWQ ranger-plugin rpm build number to 1 as default
+BUILD_NUMBER=1
+
+# Get current HAWQ releave version number.
+if [  -z "${HAWQ_RELEASE_VERSION}" ]; then
+    HAWQ_RELEASE_VERSION=$(cat ../getversion| grep ^GP_VERSION | cut -d '=' -f2 | sed 's|"||g' | cut -d '-' -f1)
+fi
+
+# Set HAWQ ranger-plugin.
+mvn ${MVN_OPTS} versions:set -DnewVersion=${HAWQ_RELEASE_VERSION}
+if [ $? != 0 ]; then
+    echo "Set HAWQ ranger-plugin failed."
+    exit 1
+fi
+
+# generate jar and war files.
+mvn ${MVN_OPTS} clean package
+if [ $? != 0 ]; then
+    echo "Generate HAWQ ranger-plugin jar and war files failed."
+    exit 1
+fi
+
+# build rpm
+mvn ${MVN_OPTS} -N -Drelease.version=${BUILD_NUMBER} install
+if [ $? != 0 ]; then
+    echo "Build HAWQ ranger-plugin rpm package failed."
+    exit 1
+fi
+
+exit 0

--- a/src/pl/pljava/Makefile
+++ b/src/pl/pljava/Makefile
@@ -58,16 +58,16 @@ MACHINE := $(shell uname -m)
 all: pljava_all deploy_all c_all examples_all
 
 install: all c_install
-	$(mkinstalldirs) '$(datadir)/pljava'
-	$(mkinstalldirs) '$(pkglibdir)/java'
-	$(INSTALL_DATA) '$(TARGETDIR)/pljava.jar' '$(pkglibdir)/.'
-	$(INSTALL_DATA) '$(SQLDIR)/install.sql' '$(datadir)/pljava/.'
-	$(INSTALL_DATA) '$(SQLDIR)/uninstall.sql' '$(datadir)/pljava/.'
-	$(INSTALL_DATA) '$(SQLDIR)/examples.sql' '$(datadir)/pljava/.'
-	$(INSTALL_SCRIPT) '$(SQLDIR)/pljava_install.sh' '$(datadir)/pljava/.'
-	$(INSTALL_DATA) '$(TARGETDIR)/examples.jar' '$(datadir)/pljava/.'
-	$(INSTALL_DATA) '$(TARGETDIR)/examples.jar' '$(pkglibdir)/java/.'
-	$(INSTALL_DATA) '$(top_srcdir)/$(subdir)/COPYRIGHT' '$(datadir)/pljava/.'
+	$(mkinstalldirs) '$(DESTDIR)$(datadir)/pljava'
+	$(mkinstalldirs) '$(DESTDIR)$(pkglibdir)/java'
+	$(INSTALL_DATA) '$(TARGETDIR)/pljava.jar' '$(DESTDIR)$(pkglibdir)/.'
+	$(INSTALL_DATA) '$(SQLDIR)/install.sql' '$(DESTDIR)$(datadir)/pljava/.'
+	$(INSTALL_DATA) '$(SQLDIR)/uninstall.sql' '$(DESTDIR)$(datadir)/pljava/.'
+	$(INSTALL_DATA) '$(SQLDIR)/examples.sql' '$(DESTDIR)$(datadir)/pljava/.'
+	$(INSTALL_SCRIPT) '$(SQLDIR)/pljava_install.sh' '$(DESTDIR)$(datadir)/pljava/.'
+	$(INSTALL_DATA) '$(TARGETDIR)/examples.jar' '$(DESTDIR)$(datadir)/pljava/.'
+	$(INSTALL_DATA) '$(TARGETDIR)/examples.jar' '$(DESTDIR)$(pkglibdir)/java/.'
+	$(INSTALL_DATA) '$(top_srcdir)/$(subdir)/COPYRIGHT' '$(DESTDIR)$(datadir)/pljava/.'
 
 uninstall: c_uninstall
 	rm -f $(pkglibdir)/pljava.jar


### PR DESCRIPTION
1. Add a RPM spec file to support building HAWQ rpm package from source code tarball.
2. Add 'make rpm' command to build HAWQ/PXF/Ranger-plugin rpm packages and make into a binary tarball from source code tarball.