### PR TITLE
HAWQ-1573. Clear debug_query_string in proc_exit to avoid crash

### DIFF
--- a/src/backend/storage/ipc/ipc.c
+++ b/src/backend/storage/ipc/ipc.c
@@ -24,12 +24,13 @@
 #include <sys/stat.h>
 
 #include "cdb/cdbdisp.h"
+#include "libpq/pqsignal.h"
 #include "miscadmin.h"
 #ifdef PROFILE_PID_DIR
 #include "postmaster/autovacuum.h"
 #endif
 #include "storage/ipc.h"
-#include "libpq/pqsignal.h"
+#include "tcop/tcopprot.h"
 
 /*
  * This flag is set during proc_exit() to change ereport()'s behavior,
@@ -182,6 +183,9 @@ proc_exit_prepare(int code)
 	 * case of elog(FATAL) for example.)
 	 */
 	error_context_stack = NULL;
+
+	/* For the same reason, reset debug_query_string before it's clobbered */
+	debug_query_string = NULL;
 
 	/*
 	* Make sure interconnect thread quit before shmem_exit() in FATAL case.


### PR DESCRIPTION
Backport following commit from PostgreSQL:
    commit e1eb7c81192bec3735eed3228202b400f31c8010
    Author: Tom Lane <tgl@sss.pgh.pa.us>
    Date:   Sat Mar 20 00:58:21 2010 +0000

Report from Xiaowen Zheng <xiaowen.zxw@alibaba-inc.com>