### PR TITLE
add hawq  start      "userinput.ask_yesno"   

### DIFF
--- a/tools/bin/hawq_ctl
+++ b/tools/bin/hawq_ctl
@@ -1477,6 +1477,9 @@ if __name__ == '__main__':
     (opts, hawq_dict) = get_args()
 
     if opts.hawq_command == 'start':
+        if opts.prompt:
+            if not userinput.ask_yesno(None, "\nContinue with HAWQ service start", 'N'):
+                sys.exit(1)
         start_hawq(opts, hawq_dict)
     elif opts.hawq_command == 'stop':
         if opts.prompt:


### PR DESCRIPTION
**The status quo:**
[hawqdb@docker1 bin]$ hawq start cluster
20170810:16:38:05:031474 hawq_start:docker1:hawqdb-[INFO]:-Prepare to do 'hawq start'
20170810:16:38:05:031474 hawq_start:docker1:hawqdb-[INFO]:-You can find log in:
20170810:16:38:05:031474 hawq_start:docker1:hawqdb-[INFO]:-/home/hawqdb/hawqAdminLogs/hawq_start_20170810.log
20170810:16:38:05:031474 hawq_start:docker1:hawqdb-[INFO]:-GPHOME is set to:
20170810:16:38:05:031474 hawq_start:docker1:hawqdb-[INFO]:-/home/hawqdb/hawq
20170810:16:38:05:031474 hawq_start:docker1:hawqdb-[INFO]:-Start hawq with args: ['start', 'cluster']
20170810:16:38:05:031474 hawq_start:docker1:hawqdb-[INFO]:-Gathering information and validating the environment...
20170810:16:38:05:031474 hawq_start:docker1:hawqdb-[INFO]:-No standby host configured
20170810:16:38:05:031474 hawq_start:docker1:hawqdb-[INFO]:-Start all the nodes in hawq cluster
20170810:16:38:05:031474 hawq_start:docker1:hawqdb-[INFO]:-Starting master node 'docker1.cmss.com'
20170810:16:38:05:031474 hawq_start:docker1:hawqdb-[INFO]:-Start master service
20170810:16:38:07:031474 hawq_start:docker1:hawqdb-[INFO]:-Master started successfully
20170810:16:38:07:031474 hawq_start:docker1:hawqdb-[INFO]:-Start all the segments in hawq cluster
20170810:16:38:07:031474 hawq_start:docker1:hawqdb-[INFO]:-Start segments in list: ['docker4.cmss.com', 'docker5.cmss.com', 'docker2.cmss.com', 'docker3.cmss.com']
20170810:16:38:07:031474 hawq_start:docker1:hawqdb-[INFO]:-Start segment service
20170810:16:38:07:031474 hawq_start:docker1:hawqdb-[INFO]:-Total segment number is: 4
....
20170810:16:38:11:031474 hawq_start:docker1:hawqdb-[INFO]:-4 of 4 segments start successfully
20170810:16:38:11:031474 hawq_start:docker1:hawqdb-[INFO]:-Segments started successfully
20170810:16:38:11:031474 hawq_start:docker1:hawqdb-[INFO]:-HAWQ cluster started successfully
[hawqdb@docker1 bin]$ hawq stop cluster
20170810:16:47:24:003630 hawq_stop:docker1:hawqdb-[INFO]:-Prepare to do 'hawq stop'
20170810:16:47:24:003630 hawq_stop:docker1:hawqdb-[INFO]:-You can find log in:
20170810:16:47:24:003630 hawq_stop:docker1:hawqdb-[INFO]:-/home/hawqdb/hawqAdminLogs/hawq_stop_20170810.log
20170810:16:47:24:003630 hawq_stop:docker1:hawqdb-[INFO]:-GPHOME is set to:
20170810:16:47:24:003630 hawq_stop:docker1:hawqdb-[INFO]:-/home/hawqdb/hawq
20170810:16:47:24:003630 hawq_stop:docker1:hawqdb-[INFO]:-Stop hawq with args: ['stop', 'cluster']

