### PR TITLE
HAWQ-1455. Wrong results on CTAS query over catalog

### DIFF
--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -4471,7 +4471,7 @@ PostgresMain(int argc, char *argv[], const char *username)
 	 * NOTE: we init entrydb as QE
 	 */
 	if (MyProcPort == NULL ||
-	    (AmIMaster() && Gp_role != GP_ROLE_EXECUTE) || AmIStandby() ||
+	    AmIMaster() || AmIStandby() ||
 	    MyProcPort->bootstrap_user == NULL){
 		am_superuser = InitPostgres(dbname, InvalidOid, username, NULL);
 	}

--- a/src/backend/utils/cache/relcache.c
+++ b/src/backend/utils/cache/relcache.c
@@ -1344,8 +1344,7 @@ RelationInitPhysicalAddr(Relation relation)
 	if (relation->rd_rel->relisshared)
 		relation->rd_node.dbNode = InvalidOid;
 	else if (relation->rd_id < FirstNormalObjectId ||
-			(AmActiveMaster() && Gp_role != GP_ROLE_EXECUTE) ||
-			AmStandbyMaster())
+			AmActiveMaster() || AmStandbyMaster())
 		relation->rd_node.dbNode = MyDatabaseId;
 	else
 		relation->rd_node.dbNode = MyProcPort->dboid;

--- a/src/test/feature/catalog/ans/entrydb.ans
+++ b/src/test/feature/catalog/ans/entrydb.ans
@@ -1,0 +1,35 @@
+-- test case for HAWQ-1455 (Wrong results on CTAS query over catalog)
+create temp table entrydb_t1 (entrydb_tta varchar, entrydb_ttb varchar);
+CREATE TABLE
+create temp table entrydb_t2 (entrydb_tta varchar, entrydb_ttb varchar);
+CREATE TABLE
+insert into entrydb_t1 values('entrydb_a', '1');
+INSERT 0 1
+insert into entrydb_t1 values('entrydb_a', '2');
+INSERT 0 1
+insert into entrydb_t1 values('entrydb_tta', '3');
+INSERT 0 1
+insert into entrydb_t1 values('entrydb_ttb', '4');
+INSERT 0 1
+insert into entrydb_t2 select pg_attribute.attname, entrydb_t1.entrydb_ttb from pg_attribute join entrydb_t1 on pg_attribute.attname = entrydb_t1.entrydb_tta;
+INSERT 0 4
+-- test case for HAWQ-512 (Query hang due to deadlock in entrydb catalog access)
+create table entrydb_t3 (key int, value int) distributed randomly;
+CREATE TABLE
+insert into entrydb_t3 values (1, 0);
+INSERT 0 1
+begin;
+BEGIN
+alter table entrydb_t3 set distributed by (key);
+ALTER TABLE
+select entrydb_t4.key FROM entrydb_t3 AS entrydb_t4, (select generate_series(1, 2)::int as key, 0::int as value) as entrydb_t5, (select generate_series(1, 2)::int as key, 0::int as value) as entrydb_t6 where entrydb_t4.value = entrydb_t5.value and entrydb_t4.value = entrydb_t6.value;
+ key 
+-----
+   1
+   1
+   1
+   1
+(4 rows)
+
+commit;
+COMMIT

--- a/src/test/feature/catalog/sql/entrydb.sql
+++ b/src/test/feature/catalog/sql/entrydb.sql
@@ -1,0 +1,22 @@
+
+-- test case for HAWQ-1455 (Wrong results on CTAS query over catalog)
+create temp table entrydb_t1 (entrydb_tta varchar, entrydb_ttb varchar);
+create temp table entrydb_t2 (entrydb_tta varchar, entrydb_ttb varchar);
+insert into entrydb_t1 values('entrydb_a', '1');
+insert into entrydb_t1 values('entrydb_a', '2');
+insert into entrydb_t1 values('entrydb_tta', '3');
+insert into entrydb_t1 values('entrydb_ttb', '4');
+
+insert into entrydb_t2 select pg_attribute.attname, entrydb_t1.entrydb_ttb from pg_attribute join entrydb_t1 on pg_attribute.attname = entrydb_t1.entrydb_tta;
+
+-- test case for HAWQ-512 (Query hang due to deadlock in entrydb catalog access)
+create table entrydb_t3 (key int, value int) distributed randomly;
+insert into entrydb_t3 values (1, 0);
+
+begin;
+
+alter table entrydb_t3 set distributed by (key);
+
+select entrydb_t4.key FROM entrydb_t3 AS entrydb_t4, (select generate_series(1, 2)::int as key, 0::int as value) as entrydb_t5, (select generate_series(1, 2)::int as key, 0::int as value) as entrydb_t6 where entrydb_t4.value = entrydb_t5.value and entrydb_t4.value = entrydb_t6.value;
+
+commit;

--- a/src/test/feature/catalog/test_entrydb.cpp
+++ b/src/test/feature/catalog/test_entrydb.cpp
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "gtest/gtest.h"
+
+#include "lib/sql_util.h"
+
+using std::string;
+
+class TestEntrydb: public ::testing::Test
+{
+	public:
+		TestEntrydb() {};
+		~TestEntrydb() {};
+};
+
+TEST_F(TestEntrydb, entrydb)
+{
+	hawq::test::SQLUtility util;
+
+	util.execSQLFile("catalog/sql/entrydb.sql", "catalog/ans/entrydb.ans");
+}

--- a/src/test/feature/full_tests.txt
+++ b/src/test/feature/full_tests.txt
@@ -3,4 +3,4 @@
 #you can have several PARALLEL or SRRIAL
 
 PARALLEL=TestErrorTable.*:TestPreparedStatement.*:TestUDF.*:TestAOSnappy.*:TestAlterOwner.*:TestAlterTable.*:TestCreateTable.*:TestGuc.*:TestType.*:TestDatabase.*:TestParquet.*:TestPartition.*:TestSubplan.*:TestAggregate.*:TestCreateTypeComposite.*:TestGpDistRandom.*:TestInformationSchema.*:TestQueryInsert.*:TestQueryNestedCaseNull.*:TestQueryPolymorphism.*:TestQueryPortal.*:TestQueryPrepare.*:TestQuerySequence.*:TestCommonLib.*:TestToast.*:TestTransaction.*:TestCommand.*:TestCopy.*:TestParser.*:TestHawqRegister.*:TestRegex.*
-SERIAL=TestExternalOid.TestExternalOidAll:TestExternalTable.TestExternalTableAll:TestTemp.BasicTest:TestRowTypes.*
+SERIAL=TestExternalOid.TestExternalOidAll:TestExternalTable.TestExternalTableAll:TestTemp.BasicTest:TestRowTypes.*:TestEntrydb.entrydb


### PR DESCRIPTION
This reverts the previous fix for HAWQ-512, however to HAWQ-512, it looks like
we could modify the lock related code following gpdb to do a real fix. Those code
was probably deleted during early hawq development.