### PR TITLE
HAWQ-1485. Fix exception of decryptPassword twice in lookupResource()

### DIFF
--- a/ranger-plugin/admin-plugin/src/main/java/org/apache/hawq/ranger/service/RangerServiceHawq.java
+++ b/ranger-plugin/admin-plugin/src/main/java/org/apache/hawq/ranger/service/RangerServiceHawq.java
@@ -102,6 +102,13 @@ public class RangerServiceHawq extends RangerBaseService {
         return result;
     }
 
+    /**
+     * decrypt password field of configs
+     * Note:
+     *  the decrypted password is set in a new password_jdbc field
+     * @param configs
+     * @throws Exception
+     */
     private void decryptPassword(Map<String, String> configs) throws Exception {
         if (configs.containsKey("password")) {
             String normal_password = configs.get("password");
@@ -112,7 +119,7 @@ public class RangerServiceHawq extends RangerBaseService {
                 // when decrypt failed do nothing
                 LOG.warn("decrypt_password failed: " + e);
             }
-            configs.put("password", normal_password);
+            configs.put("password_jdbc", normal_password);
         }
     }
 


### PR DESCRIPTION
In my earlier PR,  *decryptPassword()* is called in the beginning of *lookupResource()*, but *BaseClient* (in ranger lib) also need decrypt password in some situation, decrypt twice will cause a exception.

This PR fixed this issue. 