Continue with HAWQ service stop Yy|Nn (default=N):
> y
20170810:16:47:26:003630 hawq_stop:docker1:hawqdb-[INFO]:-No standby host configured
20170810:16:47:26:003630 hawq_stop:docker1:hawqdb-[INFO]:-Stop hawq cluster
20170810:16:47:26:003630 hawq_stop:docker1:hawqdb-[INFO]:-There are 0 connections to the database
20170810:16:47:26:003630 hawq_stop:docker1:hawqdb-[INFO]:-Commencing Master instance shutdown with mode='smart'
20170810:16:47:26:003630 hawq_stop:docker1:hawqdb-[INFO]:-Master host=docker1.cmss.com
20170810:16:47:26:003630 hawq_stop:docker1:hawqdb-[INFO]:-Stop hawq master
20170810:16:47:27:003630 hawq_stop:docker1:hawqdb-[INFO]:-Master stopped successfully
20170810:16:47:27:003630 hawq_stop:docker1:hawqdb-[INFO]:-Stop hawq segment
20170810:16:47:27:003630 hawq_stop:docker1:hawqdb-[INFO]:-Stop segments in list: ['docker4.cmss.com', 'docker5.cmss.com', 'docker2.cmss.com', 'docker3.cmss.com']
20170810:16:47:30:003630 hawq_stop:docker1:hawqdb-[INFO]:-Total segment number is: 4
...
20170810:16:47:33:003630 hawq_stop:docker1:hawqdb-[INFO]:-4 of 4 segments stop successfully
20170810:16:47:33:003630 hawq_stop:docker1:hawqdb-[INFO]:-Segments stopped successfully
20170810:16:47:33:003630 hawq_stop:docker1:hawqdb-[INFO]:-Cluster stopped successfully


**Ther ringht expale:**
[hawqdb@docker1 bin]$ hawq start  cluster
20170810:14:09:52:019805 hawq_start:docker1:hawqdb-[INFO]:-Prepare to do 'hawq start'
20170810:14:09:52:019805 hawq_start:docker1:hawqdb-[INFO]:-You can find log in:
20170810:14:09:52:019805 hawq_start:docker1:hawqdb-[INFO]:-/home/hawqdb/hawqAdminLogs/hawq_start_20170810.log
20170810:14:09:52:019805 hawq_start:docker1:hawqdb-[INFO]:-GPHOME is set to:
20170810:14:09:52:019805 hawq_start:docker1:hawqdb-[INFO]:-/home/hawqdb/hawq
20170810:14:09:52:019805 hawq_start:docker1:hawqdb-[INFO]:-Start hawq with args: ['start', 'cluster']
 
Continue with HAWQ service stop Yy|Nn (default=N):
> y

20170810:14:09:54:019805 hawq_start:docker1:hawqdb-[INFO]:-Gathering information and validating the environment...
20170810:14:09:54:019805 hawq_start:docker1:hawqdb-[INFO]:-No standby host configured
20170810:14:09:54:019805 hawq_start:docker1:hawqdb-[INFO]:-Start all the nodes in hawq cluster
20170810:14:09:54:019805 hawq_start:docker1:hawqdb-[INFO]:-Starting master node 'docker1.cmss.com'
20170810:14:09:54:019805 hawq_start:docker1:hawqdb-[INFO]:-Start master service
20170810:14:09:55:019805 hawq_start:docker1:hawqdb-[INFO]:-Master started successfully
20170810:14:09:55:019805 hawq_start:docker1:hawqdb-[INFO]:-Start all the segments in hawq cluster
20170810:14:09:55:019805 hawq_start:docker1:hawqdb-[INFO]:-Start segments in list: ['docker4.cmss.com', 'docker5.cmss.com', 'docker2.cmss.com', 'docker3.cmss.com']
20170810:14:09:55:019805 hawq_start:docker1:hawqdb-[INFO]:-Start segment service
20170810:14:09:55:019805 hawq_start:docker1:hawqdb-[INFO]:-Total segment number is: 4
.....
20170810:14:10:00:019805 hawq_start:docker1:hawqdb-[INFO]:-4 of 4 segments start successfully
20170810:14:10:00:019805 hawq_start:docker1:hawqdb-[INFO]:-Segments started successfully
20170810:14:10:00:019805 hawq_start:docker1:hawqdb-[INFO]:-HAWQ cluster started successfully


