### PR TITLE
HAWQ-1582. hawq ssh cmd bug when pipe in cmd

### DIFF
--- a/tools/bin/hawq
+++ b/tools/bin/hawq
@@ -90,7 +90,12 @@ def main():
         if hawq_command == 'ssh-exkeys' and '-p' in sub_args_list:
             password_index = sub_args_list.index('-p') + 1
             if len(sub_args_list) > password_index:
-              sub_args_list[password_index] = json.dumps(sub_args_list[password_index])
+                sub_args_list[password_index] = json.dumps(sub_args_list[password_index])
+
+        for index, arg in enumerate(sub_args_list):
+            if " " in arg:
+                sub_args_list[index] = '"%s"' % arg
+
         sub_args = " ".join(sub_args_list)
     elif len(sys.argv) > 1:
         hawq_command = sys.argv[1]


### PR DESCRIPTION
# Bug description
[HAWQ-1582](https://issues.apache.org/jira/browse/HAWQ-1582)

# Bug reason
https://github.com/apache/incubator-hawq/blob/037be68ffacdac09dbecef22951ffa97bd9acb4a/tools/bin/hawq#L94
Joining all arguments with space raises this bug when there is space in a argument. For example, argument`'ls -1 | wc -l'` becomes several arguments `'ls', '-1', '|', 'wc', '-l'`, which are feed into `subprocess.Popen`
https://github.com/apache/incubator-hawq/blob/037be68ffacdac09dbecef22951ffa97bd9acb4a/tools/bin/hawq#L41
For example, when executing `hawk ssh -h localhost -e 'ls -1 | wc -l'`, the `gpssh -h localhost -e ls -1 | wc -l` is feed into `subprocess.Popen` as cmd, while cmd is expected to be `gpssh -h localhost -e 'ls -1 | wc -l'`.

# How I fix it
[commit](https://github.com/YoungForest/incubator-hawq/commit/9ce5be82dcab0c53ab848178e1b4d8ec99a91a2e)
Not just join arguments with space simply, while keep its integrity when the argument has space in it.

Fix result:
``` bash
hawq ssh -h sdw2 -h localhost -e 'ls -1 | wc -l'
``` 
gets expected result.

``` bash
hawq ssh -h sdw2 -h localhost -e 'kill -9 \$(pgrep lava)'
```
gets expected result too after adding escape before `$`.
