### PR TITLE
HAWQ-1557. Concurrent drop should not report error for drop IF EXISTS.

### DIFF
--- a/src/backend/cdb/cdbsreh.c
+++ b/src/backend/cdb/cdbsreh.c
@@ -298,7 +298,7 @@ void DropErrorTable(CdbSreh *cdbsreh)
 							 RelationGetRelationName(cdbsreh->errtbl), -1);
 
 	/* DROP the relation on the QD */
-	RemoveRelation(errtbl_rv,DROP_RESTRICT, NULL);
+	RemoveRelation(errtbl_rv,DROP_RESTRICT, NULL, RELKIND_RELATION);
 }
 
 /*

--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -151,8 +151,8 @@ DropErrorMsgWrongType(char *relname, char wrongkind, char rightkind)
  * Emit the right error message for a "DROP" command issued on a
  * non-existent relation
  */
-static void
-DropErrorMsgNonExistent(RangeVar *rel, char rightkind, bool missing_ok)
+void
+DropErrorMsgNonExistent(const RangeVar *rel, char rightkind, bool missing_ok)
 {
 	const struct msgstrings *rentry;
 
@@ -582,7 +582,7 @@ ProcessDropStatement(DropStmt *stmt)
 				if (CheckDropPermissions(rel, RELKIND_RELATION,
 										 stmt->missing_ok) &&
 					CheckDropRelStorage(rel, stmt->removeType))
-					RemoveRelation(rel, stmt->behavior, stmt);
+					RemoveRelation(rel, stmt->behavior, stmt, RELKIND_RELATION);
 
 				break;
 
@@ -590,7 +590,7 @@ ProcessDropStatement(DropStmt *stmt)
 				rel = makeRangeVarFromNameList(names);
 				if (CheckDropPermissions(rel, RELKIND_SEQUENCE,
 										 stmt->missing_ok))
-					RemoveRelation(rel, stmt->behavior, stmt);
+					RemoveRelation(rel, stmt->behavior, stmt, RELKIND_SEQUENCE);
 
 				break;
 

--- a/src/include/commands/tablecmds.h
+++ b/src/include/commands/tablecmds.h
@@ -63,7 +63,7 @@ extern void	DefinePartitionedRelation(CreateStmt *stmt, Oid reloid);
 extern void EvaluateDeferredStatements(List *deferredStmts);
 
 extern void RemoveRelation(const RangeVar *relation, DropBehavior behavior,
-						   DropStmt *stmt /* MPP */);
+						   DropStmt *stmt /* MPP */, char relkind);
 
 extern bool RelationToRemoveIsTemp(const RangeVar *relation, DropBehavior behavior);
 

--- a/src/include/tcop/utility.h
+++ b/src/include/tcop/utility.h
@@ -41,4 +41,6 @@ extern bool CommandIsReadOnly(Node *parsetree);
 
 extern void CheckRelationOwnership(Oid relOid, bool noCatalogs);
 
+extern void DropErrorMsgNonExistent(const RangeVar *rel, char rightkind, bool missing_ok);
+
 #endif   /* UTILITY_H */


### PR DESCRIPTION
Concurrent drop should not report error for drop IF EXISTS. The reason is: relation can potential be dropped or altered while waiting to acquire lock, it may happen that the name is no longer valid by the time DROP acquires the lock. In such case, DROP TABLE should look up the name again; if it fails again, we need to unlock the relation as well.
