### PR TITLE
HAWQ-1438. Support resource owner beyond transaction boundary

### DIFF
--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -2458,7 +2458,7 @@ CommitTransaction(void)
 	//AtEOXact_Snapshot(true);
 	pgstat_report_xact_timestamp(0);
 
-	CurrentResourceOwner = NULL;
+	CurrentResourceOwner = GetTopResourceOwner();
 	ResourceOwnerDelete(TopTransactionResourceOwner);
 	s->curTransactionOwner = NULL;
 	CurTransactionResourceOwner = NULL;
@@ -2687,7 +2687,7 @@ PrepareTransaction(void)
 	AtEOXact_HashTables(true);
 	/* don't call AtEOXact_PgStat here */
 
-	CurrentResourceOwner = NULL;
+	CurrentResourceOwner = GetTopResourceOwner();
 	ResourceOwnerDelete(TopTransactionResourceOwner);
 	s->curTransactionOwner = NULL;
 	CurTransactionResourceOwner = NULL;
@@ -2933,7 +2933,7 @@ CleanupTransaction(void)
 	 */
 	AtCleanup_Portals();		/* now safe to release portal memory */
 
-	CurrentResourceOwner = NULL;	/* and resource owner */
+	CurrentResourceOwner = GetTopResourceOwner();	/* and resource owner */
 	if (TopTransactionResourceOwner)
 		ResourceOwnerDelete(TopTransactionResourceOwner);
 	s->curTransactionOwner = NULL;

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -6561,7 +6561,7 @@ StartupXLOG(void)
 					(errmsg("redo done at %X/%X",
 							ReadRecPtr.xlogid, ReadRecPtr.xrecoff)));
 
-			CurrentResourceOwner = NULL;
+			CurrentResourceOwner = GetTopResourceOwner();
 
 			InRedo = false;
 
@@ -7574,7 +7574,7 @@ XLogStandbyRecoverRange(XLogRecPtr *redoCheckpointLoc, CheckPoint *redoCheckPoin
 	 */
 	FlushBufferPool();
 
-	CurrentResourceOwner = NULL;
+	CurrentResourceOwner = GetTopResourceOwner();
 
 	InRedo = false;
 	InRecovery = false;

--- a/src/backend/utils/init/flatfiles.c
+++ b/src/backend/utils/init/flatfiles.c
@@ -1107,7 +1107,7 @@ BuildFlatFiles(bool database_only)
 		write_auth_time_file(rel_authid, rel_authtime);
 	}
 
-	CurrentResourceOwner = NULL;
+	CurrentResourceOwner = GetTopResourceOwner();
 	ResourceOwnerDelete(owner);
 
 	XLogCloseRelationCache();

--- a/src/include/utils/resowner.h
+++ b/src/include/utils/resowner.h
@@ -67,6 +67,7 @@ typedef void (*ResourceReleaseCallback) (ResourceReleasePhase phase,
  */
 
 /* generic routines */
+extern ResourceOwner GetTopResourceOwner();
 extern ResourceOwner ResourceOwnerCreate(ResourceOwner parent,
 					const char *name);
 extern void ResourceOwnerRelease(ResourceOwner owner,
@@ -74,6 +75,7 @@ extern void ResourceOwnerRelease(ResourceOwner owner,
 					 bool isCommit,
 					 bool isTopLevel);
 extern void ResourceOwnerDelete(ResourceOwner owner);
+extern void DeleteTopResourceOwner();
 extern ResourceOwner ResourceOwnerGetParent(ResourceOwner owner);
 extern void ResourceOwnerNewParent(ResourceOwner owner,
 					   ResourceOwner newparent);


### PR DESCRIPTION
(1) Add TopResourceOwner to trace resource used beyond the transaction boundary.
(2) When to auto alloc a new TopResourceOwner for each process?
    Generate a singleton TopResourceOwner when setting CurrentResourceOwner to NULL.
(3) If crashed at some code beyond the transaction boundary, we should manually create
    a new resource owner, because we don't manually create TopResourceOwner for each process.
(4) When to call ResourceOwnerDelete(TopResourceOwner) automatically for each process?
    Register it at on_proc_exit().