### PR TITLE
HAWQ-1453. Fixed relation_close() error at analyzeStmt(): not owned b…

### DIFF
--- a/src/backend/access/heap/heapam.c
+++ b/src/backend/access/heap/heapam.c
@@ -1269,6 +1269,14 @@ relation_close(Relation relation, LOCKMODE lockmode)
 }
 
 
+void
+relation_close_at_resource_owner(Relation relation, LOCKMODE lockmode, ResourceOwner resowner)
+{
+	ResourceOwner oldOwner = CurrentResourceOwner;
+	CurrentResourceOwner = resowner;
+	relation_close(relation, lockmode);
+	CurrentResourceOwner = oldOwner;
+}
 /* ----------------
  *		heap_open - open a heap relation by relation OID
  *

--- a/src/backend/commands/analyze.c
+++ b/src/backend/commands/analyze.c
@@ -308,7 +308,7 @@ void analyzeStmt(VacuumStmt *stmt, List *relids, int preferred_seg_num)
 	ListCell				*le1 = NULL;
 	int 					successCount = 0, failCount = 0;
 	StringInfoData 			failNames;
-	ResourceOwner owner, oldOwner;
+	ResourceOwner asOwner, oldOwner1;  /* asOwner for analyzeStmt resource owner */
 
 	/**
 	 * Ensure that an ANALYZE is requested.
@@ -480,9 +480,9 @@ void analyzeStmt(VacuumStmt *stmt, List *relids, int preferred_seg_num)
 	/**
 	 * Create a resource owner to keep track of our resources even not in trasaction block
 	 */
-	owner = ResourceOwnerCreate(CurrentResourceOwner, "analyzeStmt");
-	oldOwner = CurrentResourceOwner;
-	CurrentResourceOwner = owner;
+	asOwner = ResourceOwnerCreate(CurrentResourceOwner, "analyzeStmt");
+	oldOwner1 = CurrentResourceOwner;
+	CurrentResourceOwner = asOwner;
 
 	/**
 	 *  we use preferred_seg_num as default and
@@ -612,12 +612,12 @@ void analyzeStmt(VacuumStmt *stmt, List *relids, int preferred_seg_num)
 						        (errmsg("skipping \"%s\" --- cannot analyze indexes, views, external tables or special system tables",
 						                RelationGetRelationName(candidateRelation))));
 
-						relation_close(candidateRelation, ShareUpdateExclusiveLock);
+						relation_close_at_resource_owner(candidateRelation, ShareUpdateExclusiveLock, asOwner);
 					}
 					else if (isOtherTempNamespace(RelationGetNamespace(candidateRelation)))
 					{
 						/* Silently ignore tables that are temp tables of other backends. */
-						relation_close(candidateRelation, ShareUpdateExclusiveLock);
+						relation_close_at_resource_owner(candidateRelation, ShareUpdateExclusiveLock, asOwner);
 					}
 					else if (RelationIsExternalPxfReadOnly(candidateRelation, &ext_uri) &&
 					         (!pxf_enable_stat_collection))
@@ -627,7 +627,7 @@ void analyzeStmt(VacuumStmt *stmt, List *relids, int preferred_seg_num)
 						        (errmsg("skipping \"%s\" --- analyze for PXF tables is turned off by 'pxf_enable_stat_collection'",
 						                RelationGetRelationName(candidateRelation))));
 
-						relation_close(candidateRelation, ShareUpdateExclusiveLock);
+						relation_close_at_resource_owner(candidateRelation, ShareUpdateExclusiveLock, asOwner);
 					}
 					else
 					{
@@ -722,7 +722,7 @@ void analyzeStmt(VacuumStmt *stmt, List *relids, int preferred_seg_num)
 						 * releasing the lock before commit would expose
 						 * us to concurrent-update failures.)
 						 */
-						relation_close(candidateRelation, NoLock);
+						relation_close_at_resource_owner(candidateRelation, NoLock, asOwner);
 
 						/* MPP-6929: metadata tracking */
 						if (!bTemp && (Gp_role == GP_ROLE_DISPATCH))
@@ -753,7 +753,7 @@ void analyzeStmt(VacuumStmt *stmt, List *relids, int preferred_seg_num)
 					        (errmsg("Skipping \"%s\" --- only table or database owner can analyze it",
 					                RelationGetRelationName(candidateRelation))));
 
-					relation_close(candidateRelation, ShareUpdateExclusiveLock);
+					relation_close_at_resource_owner(candidateRelation, ShareUpdateExclusiveLock, asOwner);
 				} /* if (analyzePermitted(RelationGetRelid(candidateRelation))) */
 			}
 			else
@@ -795,11 +795,11 @@ void analyzeStmt(VacuumStmt *stmt, List *relids, int preferred_seg_num)
 	UnsetActiveQueryResource();
 	SetActiveQueryResource(savedResource);
 
-	ResourceOwnerRelease(owner,
+	ResourceOwnerRelease(asOwner,
             RESOURCE_RELEASE_BEFORE_LOCKS,
             false, false);
-	CurrentResourceOwner = oldOwner;
-	ResourceOwnerDelete(owner);
+	CurrentResourceOwner = oldOwner1;
+	ResourceOwnerDelete(asOwner);
 
 	if (bUseOwnXacts)
 	{

--- a/src/include/access/heapam.h
+++ b/src/include/access/heapam.h
@@ -211,6 +211,7 @@ extern Relation try_relation_openrv(const RangeVar *relation, LOCKMODE lockmode,
 									bool noWait);
 
 extern void relation_close(Relation relation, LOCKMODE lockmode);
+extern void relation_close_at_resource_owner(Relation relation, LOCKMODE lockmode, ResourceOwner resowner);
 
 extern Relation heap_open(Oid relationId, LOCKMODE lockmode);
 extern Relation heap_openrv(const RangeVar *relation, LOCKMODE lockmode);


### PR DESCRIPTION
…y resource owner TopTransaction (resowner.c:814)

The relation opened at TopResourceOwner, while close at a new transaction resource owner.
So when we close these relations, we need to firstly switch back to the TopResourceOwner.

Verified on reproducible environment. Please help me to review it. Thanks.