### PR TITLE
HAWQ-1475. Add LICENSE, NOTICE, and DISCLAIMER files for Apache HAWQ binary release

### DIFF
--- a/GNUmakefile.in
+++ b/GNUmakefile.in
@@ -30,6 +30,7 @@ install:
 	$(MAKE) -C contrib $@
 	$(MAKE) -C tools $@
 	$(MAKE) -C ranger-plugin $@
+	$(MAKE) -C dist $@
 	@echo "HAWQ installation complete."
 
 installdirs uninstall:

--- a/dist/Makefile
+++ b/dist/Makefile
@@ -1,0 +1,31 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------------------
+#
+# Makefile for license information of the rpm package
+#
+#-------------------------------------------------------------------------
+
+subdir = dist
+top_builddir = ..
+include $(top_builddir)/src/Makefile.global
+
+all: install
+
+install:
+	${MAKE} -C hawq $@

--- a/dist/hawq/DISCLAIMER
+++ b/dist/hawq/DISCLAIMER
@@ -1,0 +1,11 @@
+Apache HAWQ is an effort undergoing incubation at the Apache Software
+Foundation (ASF), sponsored by the Apache Incubator PMC.
+
+Incubation is required of all newly accepted projects until a further
+review indicates that the infrastructure, communications, and decision
+making process have stabilized in a manner consistent with other
+successful ASF projects.
+
+While incubation status is not necessarily a reflection of the
+completeness or stability of the code, it does indicate that the
+project has yet to be fully endorsed by the ASF.

