### PR TITLE
HAWQ-1530. Illegally killing a JDBC select query causes locking problems

### DIFF
--- a/src/backend/cdb/dispatcher.c
+++ b/src/backend/cdb/dispatcher.c
@@ -59,6 +59,7 @@
 #include "tcop/pquery.h"			/* PortalGetResource */
 
 #include "resourcemanager/communication/rmcomm_QD2RM.h"
+#include "storage/ipc.h"
 
 /* Define and structure */
 typedef struct DispatchTask
@@ -1414,9 +1415,12 @@ dispatch_cleanup(DispatchData *data)
 	if (dispatcher_is_state_error(data))
 	{
 		/* We cannot unbind executors until we retrieve error message! */
-		dispatch_throw_error(data);
-		Assert(false);
-		return;	/* should not hit */
+		if (!proc_exit_inprogress) {
+			dispatch_throw_error(data);
+			Assert(false);
+			return;	/* should not hit */
+		}
+
 	}
 	
 	dispatch_end_env(data);


### PR DESCRIPTION
This bug root cause maybe twice FATAL error throwing, I cannot exactly reproduce it according to this issue's comment, just based on my understanding and previous bug fix experiences. We cannot allow a FATAL throwed again when anohter FATAL causes process into exit phase.