### PR TITLE
HAWQ-1579. fix logging issue with null Metadata

### DIFF
--- a/pxf/pxf-service/src/main/java/org/apache/hawq/pxf/service/FragmentsResponseFormatter.java
+++ b/pxf/pxf-service/src/main/java/org/apache/hawq/pxf/service/FragmentsResponseFormatter.java
@@ -143,8 +143,10 @@ public class FragmentsResponseFormatter {
                 result.append(" ").append(host);
             }
 
-            result.append(", Metadata: ").append(
+            if (fragment.getMetadata() != null) {
+                result.append(", Metadata: ").append(
                     new String(fragment.getMetadata()));
+            }
 
             if (fragment.getUserData() != null) {
                 result.append(", User Data: ").append(


### PR DESCRIPTION
When you enable pxf DEBUG logging you might get annoying exceptions:
```
SEVERE: The RuntimeException could not be mapped to a response, re-throwing to the HTTP container
java.lang.NullPointerException
        at java.lang.String.<init>(String.java:566)
        at org.apache.hawq.pxf.service.FragmentsResponseFormatter.printList(FragmentsResponseFormatter.java:147)
        at org.apache.hawq.pxf.service.FragmentsResponseFormatter.formatResponse(FragmentsResponseFormatter.java:54)
        at org.apache.hawq.pxf.service.rest.FragmenterResource.getFragments(FragmenterResource.java:88)
```
 I just added the trivial fix.