### PR TITLE
HAWQ-1499. Update README.md Travis CI status to report only master branch status.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 |CI Process|Status|
 |---|---|
-|Travis CI Build|[![https://travis-ci.org/apache/incubator-hawq.png](https://travis-ci.org/apache/incubator-hawq.png)](https://travis-ci.org/apache/incubator-hawq)|
+|Travis CI Build|[![https://travis-ci.org/apache/incubator-hawq.svg?branch=master](https://travis-ci.org/apache/incubator-hawq.png?branch=master)](https://travis-ci.org/apache/incubator-hawq?branch=master)|
 |Apache Release Audit Tool ([RAT](https://creadur.apache.org/rat/))|[![Rat Status](https://builds.apache.org/buildStatus/icon?job=HAWQ-rat)](https://builds.apache.org/view/HAWQ/job/HAWQ-rat/)|
 |Coverity Static Analysis   |[![Coverity Scan Build](https://scan.coverity.com/projects/apache-incubator-hawq/badge.svg)](https://scan.coverity.com/projects/apache-incubator-hawq)|
 


### PR DESCRIPTION
I noticed the Travis CI build status was reporting a failed status (red) even though the master branch build was good (green). This change only reports the Travis CI master build status.

Reviewer: @radarwave @lavjain @interma 