### PR TITLE
HAWQ-1520. Create filespace should also skip hdfs trash directory

### DIFF
--- a/src/backend/commands/filespace.c
+++ b/src/backend/commands/filespace.c
@@ -318,11 +318,10 @@ CreateFileSpace(CreateFileSpaceStmt *stmt)
 	encoded = EncodeFileLocations(stmt->fsysname, fsrep, stmt->location);
 
 	bool existed;
-	if (HdfsPathExistAndNonEmpty(encoded, &existed))
+	if (HdfsPathExistAndNonEmpty(encoded, &existed, true)) /* skip hdfs trash directory */
 		ereport(ERROR, 
 				(errcode_for_file_access(),
 				 errmsg("%s: File exists and non empty", encoded)));
-
 	add_catalog_filespace_entry(rel, fsoid, 0, encoded);
 
 	heap_close(rel, RowExclusiveLock);

--- a/src/include/storage/fd.h
+++ b/src/include/storage/fd.h
@@ -184,7 +184,11 @@ extern size_t GetTempFilePrefix(char * buf, size_t buflen, const char * fileName
 extern bool TestFileValid(File file);
 
 extern bool HdfsPathExist(char *path);
-extern bool HdfsPathExistAndNonEmpty(char *path, bool *existed);
+
+/* hdfs trash direcotry name */
+#define TRASH_DIRECTORY_NAME ".Trash"
+
+extern bool HdfsPathExistAndNonEmpty(char *path, bool *existed, bool skip_trash);
 
 extern int64 HdfsPathSize(const char *path);
 


### PR DESCRIPTION
There is a double check (directory empty) in create space command, so we also skip trash directory here.
My last PR miss it, **very sorry** for it!
