### PR TITLE
HAWQ-1565. Include Pluggable Storage Format Framework in External Table Scan

### DIFF
--- a/src/include/access/fileam.h
+++ b/src/include/access/fileam.h
@@ -82,17 +82,21 @@ typedef enum DataLineStatus
 	END_MARKER
 } DataLineStatus;
 
-extern FileScanDesc external_beginscan(Relation relation, Index scanrelid,
-								   uint32 scancounter, List *uriList,
-								   List *fmtOpts, char fmtType, bool isMasterOnly,
-								   int rejLimit, bool rejLimitInRows,
-								   Oid fmterrtbl, ResultRelSegFileInfo *segfileinfo, int encoding,
-								   List *scanquals);
+extern FileScanDesc external_beginscan(ExternalScan *extScan,
+                                       Relation currentRelation,
+                                       ResultRelSegFileInfo *segFileInfo,
+                                       int formatterType,
+                                       char *formatterName);
 extern void external_rescan(FileScanDesc scan);
 extern void external_endscan(FileScanDesc scan);
 extern void external_stopscan(FileScanDesc scan);
 extern ExternalSelectDesc external_getnext_init(PlanState *state, ExternalScanState *es_state);
-extern HeapTuple external_getnext(FileScanDesc scan, ScanDirection direction, ExternalSelectDesc desc);
+extern bool external_getnext(FileScanDesc scan,
+                             ScanDirection direction,
+                             ExternalSelectDesc desc,
+                             ScanState *ss,
+                             TupleTableSlot *slot);
+
 extern ExternalInsertDesc external_insert_init(Relation rel, int errAosegno);
 extern Oid external_insert(ExternalInsertDesc extInsertDesc, HeapTuple instup);
 extern void external_insert_finish(ExternalInsertDesc extInsertDesc);


### PR DESCRIPTION
Rewrite the tuple construct and consume work flow to improve the read and write performance in pluggable storage framework. To be specific, it uses virtual tuple in tuple table slot instead of heap tuple between storage and executor to avoid tuple data copy during query processing.

@huor @jiny2 