### PR TITLE
HAWQ-1489. Add LICENSE, DISCLAIMER and NOTICE to pxf jar files.

### DIFF
--- a/pxf/build.gradle
+++ b/pxf/build.gradle
@@ -79,6 +79,16 @@ subprojects { subProject ->
             "-Xlint:-fallthrough", "-Xlint:-deprecation", "-Xlint:-unchecked", "-Xlint:-options"
     ]
 
+    // Add LICENSE, DISCLAIMER and NOTICE to generated jar files.
+    sourceSets {
+        main {
+            resources {
+                srcDir '../resources'
+                include '**/*'
+            }
+        }
+    }
+
     repositories {
         // mavenCentral without https:
         maven { url 'http://repo1.maven.org/maven2' }

--- a/pxf/resources/META-INF/DISCLAIMER
+++ b/pxf/resources/META-INF/DISCLAIMER
@@ -1,0 +1,11 @@
+Apache HAWQ is an effort undergoing incubation at the Apache Software
+Foundation (ASF), sponsored by the Apache Incubator PMC.
+
+Incubation is required of all newly accepted projects until a further
+review indicates that the infrastructure, communications, and decision
+making process have stabilized in a manner consistent with other
+successful ASF projects.
+
+While incubation status is not necessarily a reflection of the
+completeness or stability of the code, it does indicate that the
+project has yet to be fully endorsed by the ASF.

--- a/pxf/resources/META-INF/LICENSE
+++ b/pxf/resources/META-INF/LICENSE
@@ -1,0 +1,380 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+=======================================================================
+
+Apache HAWQ (incubating) - contained works supporting PXF components:
+
+This product contains additional works that are distributed under
+Apache License, Version 2.0 (ALv2).
+
+    Apache Tomcat 7.0.62
+
+=======================================================================
+
+Apache HAWQ (incubating) PXF runtime dependent subcomponents:
+
+  The Apache HAWQ (incubating) project contains PXF. It is an
+  extensible framework that allows HAWQ to query external data files,
+  whose metadata is not managed by HAWQ. PXF includes built-in
+  connectors for accessing data that exists inside HDFS files, Hive
+  tables, HBase tables and more. Users can also create their own
+  connectors to other data storages or processing engines. To create
+  these connectors using JAVA plugins, see the PXF API and Reference
+  Guide online.
+
+  The convenience binaries require the following hadoop components are
+  higher:
+
+    hadoop: 2.7.1
+    hadoop-hdfs: 2.7.1
+    hadoop-mapreduce: 2.7.1
+
+  The runtime dependencies (below) are accessed via classpath
+  configurations from the hadoop component distributions. They are not
+  distributed with these convenience binary packages.
+
+    ST4, 4.0.4
+    activation, 1.1
+    ant, 1.9.1
+    ant-launcher, 1.9.1
+    antlr, 2.7.7
+    aopalliance, 1.0
+    apache-curator, 2.6.0
+    apache-log4j-extras, 1.2.17
+    apacheds-i18n, 2.0.0-M15
+    apacheds-kerberos-codec, 2.0.0-M15
+    api-asn1-api, 1.0.0-M20
+    api-util, 1.0.0-M20
+    asm-parent, 3.1
+    avro, 1.7.4
+    avro-ipc, 1.7.4
+    avro-mapred, 1.7.4
+    bonecp, 0.8.0.RELEASE
+    cglib, 2.2.1-v20090111
+    commons-beanutils, 1.7.0
+    commons-beanutils-core, 1.8.0
+    commons-cli, 1.2
+    commons-codec, 1.4
+    commons-collections, 3.2.1
+    commons-compress, 1.4.1
+    commons-configuration, 1.6
+    commons-daemon, 1.0.13
+    commons-dbcp, 1.4
+    commons-digester, 1.8
+    commons-httpclient, 3.1
+    commons-io, 2.4
+    commons-lang, 2.4
+    commons-lang, 2.6
+    commons-logging, 1.1.3
+    commons-math3, 3.1.1
+    commons-net, 3.1
+    commons-pool, 1.5.4
+    curator-client, 2.7.1
+    curator-framework, 2.7.1
+    curator-recipes, 2.7.1
+    datanucleus-api-jdo, 3.2.6
+    datanucleus-core, 3.2.10
+    datanucleus-rdbms, 3.2.9
+    derby, 10.10.2.0
+    findbugs-annotations, 1.3.9-1
+    groovy-all, 2.1.6
+    gson, 2.2.4
+    guava, 16.0.1
+    guice, 3.0
+    guice-servlet, 3.0
+    hadoop-annotations, 2.7.1
+    hadoop-auth, 2.7.1
+    hadoop-common, 2.7.1
+    hadoop-hdfs, 2.7.1
+    hadoop-mapreduce-client-core, 2.5.1
+    hadoop-mapreduce-client-core, 2.7.1
+    hadoop-yarn-api, 2.5.1
+    hadoop-yarn-api, 2.7.1
+    hadoop-yarn-common, 2.5.1
+    hadoop-yarn-common, 2.7.1
+    hadoop-yarn-server-applicationhistoryservice, 2.6.0
+    hadoop-yarn-server-common, 2.6.0
+    hadoop-yarn-server-resourcemanager, 2.6.0
+    hadoop-yarn-server-web-proxy, 2.6.0
+    hamcrest-core, 1.3
+    hbase-annotations, 1.1.2
+    hbase-client, 1.1.2
+    hbase-common, 1.1.2
+    hbase-protocol, 1.1.2
+    hive-ant, 1.2.1
+    hive-common, 1.2.1
+    hive-exec, 1.2.1
+    hive-metastore, 1.2.1
+    hive-serde, 1.2.1
+    hive-shims, 1.2.1
+    hive-shims-0.20S, 1.2.1
+    hive-shims-0.23, 1.2.1
+    hive-shims-common, 1.2.1
+    hive-shims-scheduler, 1.2.1
+    htrace-core, 3.1.0-incubating
+    httpclient, 4.2.5
+    httpcore, 4.2.4
+    ivy, 2.4.0
+    jackson-core-asl, 1.9.13
+    jackson-jaxrs, 1.9.13
+    jackson-mapper-asl, 1.9.13
+    jackson-xc, 1.9.13
+    java-xmlbuilder, 0.4
+    javax.inject, 1
+    jaxb-api, 2.2.2
+    jaxb-impl, 2.2.3-1
+    jcodings, 1.0.8
+    jdo-api, 3.0.1
+    jersey-client, 1.9
+    jersey-core, 1.9
+    jersey-guice, 1.9
+    jersey-json, 1.9
+    jersey-server, 1.9
+    jets3t, 0.9.0
+    jettison, 1.1
+    jetty, 6.1.26
+    jetty-util, 6.1.26
+    jline, 0.9.94
+    jline, 2.12
+    joda-time, 2.5
+    joni, 2.1.2
+    jsch, 0.1.42
+    json, 20090211
+    jsp-api, 2.1
+    jsr305, 3.0.0
+    jta, 1.1
+    junit, 4.11
+    leveldbjni-all, 1.8
+    libfb303, 0.9.2
+    libthrift, 0.9.2
+    log4j, 1.2.17
+    netty, 3.7.0.Final
+    netty-all, 4.0.23.Final
+    opencsv, 2.3
+    oro, 2.0.8
+    oss-parent, 7
+    paranamer, 2.3
+    parquet-hadoop-bundle, 1.6.0
+    protobuf-java, 2.5.0
+    servlet-api, 2.5
+    servlet-api, 2.5-20081211
+    slf4j-api, 1.7.10
+    slf4j-log4j12, 1.7.10
+    snappy-java, 1.0.4.1
+    stax-api, 1.0-2
+    stax-api, 1.0.1
+    stringtemplate, 3.2.1
+    tomcat-annotations-api, 7.0.62
+    tomcat-api, 7.0.62
+    tomcat-catalina, 7.0.62
+    tomcat-juli, 7.0.62
+    tomcat-servlet-api, 7.0.62
+    tomcat-util, 7.0.62
+    velocity, 1.5
+    velocity, 1.7
+    xercesImpl, 2.9.1
+    xml-apis, 1.3.04
+    xmlenc, 0.52
+    xz, 1.0
+    zookeeper, 3.4.6
+    

--- a/pxf/resources/META-INF/NOTICE
+++ b/pxf/resources/META-INF/NOTICE
@@ -1,0 +1,5 @@
+Apache HAWQ (incubating) 
+Copyright 2017 The Apache Software Foundation.
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).


### PR DESCRIPTION
This adds a LICENSE, DISCLAIMER, and NOTICE to each PXF jar file. As the RPMs scatter files about the system. I have not added them as explicit files in the RPM. We can perform this in a separate Jira if needed.

Reviewers: @radarwave @rvs @huor 