### PR TITLE
HAWQ-1443. Implement Ranger lookup for HAWQ with Kerberos enabled.

### DIFF
--- a/ranger-plugin/admin-plugin/src/main/java/org/apache/hawq/ranger/service/RangerServiceHawq.java
+++ b/ranger-plugin/admin-plugin/src/main/java/org/apache/hawq/ranger/service/RangerServiceHawq.java
@@ -19,6 +19,8 @@
 package org.apache.hawq.ranger.service;
 
 import org.apache.ranger.plugin.client.HadoopException;
+import org.apache.ranger.plugin.model.RangerService;
+import org.apache.ranger.plugin.model.RangerServiceDef;
 import org.apache.ranger.plugin.service.RangerBaseService;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -30,6 +32,15 @@ public class RangerServiceHawq extends RangerBaseService {
 
     private static final Log LOG = LogFactory.getLog(RangerServiceHawq.class);
 
+    public RangerServiceHawq() {
+		super();
+	}
+	
+	@Override
+	public void init(RangerServiceDef serviceDef, RangerService service) {
+		super.init(serviceDef, service);
+	}
+	
     @Override
     public HashMap<String, Object> validateConfig() throws Exception {
         boolean isDebugEnabled = LOG.isDebugEnabled();
@@ -39,10 +50,10 @@ public class RangerServiceHawq extends RangerBaseService {
         }
 
         HashMap<String, Object> result = new HashMap<>();
-
+        String 	serviceName = getServiceName();
         if (configs != null) {
             try  {
-                HawqClient hawqClient = new HawqClient(configs);
+                HawqClient hawqClient = new HawqClient(serviceName, configs);
                 result = hawqClient.checkConnection(configs);
             } catch (HadoopException e) {
                 LOG.error("<== RangerServiceHawq.validateConfig Error:" + e);
@@ -58,7 +69,10 @@ public class RangerServiceHawq extends RangerBaseService {
 
     @Override
     public List<String> lookupResource(ResourceLookupContext context) throws Exception {
-        List<String> resources = HawqResourceMgr.getHawqResources(getConfigs(), context);
+    		String 	serviceName = getServiceName();
+    		String	serviceType = getServiceType();
+    		
+        List<String> resources = HawqResourceMgr.getHawqResources(serviceName, serviceType, getConfigs(), context);
 
         return resources;
     }

--- a/ranger-plugin/conf/ranger-servicedef-hawq.json
+++ b/ranger-plugin/conf/ranger-servicedef-hawq.json
@@ -241,6 +241,29 @@
     },
     {
       "itemId": 3,
+      "name": "authentication",
+      "type": "enum",
+      "subType": "authType",
+      "mandatory": false,
+      "validationRegEx": "",
+      "validationMessage": "",
+      "uiHint": "",
+      "label": "HAWQ Authentication Type",
+      "defaultValue": "simple"
+    },
+    {
+      "itemId": 4,
+      "name": "principal",
+      "type": "string",
+      "mandatory": false,
+      "validationRegEx": "",
+      "validationMessage": "",
+      "uiHint": "",
+      "label": "HAWQ Kerberos Service Name",
+      "defaultValue": ""
+    },
+    {
+      "itemId": 5,
       "name": "hostname",
       "type": "string",
       "mandatory": true,
@@ -250,7 +273,7 @@
       "label": "HAWQ Master Hostname"
     },
     {
-      "itemId": 4,
+      "itemId": 6,
       "name": "port",
       "type": "int",
       "mandatory": true,
@@ -261,7 +284,27 @@
       "defaultValue": 5432
     }
   ],
-  "enums": [],
+  "enums": 
+  [
+    {
+      "itemId": 1,
+      "name": "authType",
+      "elements": 
+      [
+        {
+          "itemId": 1,
+          "name": "simple",
+          "label": "Simple"
+        },
+        {
+          "itemId": 2,
+          "name": "kerberos",
+          "label": "Kerberos"
+        }
+      ],
+      "defaultIndex": 0
+    }
+  ],
   "contextEnrichers": [],
   "policyConditions": [],
   "dataMaskDef": {},


### PR DESCRIPTION
This PR implements the HAWQ client in ranger to lookup HAWQ resource in kerberos environment.
With Kerberos authentication, the jdbc URL looks like:  jdbc:postgresql://host:port/db?kerberosServerName=HawqKerberosServiceName&jaasApplicationName=pgjdbc&user=LookupPricipal
With Simple authentication,  the jdbc URL just looks like:  jdbc:postgresql://host:port/db and with user name and password as parameter.

In Kerberos env, we also do kinit with principal name and principal password. Keytab file is not supported yet.


Signed-off-by: xiang sheng <stanly.sxiang@gmail.com>