### PR TITLE
HAWQ-1456. Copy RPS configuration files to standby in specific scenarios

### DIFF
--- a/tools/bin/hawq_ctl
+++ b/tools/bin/hawq_ctl
@@ -387,6 +387,10 @@ class HawqInit:
                  (self.GPHOME, self.standby_host_name, self.GPHOME)
         check_return_code(remote_ssh(scpcmd, self.master_host_name, self.user), \
                           logger, "Sync slaves file failed")
+        scpcmd = "scp %s/ranger/etc/* %s:%s/ranger/etc/ > /dev/null" % \
+                 (self.GPHOME, self.standby_host_name, self.GPHOME)
+        check_return_code(remote_ssh(scpcmd, self.master_host_name, self.user), \
+                          logger, "Sync rps configuration files failed")
 
         standby_init_cmd = self._get_standby_init_cmd()
 

--- a/tools/bin/hawq_ctl
+++ b/tools/bin/hawq_ctl
@@ -387,9 +387,11 @@ class HawqInit:
                  (self.GPHOME, self.standby_host_name, self.GPHOME)
         check_return_code(remote_ssh(scpcmd, self.master_host_name, self.user), \
                           logger, "Sync slaves file failed")
-        scpcmd = "scp %s/ranger/etc/* %s:%s/ranger/etc/ > /dev/null" % \
+        # Sync rps configuration
+        if os.path.exists("%s/ranger/" % (self.GPHOME)):
+            scpcmd = "scp %s/ranger/etc/* %s:%s/ranger/etc/ > /dev/null" % \
                  (self.GPHOME, self.standby_host_name, self.GPHOME)
-        check_return_code(remote_ssh(scpcmd, self.master_host_name, self.user), \
+            check_return_code(remote_ssh(scpcmd, self.master_host_name, self.user), \
                           logger, "Sync rps configuration files failed")
 
         standby_init_cmd = self._get_standby_init_cmd()


### PR DESCRIPTION
copy RPS configuration files to standby in:
  * hawq init standby
  * enable-ranger-plugin.sh

besides copy files, enhance enable-ranger-plugin.sh to support read items(e.g. hawq_master_address_host) in hawq-site.xml now.