### PR TITLE
HAWQ-1498. Segments keep open file descriptors for deleted files

### DIFF
--- a/src/backend/cdb/cdbpersistentfilesysobj.c
+++ b/src/backend/cdb/cdbpersistentfilesysobj.c
@@ -2129,6 +2129,9 @@ void PersistentFileSysObj_EndXactDrop(
 							ignoreNonExistence,
 							Debug_persistent_print,
 							Persistent_DebugPrintLevel());
+
+	// clean up alive connections that are used for deleting hdfs objects
+	cleanup_hdfs_handlers_for_dropping();
 }
 
 void PersistentFileSysObj_UpdateRelationBufpoolKind(

--- a/src/backend/storage/file/fd.c
+++ b/src/backend/storage/file/fd.c
@@ -2489,7 +2489,6 @@ HdfsGetConnection(const char * path, bool isForDrop)
 		}
 		else
 		{
-			elog(LOG, "search 4 drop 1");
 			entry = (struct FsEntry *) hash_search(HdfsFsTable4Drop,
 												   location,
 												   HASH_ENTER,
@@ -2528,7 +2527,6 @@ HdfsGetConnection(const char * path, bool isForDrop)
 						if (!isForDrop)
 							hash_search(HdfsFsTable, location, HASH_REMOVE, &found);
 						else {
-							elog(LOG, "search 4 drop 2");
 							hash_search(HdfsFsTable4Drop, location, HASH_REMOVE, &found);
 						}
 						errno = EACCES;

--- a/src/include/storage/fd.h
+++ b/src/include/storage/fd.h
@@ -113,6 +113,7 @@ extern char *DeserializeDelegationToken(void *binary, int size);
 
 extern void cleanup_lru_opened_files(void);
 extern void cleanup_filesystem_handler(void);
+extern void cleanup_hdfs_handlers_for_dropping(void);
 
 /* abstract file system */
 extern File FileNameOpenFile(FileName fileName, const char *temp_dir, int fileFlags, int fileMode);


### PR DESCRIPTION
The idea is to hold a list of all connections ever used for dropping objects in HDFS, then when the transaction ends, no matter commit or rollback, those connections are forced to close. Those connections cached but never used for dropping, are not touched.