### PR TITLE
HAWQ-1436. Print a message to command line if hawq switches from standby RPS to master RPS

### DIFF
--- a/src/backend/libpq/rangerrest.c
+++ b/src/backend/libpq/rangerrest.c
@@ -466,7 +466,7 @@ static int call_ranger_rest(CURL_HANDLE curl_handle, const char* request)
 		}
 		else
 		{
-			if (switchToMaster)
+			if (switchToMaster && !curl_handle->talkingWithStandby)
 			{
 				/* master's RPS has recovered, switch from standby's RPS to master's RPS */
 				elog(NOTICE, "switch from standby's RPS to master's RPS");

--- a/src/backend/libpq/rangerrest.c
+++ b/src/backend/libpq/rangerrest.c
@@ -385,8 +385,8 @@ static int call_ranger_rest(CURL_HANDLE curl_handle, const char* request)
 	int ret = -1;
 	int retry = 2;
 	CURLcode res;
-	Assert(request != NULL);
 	bool switchToMaster = false;
+	Assert(request != NULL);
 
 	/*
 	 * If master is talking with standby RPS, for every predefined interval


### PR DESCRIPTION
This improvement happens in such case: hawq master is talking with standby RPS, when master's RPS has recovered, master switches from standby RPS to local RPS, a reminder message is printed.
Please review. 