**I modified results:**
[hawqdb@docker1 bin]$ hawq start cluster
20170810:14:09:52:019805 hawq_start:docker1:hawqdb-[INFO]:-Prepare to do 'hawq start'
20170810:14:09:52:019805 hawq_start:docker1:hawqdb-[INFO]:-You can find log in:
20170810:14:09:52:019805 hawq_start:docker1:hawqdb-[INFO]:-/home/hawqdb/hawqAdminLogs/hawq_start_20170810.log
20170810:14:09:52:019805 hawq_start:docker1:hawqdb-[INFO]:-GPHOME is set to:
20170810:14:09:52:019805 hawq_start:docker1:hawqdb-[INFO]:-/home/hawqdb/hawq
20170810:14:09:52:019805 hawq_start:docker1:hawqdb-[INFO]:-Start hawq with args: ['start', 'cluster']

Continue with HAWQ service start Yy|Nn (default=N):
> y

20170810:14:09:54:019805 hawq_start:docker1:hawqdb-[INFO]:-Gathering information and validating the environment...
20170810:14:09:54:019805 hawq_start:docker1:hawqdb-[INFO]:-No standby host configured
20170810:14:09:54:019805 hawq_start:docker1:hawqdb-[INFO]:-Start all the nodes in hawq cluster
20170810:14:09:54:019805 hawq_start:docker1:hawqdb-[INFO]:-Starting master node 'docker1.cmss.com'
20170810:14:09:54:019805 hawq_start:docker1:hawqdb-[INFO]:-Start master service
20170810:14:09:55:019805 hawq_start:docker1:hawqdb-[INFO]:-Master started successfully
20170810:14:09:55:019805 hawq_start:docker1:hawqdb-[INFO]:-Start all the segments in hawq cluster
20170810:14:09:55:019805 hawq_start:docker1:hawqdb-[INFO]:-Start segments in list: ['docker4.cmss.com', 'docker5.cmss.com', 'docker2.cmss.com', 'docker3.cmss.com']
20170810:14:09:55:019805 hawq_start:docker1:hawqdb-[INFO]:-Start segment service
20170810:14:09:55:019805 hawq_start:docker1:hawqdb-[INFO]:-Total segment number is: 4
.....
20170810:14:10:00:019805 hawq_start:docker1:hawqdb-[INFO]:-4 of 4 segments start successfully
20170810:14:10:00:019805 hawq_start:docker1:hawqdb-[INFO]:-Segments started successfully
20170810:14:10:00:019805 hawq_start:docker1:hawqdb-[INFO]:-HAWQ cluster started successfully


[hawqdb@docker1 bin]$ hawq start master
20170810:17:51:30:004694 hawq_start:docker1:hawqdb-[INFO]:-Prepare to do 'hawq start'
20170810:17:51:30:004694 hawq_start:docker1:hawqdb-[INFO]:-You can find log in:
20170810:17:51:30:004694 hawq_start:docker1:hawqdb-[INFO]:-/home/hawqdb/hawqAdminLogs/hawq_start_20170810.log
20170810:17:51:30:004694 hawq_start:docker1:hawqdb-[INFO]:-GPHOME is set to:
20170810:17:51:30:004694 hawq_start:docker1:hawqdb-[INFO]:-/home/hawqdb/hawq
20170810:17:51:30:004694 hawq_start:docker1:hawqdb-[INFO]:-Start hawq with args: ['start', 'master']

Continue with HAWQ service start Yy|Nn (default=N):
> y
20170810:17:51:31:004694 hawq_start:docker1:hawqdb-[INFO]:-Gathering information and validating the environment...
20170810:17:51:31:004694 hawq_start:docker1:hawqdb-[INFO]:-No standby host configured
20170810:17:51:31:004694 hawq_start:docker1:hawqdb-[INFO]:-Start master service
20170810:17:51:33:004694 hawq_start:docker1:hawqdb-[INFO]:-Master started successfully
