### PR TITLE
HAWQ-1476. Augment enable-ranger-plugin.sh to support kerberos.

### DIFF
--- a/ranger-plugin/conf/ranger-servicedef-hawq.json
+++ b/ranger-plugin/conf/ranger-servicedef-hawq.json
@@ -244,7 +244,7 @@
       "name": "authentication",
       "type": "enum",
       "subType": "authType",
-      "mandatory": false,
+      "mandatory": true,
       "validationRegEx": "",
       "validationMessage": "",
       "uiHint": "",


### PR DESCRIPTION
Now ranger can lookup hawq resource in kerberized environment. So we also need to change enable-ranger-plugin.sh to support automatically fill the authentication type and hawq kerberos service name fields
