### PR TITLE
HAWQ-326. Fix specified HAWQ_RELEASE_VERSION for rpm build.

### DIFF
--- a/GNUmakefile.in
+++ b/GNUmakefile.in
@@ -88,6 +88,7 @@ distclean maintainer-clean:
 	-$(MAKE) -C tools $@
 	-$(MAKE) -C src feature-test-clean
 	-$(MAKE) -C src $@
+	-$(MAKE) -C pxf $@
 	-$(MAKE) -C ranger-plugin $@
 	-rm -f config.cache config.log config.status GNUmakefile
 # Garbage from autoconf:

--- a/contrib/Makefile
+++ b/contrib/Makefile
@@ -28,6 +28,7 @@ clean distclean maintainer-clean:
 	@for dir in $(WANTED_DIRS); do \
 		$(MAKE) -C $$dir $@ || true; \
 	done
+	$(MAKE) -C hawq-package $@
 
 # We'd like check operations to run all the subtests before failing.
 check installcheck: pgcrypto_prepare

--- a/contrib/hawq-package/build_hawq_rpm.sh
+++ b/contrib/hawq-package/build_hawq_rpm.sh
@@ -54,9 +54,14 @@ fi
 
 # Copy HAWQ source code tarball for rpm build
 if [ -f "${HAWQ_SOURCE_TARBALL_PATH}/${HAWQ_SOURCE_TARBALL_FILE}" ]; then
+    echo "Using HAWQ source code tarball: ${HAWQ_SOURCE_TARBALL_PATH}/${HAWQ_SOURCE_TARBALL_FILE}"
     cp ${HAWQ_SOURCE_TARBALL_PATH}/${HAWQ_SOURCE_TARBALL_FILE} rpmbuild/SOURCES/
 else
-    echo "Can not find ${HAWQ_SOURCE_TARBALL_PATH}/${HAWQ_SOURCE_TARBALL_FILE} "
+    echo "========================================================================="
+    echo "Can not find ${HAWQ_SOURCE_TARBALL_PATH}/${HAWQ_SOURCE_TARBALL_FILE}"
+    echo "Please copy the source code tarball in place."
+    echo "Or use environment variable 'HAWQ_SOURCE_TARBALL_PATH' to specify the find path of HAWQ source tarball."
+    echo "========================================================================="
     exit 1
 fi
 
@@ -71,8 +76,14 @@ rpmbuild --define "_topdir ${RPM_TOP_DIR}" \
          -bb SPECS/hawq.spec
 if [ $? != 0 ]; then
     echo "Build HAWQ rpm package failed, exit..."
-    exit 0
+    exit $?
 fi
 
 set +x
 popd > /dev/null
+
+echo "========================================================================="
+echo "Build HAWQ rpm package successfully."
+echo "========================================================================="
+echo ""
+exit 0

--- a/contrib/hawq-package/make_rpm_tarball.sh
+++ b/contrib/hawq-package/make_rpm_tarball.sh
@@ -19,7 +19,9 @@
 CUR_DIR=$(pwd)
 SRC_TOP_DIR=../..
 
-HAWQ_RELEASE_VERSION=$(cat ../../getversion| grep ^GP_VERSION | cut -d '=' -f2 | sed 's|"||g' | cut -d '-' -f1)
+if [ -z  "${HAWQ_RELEASE_VERSION}" ]; then
+    HAWQ_RELEASE_VERSION=$(cat ../../getversion| grep ^GP_VERSION | cut -d '=' -f2 | sed 's|"||g' | cut -d '-' -f1)
+fi
 
 RPM_PKG_DIR=${CUR_DIR}/hawq_rpm_packages
 if [ -d ${RPM_PKG_DIR} ]; then
@@ -29,7 +31,7 @@ fi
 mkdir -p ${RPM_PKG_DIR}
 if [ $? != 0 ]; then
     echo "Create HAWQ rpm package directory: ${RPM_PKG_DIR} failed."
-    exit 1
+    exit $?
 fi
 
 echo "Copying HAWQ rpm packages into directory: ${RPM_PKG_DIR}"
