### PR TITLE
HAWQ-1465. Disable alter schema help doc

### DIFF
--- a/doc/src/sgml/ref/alter_schema.sgml
+++ b/doc/src/sgml/ref/alter_schema.sgml
@@ -11,7 +11,7 @@ PostgreSQL documentation
 
  <refnamediv>
   <refname>ALTER SCHEMA</refname>
-  <refpurpose>change the definition of a schema</refpurpose>
+  <refpurpose>change the definition of a schema, which is not supported yet</refpurpose>
  </refnamediv>
 
  <indexterm zone="sql-alterschema">


### PR DESCRIPTION
testdb=# ALTER SCHEMA test1 owner to test1;
ERROR: Cannot support alter schema owner statement yet
testdb=# \h alter schema
Command: ALTER SCHEMA
Description: change the definition of a schema
Syntax:
ALTER SCHEMA name RENAME TO newname
ALTER SCHEMA name OWNER TO newowner

Disable this part of help doc