### PR TITLE
HAWQ-1458. The maximum value of guc share_input_scan_wait_lockfile_timeout should be greater than the default value.

### DIFF
--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -6693,7 +6693,7 @@ static struct config_int ConfigureNamesInt[] =
 			NULL
 		},
 		&share_input_scan_wait_lockfile_timeout,
-		300000, 1, 65536, NULL, NULL
+		300000, 1, INT_MAX, NULL, NULL
 	},
 
 


### PR DESCRIPTION
fix a bug which cause HAWQ debug version failed in initializing. 