--- a/dist/hawq/LICENSE
+++ b/dist/hawq/LICENSE
@@ -1,0 +1,490 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+=======================================================================
+
+Apache HAWQ (incubating) Subcomponents:
+
+  The Apache HAWQ (incubating) project contains subcomponents with
+  separate copyright notices and license terms. Your use of the source
+  code for these subcomponents is subject to the terms and conditions
+  of the following licenses.
+
+=======================================================================
+Stream License
+======================================================================
+
+  The following files are used:
+  
+      tools/bin/src/stream
+  
+  This file is made available under the following Stream License:
+  
+      licenses/LICENSE-stream.txt
+
+======================================================================
+PyGreSQL 4.0 License
+======================================================================
+
+  The following files are used:
+  
+      tools/bin/pythonSrc/PyGreSQL-4.0
+  
+  This file is made available under the following PyGreSQL License:
+  
+      licenses/LICENSE-pygresql.txt
+
+======================================================================
+MIT License
+======================================================================
+
+  The following components are provided under a MIT license. See
+  project link for details.  The text of each license is also included
+  at licenses/LICENSE-[project].txt.
+
+     lockfile (0.9.1)
+       tools/bin/pythonSrc/lockfile-0.9.1
+       tools/bin/pythonSrc/lockfile-0.9.1/lockfile/pidlockfile.py
+
+     PSI (0.3b2_gp)
+       tools/bin/pythonSrc/PSI-0.3b2_gp
+
+     simplejson (1.7.3)
+       tools/bin/ext/simplejson
+
+     PyYAML
+       tools/bin/ext/yaml
+
+======================================================================
+BSD-style licenses
+======================================================================
+
+  The following components are provided under a BSD-style license. See
+  project link for details.  The text of each license is also included
+  at licenses/LICENSE-[project].txt.
+
+     (BSD 2 Clause) Google Mock (https://github.com/google/googletest/tree/master/googlemock)
+       depends/thirdparty/googletest/googlemock
+
+     (BSD 2 Clause) Google Test (https://github.com/google/googletest)
+       depends/thirdparty/googletest
+
+     (BSD 3 Clause) CMake (https://cmake.org)
+       depends/libyarn/CMake
+       depends/libhdfs3/CMake
+
+     (BSD License) pychecker (v0.8.18 - http://pychecker.sourceforge.net/)
+       tools/bin/pythonSrc/pychecker-0.8.18 
+     
+     (BSD License) unittest2 (v2-0.5.1 - https://pypi.python.org/pypi/unittest2)
+       tools/bin/pythonSrc/unittest2-0.5.1
+     
+     (BSD License) figleaf (http://darcs.idyll.org/~t/projects/figleaf/)
+       tools/bin/ext/figleaf
+    
+     (BSD License) pg8000
+       tools/bin/ext/pg8000
+      
+======================================================================
+BZIP2 License
+======================================================================
+
+  The following files are used:
+  
+      src/include/port/win32_msvc/bzlib.h
+  
+  This file is made available under the following bzip2 and libbzip2
+  License v1.0.5 license:
+  
+      licenses/LICENSE-bzip2.txt
+
+======================================================================
+Google Test License
+======================================================================
+
+  The following files are used:
+  
+      depends/thirdparty/googletest
+  
+  This file is made available under the following Google test license:
+  
+      licenses/LICENSE-googletest.txt
+
+======================================================================
+Oraface License
+======================================================================
+
+  The following files are used:
+  
+      contrib/orafce
+  
+  This file is made available under the following Oraface license:
+  
+      licenses/LICENSE-oraface.txt
+
+======================================================================
+Pexpect License
+======================================================================
+
+  The following files are used:
+  
+      tools/bin/lib/pexpect.py
+  
+  This file is made available under the following Pexpect license:
+  
+      licenses/LICENSE-pexect.txt
+
+======================================================================
+PostgreSQL LICENSE
+======================================================================
+
+The rest of the source code without explicit ASF license headers was
+derived from PostgreSQL and is available under the following license:
+
+      licenses/LICENSE-postgresql.txt
+
+  This includes the following explicitely listed source directories:
+
+     contrib/extprotocol
+     contrib/formatter_fixedwidth
+     contrib/gp_cancel_query
+     contrib/hawq-hadoop
+     contrib/orafce
+     contrib/pgcrypto
+     pxf/pxf
+     src/backend/libpq
+     src/backend/port/beos/shm.c
+     src/backend/port/qnx4/shm.c
+     src/backend/utils/mb/conversion_procs/ascii_and_mic
+     src/backend/utils/mb/conversion_procs/cyrillic_and_mic
+     src/backend/utils/mb/conversion_procs/euc_cn_and_mic
+     src/backend/utils/mb/conversion_procs/euc_jis_2004_and_shift_jis_2004
+     src/backend/utils/mb/conversion_procs/euc_jp_and_sjis
+     src/backend/utils/mb/conversion_procs/euc_kr_and_mic
+     src/backend/utils/mb/conversion_procs/euc_tw_and_big5
+     src/backend/utils/mb/conversion_procs/latin2_and_win1250
+     src/backend/utils/mb/conversion_procs/latin_and_mic
+     src/backend/utils/mb/conversion_procs/utf8_and_ascii
+     src/backend/utils/mb/conversion_procs/utf8_and_big5
+     src/backend/utils/mb/conversion_procs/utf8_and_cyrillic
+     src/backend/utils/mb/conversion_procs/utf8_and_euc_cn
+     src/backend/utils/mb/conversion_procs/utf8_and_euc_jis_2004
+     src/backend/utils/mb/conversion_procs/utf8_and_euc_jp
+     src/backend/utils/mb/conversion_procs/utf8_and_euc_kr
+     src/backend/utils/mb/conversion_procs/utf8_and_euc_tw
+     src/backend/utils/mb/conversion_procs/utf8_and_gb18030
+     src/backend/utils/mb/conversion_procs/utf8_and_gbk
+     src/backend/utils/mb/conversion_procs/utf8_and_iso8859
+     src/backend/utils/mb/conversion_procs/utf8_and_iso8859_1
+     src/backend/utils/mb/conversion_procs/utf8_and_johab
+     src/backend/utils/mb/conversion_procs/utf8_and_shift_jis_2004
+     src/backend/utils/mb/conversion_procs/utf8_and_sjis
+     src/backend/utils/mb/conversion_procs/utf8_and_uhc
+     src/backend/utils/mb/conversion_procs/utf8_and_win
+     src/backend/utils/mb/Unicode
+     src/bin/gpfilesystem/hdfs/gpfshdfs.c
+     src/bin/gpoptutils
+     src/bin/gpupgrade
+     src/bin/pg_dump
+     src/include/libpq
+     src/interfaces/ecpg
+     src/interfaces/ecpg/pgtypeslib
+     src/interfaces/libpq
+     src/interfaces/libpq/po
+     src/pl/pljava
+     src/pl/plperl
+     src/pl/plpgsql
+     src/pl/plpython
+     src/port
+     tools/bin/pythonSrc/PSI-0.3b2_gp/src
+
+  (BSD 4 Clause revised) dynloader
+    src/backend/port/dynloader/freebsd.c
+    src/backend/port/dynloader/netbsd.c
+    src/backend/port/dynloader/openbsd.c
+    src/backend/port/dynloader/ultrix4.h
+
+    Revised based on: ftp://ftp.cs.berkeley.edu/pub/4bsd/README.Impt.License.Change
+    
+  (BSD 4 Clause revised) glob
+    src/bin/gpfdist/src/gpfdist/glob.c
+    src/bin/gpfdist/src/gpfdist/include/glob.h
+    src/include/port/win32_msvc/glob.h
+    src/port/glob.c
+
+    Revised based on: ftp://ftp.cs.berkeley.edu/pub/4bsd/README.Impt.License.Change
+
+  (BSD License) pg_controldata 
+    src/bin/pg_controldata/pg_controldata.c 
+
+  (BSD License) port
+    src/port/inet_aton.c
+    src/port/snprintf.c
+    src/port/crypt.c
+    src/port/memcmp.c
+    src/port/strlcpy.c
+
+  (BSD License) wstrcmp
+    src/backend/utils/mb/wstrcmp.c
+
+  (BSD License) libpq-sha2
+    src/backend/libpq/sha2.[ch]
+
+      licenses/LICENSE-sha2.txtLICENSE-sha2.txt
+
+  (BSD License)
+   src/pl/pljava
+
+      licenses/LICENSE-pljava.txt
+
+  (Perl Artistic License) (exception)
+    src/pl/plperl/ppport.h
+  
+      Pursuant to https://issues.apache.org/jira/browse/LEGAL-79 and
+      PL/Perl's use of a generated header file, we declare this file to
+      be an exception to the Perl Artistic License.  This file is
+      derived from the PostgreSQL code base.
+  
+      For completeness sake, we have provided the Perl Artistic License
+      for the Perl Devel-PPPort module
+      (http://search.cpan.org/~wolfsage/Devel-PPPort-3.32/PPPort.pm).
+      This module was used to generate the src/pl/plperl/ppport.h header
+      file. The license is available:
+  
+         licenses/LICENSE-ppport.txt
+
+  (test-ctype LICENSE)
+    src/test/locale/test-ctype.c
+  
+      licenses/LICENSE-test-ctype.txt
+ 
+  (port-rand LICENSE)
+    src/port/rand.c 
+  
+      licenses/LICENSE-port-rand.txt
+
+  (Internet Systems Consortium/Internet Software Consortium (ISC) LICENSE)
+    
+    src/backend/utils/adt/inet_net_ntop.c
+    src/backend/utils/adt/inet_net_pton.c 
+  
+      licenses/LICENSE-isc.txt
+
+    The following components are provided under the ISC license. See
+    project link for details.  The text of each license is also
+    included at licenses/LICENSE-[project].txt.
+  
+       pexpect-4.2 (https://pypi.python.org/pypi/pexpect/4.2.0)
+         tools/bin/pythonSrc/pexpect-4.2
+  
+       ptyprocess-0.5.1 (https://pypi.python.org/pypi/ptyprocess/0.5.1)
+         tools/bin/pythonSrc/ptyprocess-0.5.1
+
+  (regex LICENSE)
+    src/backend/regex 
+  
+      licenses/LICENSE-regex.txt
+
+  (port-gettimeofday LICENSE)
+    src/port/gettimeofday.c 
+  
+      licenses/LICENSE-port-gettimeofday.txt

--- a/dist/hawq/Makefile
+++ b/dist/hawq/Makefile
@@ -1,0 +1,35 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------------------
+#
+# Makefile for license information of hawq rpm package
+#
+#-------------------------------------------------------------------------
+
+subdir = dist/hawq
+top_builddir = ../..
+include $(top_builddir)/src/Makefile.global
+
+SKIP_INSTALL=.gitignore|.p4ignore|.rcfile|Makefile
+
+all: install
+
+install:
+	for files in `find * -type f -maxdepth 0 | grep -v -E "${SKIP_INSTALL}"`; do ${INSTALL_SCRIPT} $${files} ${DESTDIR}/${prefix}; done
+	mkdir -p ${DESTDIR}/${prefix}/licenses
+	for files in `find ${top_builddir}/licenses/* -type f -maxdepth 0 | grep -v -E "${SKIP_INSTALL}"`; do ${INSTALL_SCRIPT} $${files} ${DESTDIR}/${prefix}/licenses/; done

--- a/dist/hawq/NOTICE
+++ b/dist/hawq/NOTICE
@@ -1,0 +1,35 @@
+Apache HAWQ (incubating) 
+Copyright 2017 The Apache Software Foundation.
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+This project includes software copyrighted by PostgreSQL Global
+Development Group (PostgreSQL 8.2.15) with the following copyright
+notice.  The contents were originally available in the COPYRIGHT file.
+This file has been removed and included here to conform to recommended
+Apache source packaging contents.
+
+  PostgreSQL Database Management System
+  (formerly known as Postgres, then as Postgres95)
+  
+  Portions Copyright (c) 1996-2006, PostgreSQL Global Development Group
+  
+  Portions Copyright (c) 1994, The Regents of the University of California
+  
+  Permission to use, copy, modify, and distribute this software and its
+  documentation for any purpose, without fee, and without a written agreement
+  is hereby granted, provided that the above copyright notice and this
+  paragraph and the following two paragraphs appear in all copies.
+  
+  IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY FOR
+  DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+  LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS
+  DOCUMENTATION, EVEN IF THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE
+  POSSIBILITY OF SUCH DAMAGE.
+  
+  THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+  AND FITNESS FOR A PARTICULAR PURPOSE.  THE SOFTWARE PROVIDED HEREUNDER IS
+  ON AN "AS IS" BASIS, AND THE UNIVERSITY OF CALIFORNIA HAS NO OBLIGATIONS TO
+  PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.


### PR DESCRIPTION
This commit includes:
1. The LICENSE, NOTICE, and DISCLAIMER files for Apache HAWQ c/c++ components for the binary release.
2. The build process to add the LICENSE, NOTICE, and DISCLAIMER files in Apache HAWQ binary package.