@@ -38,28 +40,28 @@ echo "Copying HAWQ rpm packages into directory: ${RPM_PKG_DIR}"
 cp ${SRC_TOP_DIR}/contrib/hawq-package/rpmbuild/RPMS/x86_64/apache-hawq-${HAWQ_RELEASE_VERSION}*.rpm ${RPM_PKG_DIR}/
 if [ $? != 0 ]; then
     echo "Copy HAWQ rpm package failed."
-    exit 1
+    exit $?
 fi
 
 # Copy apache tomcat rpm package for PXF
 cp ${SRC_TOP_DIR}/pxf/distributions/apache-tomcat*.rpm ${RPM_PKG_DIR}/
 if [ $? != 0 ]; then
     echo "Copy Tomcat rpm package failed."
-    exit 1
+    exit $?
 fi
 
 # Copy PXF rpm packages
 cp ${SRC_TOP_DIR}/pxf/build/distributions/pxf*.rpm ${RPM_PKG_DIR}/
 if [ $? != 0 ]; then
     echo "Copy PXF rpm packages failed."
-    exit 1
+    exit $?
 fi
 
 # Copy HAWQ Ranger rpm package
 cp ${SRC_TOP_DIR}/ranger-plugin/target/rpm/hawq-ranger-plugin_*/RPMS/noarch/hawq-ranger-plugin*.rpm ${RPM_PKG_DIR}/
 if [ $? != 0 ]; then
     echo "Copy HAWQ Ranger plugin rpm package failed."
-    exit 1
+    exit $?
 fi
 
 echo "Copied all the HAWQ/PXF/Range-plugin rpm packages."
@@ -70,11 +72,12 @@ ls ${RPM_PKG_DIR}/
 tar czvf apache-hawq-rpm-${HAWQ_RELEASE_VERSION}-incubating.tar.gz  hawq_rpm_packages
 if [ $? != 0 ]; then
     echo "Make HAWQ/PXF/Ranger-plugin rpm tarball failed."
-    exit 1
+    exit $?
 else
-    echo "Make HAWQ/PXF/Ranger-plugin rpm tarball successful."
+    echo "Make HAWQ/PXF/Ranger-plugin rpm tarball successfully."
+    echo "You can find the rpm binary tarball at:"
+    echo "${CUR_DIR}/apache-hawq-rpm-${HAWQ_RELEASE_VERSION}-incubating.tar.gz"
+    ls -l apache-hawq-rpm-${HAWQ_RELEASE_VERSION}-incubating.tar.gz
 fi
-
-ls -l apache-hawq-rpm-${HAWQ_RELEASE_VERSION}-incubating.tar.gz
 
 exit 0

--- a/pxf/Makefile
+++ b/pxf/Makefile
@@ -73,6 +73,9 @@ rpm: tomcat
 	
 clean:
 	./gradlew clean
+	@rm -rf ./distributions/apache-tomcat*.rpm
+
+distclean maintainer-clean: clean
 
 doc:
 	./gradlew aggregateJavadoc 

--- a/ranger-plugin/scripts/build_ranger_rpm.sh
+++ b/ranger-plugin/scripts/build_ranger_rpm.sh
@@ -30,21 +30,21 @@ fi
 mvn ${MVN_OPTS} versions:set -DnewVersion=${HAWQ_RELEASE_VERSION}
 if [ $? != 0 ]; then
     echo "Set HAWQ ranger-plugin failed."
-    exit 1
+    exit $?
 fi
 
 # generate jar and war files.
 mvn ${MVN_OPTS} clean package
 if [ $? != 0 ]; then
     echo "Generate HAWQ ranger-plugin jar and war files failed."
-    exit 1
+    exit $?
 fi
 
 # build rpm
 mvn ${MVN_OPTS} -N -Drelease.version=${BUILD_NUMBER} install
 if [ $? != 0 ]; then
     echo "Build HAWQ ranger-plugin rpm package failed."
-    exit 1
+    exit $?
 fi
 
 exit 0


### PR DESCRIPTION
This fix included:
  1) Fixed HAWQ_RELEASE_VERSION for rpm tarball.
  2) Make sure distclean delete all the rpm artifacts.
  3) Added some log output.