### PR TITLE
HAWQ-1529. Fix segment resource manager hang when postmaster died

### DIFF
--- a/src/backend/resourcemanager/resourcemanager_RMSEG.c
+++ b/src/backend/resourcemanager/resourcemanager_RMSEG.c
@@ -27,6 +27,7 @@
 #include "communication/rmcomm_RMSEG2RM.h"
 #include "resourceenforcer/resourceenforcer.h"
 #include "cdb/cdbtmpdir.h"
+#include "storage/pmsignal.h" /* PostmasterIsAlive */
 
 int ResManagerMainSegment2ndPhase(void)
 {


### PR DESCRIPTION
If PostmasterIsAlive() is under implicit declaration, %eax (32-bits) will be used for comparison rather than %al (8-bits), BUT PostmasterIsAlive() only set the lower 8-bits (because 'bool' is really a 'char'). Then segment resource manager will never exit after postmaster died.