### PR TITLE
HAWQ-1514. TDE feature makes libhdfs3 require openssl1.1

### DIFF
--- a/configure
+++ b/configure
@@ -9457,6 +9457,60 @@ fi
   fi
 fi
 
+#Check specific openssl for libhdfs used --wwang
+#Choose the default hdfs dependency prefix
+hdfs_default_dependency=${HDFS_DEPENDENCY_INSTALL_PREFIX}
+
+if [ x"${hdfs_default_dependency}" = x"" ]; then
+    hdfs_default_dependency="/opt/dependency"
+fi
+
+ac_check_lib_save_LIBS=$LIBS
+ac_check_save_cppflag=$CPPFLAGS
+ac_check_save_ldflag=$LDFLAGS
+
+CPPFLAGS="-I$hdfs_default_dependency/include $CPPFLAGS"
+LDFLAGS="-L$hdfs_default_dependency/lib $LDFLAGS"
+LIBS="-lcrypto $LIBS"
+
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+  /* end confdefs.h.  */
+
+  /* Override any GCC internal prototype to avoid an error.
+     Use char because int might match the return type of a GCC
+     builtin and then its argument prototype would still apply.  */
+  #ifdef __cplusplus
+  extern "C"
+  #endif
+  char EVP_aes_256_ctr();
+  int
+  main ()
+  {
+  return EVP_aes_256_ctr();
+    ;
+    return 0;
+  }
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  has_evp=yes
+else
+  has_evp=no
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+
+if test "x$has_evp" = xno; then :
+	as_fn_error $? "function 'EVP_aes_256_ctr' in library 'crypto' is required for OpenSSL. 
+Check config.log for details. It is possible the compiler isn't looking in the proper directory. 
+export HDFS_DEPENDENCY_INSTALL_PREFIX environment variable to indicate hdfs dependent openssl path" "$LINENO" 5
+fi
+
+
+LIBS=$ac_check_lib_save_LIBS
+CPPFLAGS=$ac_check_save_cppflag
+LDFLAGS=$ac_check_save_ldflag
+#Check libhdfs end
+
 if test "$with_openssl" = yes ; then
     if test "$PORTNAME" == "darwin"; then
 	LDFLAGS = "$LDFLAGS -L/usr/local/opt/openssl/lib"

--- a/configure
+++ b/configure
@@ -9457,60 +9457,6 @@ fi
   fi
 fi
 
-#Check specific openssl for libhdfs used --wwang
-#Choose the default hdfs dependency prefix
-hdfs_default_dependency=${HDFS_DEPENDENCY_INSTALL_PREFIX}
-
-if [ x"${hdfs_default_dependency}" = x"" ]; then
-    hdfs_default_dependency="/opt/dependency"
-fi
-
-ac_check_lib_save_LIBS=$LIBS
-ac_check_save_cppflag=$CPPFLAGS
-ac_check_save_ldflag=$LDFLAGS
-
-CPPFLAGS="-I$hdfs_default_dependency/include $CPPFLAGS"
-LDFLAGS="-L$hdfs_default_dependency/lib $LDFLAGS"
-LIBS="-lcrypto $LIBS"
-
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-  /* end confdefs.h.  */
-
-  /* Override any GCC internal prototype to avoid an error.
-     Use char because int might match the return type of a GCC
-     builtin and then its argument prototype would still apply.  */
-  #ifdef __cplusplus
-  extern "C"
-  #endif
-  char EVP_aes_256_ctr();
-  int
-  main ()
-  {
-  return EVP_aes_256_ctr();
-    ;
-    return 0;
-  }
-_ACEOF
-if ac_fn_c_try_link "$LINENO"; then :
-  has_evp=yes
-else
-  has_evp=no
-fi
-rm -f core conftest.err conftest.$ac_objext \
-    conftest$ac_exeext conftest.$ac_ext
-
-if test "x$has_evp" = xno; then :
-	as_fn_error $? "function 'EVP_aes_256_ctr' in library 'crypto' is required for OpenSSL. 
-Check config.log for details. It is possible the compiler isn't looking in the proper directory. 
-export HDFS_DEPENDENCY_INSTALL_PREFIX environment variable to indicate hdfs dependent openssl path" "$LINENO" 5
-fi
-
-
-LIBS=$ac_check_lib_save_LIBS
-CPPFLAGS=$ac_check_save_cppflag
-LDFLAGS=$ac_check_save_ldflag
-#Check libhdfs end
-
 if test "$with_openssl" = yes ; then
     if test "$PORTNAME" == "darwin"; then
 	LDFLAGS = "$LDFLAGS -L/usr/local/opt/openssl/lib"
@@ -11279,6 +11225,82 @@ fi
 done
 
 fi
+
+BACKUPCPPFLAG=${CPPFLAGS}
+BACKUPLDFLAG=${LDFLAGS}
+
+if test "$PORTNAME" == "darwin"; then
+    CPPFLAGS="-I/usr/local/opt/openssl/include $CPPFLAGS"
+    LDFLAGS="-L/usr/local/opt/openssl/lib $LDFLAGS"
+fi
+
+if test x"${DEPENDENCY_INSTALL_PREFIX}" == x""; then
+    CPPFLAGS="-I${DEPENDENCY_INSTALL_PREFIX}/include $CPPFLAGS"
+    LDFLAGS="-L${DEPENDENCY_INSTALL_PREFIX}/lib $LDFLAGS"
+fi
+
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing EVP_aes_256_ctr" >&5
+$as_echo_n "checking for library containing EVP_aes_256_ctr... " >&6; }
+if ${ac_cv_search_EVP_aes_256_ctr+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_func_search_save_LIBS=$LIBS
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+/* Override any GCC internal prototype to avoid an error.
+   Use char because int might match the return type of a GCC
+   builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char EVP_aes_256_ctr ();
+int
+main ()
+{
+return EVP_aes_256_ctr ();
+  ;
+  return 0;
+}
+_ACEOF
+for ac_lib in '' crypto; do
+  if test -z "$ac_lib"; then
+    ac_res="none required"
+  else
+    ac_res=-l$ac_lib
+    LIBS="-l$ac_lib  $ac_func_search_save_LIBS"
+  fi
+  if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_search_EVP_aes_256_ctr=$ac_res
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext
+  if ${ac_cv_search_EVP_aes_256_ctr+:} false; then :
+  break
+fi
+done
+if ${ac_cv_search_EVP_aes_256_ctr+:} false; then :
+
+else
+  ac_cv_search_EVP_aes_256_ctr=no
+fi
+rm conftest.$ac_ext
+LIBS=$ac_func_search_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_EVP_aes_256_ctr" >&5
+$as_echo "$ac_cv_search_EVP_aes_256_ctr" >&6; }
+ac_res=$ac_cv_search_EVP_aes_256_ctr
+if test "$ac_res" != no; then :
+  test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
+
+else
+  as_fn_error $? "function 'EVP_aes_256_ctr' in library 'openssl' is required by libhdfs3.You can export HDFS_DEPENDENCY_INSTALL_PREFIX as custom path.
+Check config.log for details. It is possible the compiler isn't looking in the proper directory." "$LINENO" 5
+fi
+
+
+CPPFLAGS=${BACKUPCPPFLAG}
+LDFLAGS=${BACKUPLDFLAG}
 
 if test "$with_pam" = yes ; then
   for ac_header in security/pam_appl.h

--- a/configure
+++ b/configure
@@ -11234,7 +11234,7 @@ if test "$PORTNAME" == "darwin"; then
     LDFLAGS="-L/usr/local/opt/openssl/lib $LDFLAGS"
 fi
 
-if test x"${DEPENDENCY_INSTALL_PREFIX}" == x""; then
+if test ! x"${DEPENDENCY_INSTALL_PREFIX}" == x""; then
     CPPFLAGS="-I${DEPENDENCY_INSTALL_PREFIX}/include $CPPFLAGS"
     LDFLAGS="-L${DEPENDENCY_INSTALL_PREFIX}/lib $LDFLAGS"
 fi
@@ -11294,7 +11294,7 @@ if test "$ac_res" != no; then :
   test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
 
 else
-  as_fn_error $? "function 'EVP_aes_256_ctr' in library 'openssl' is required by libhdfs3.You can export HDFS_DEPENDENCY_INSTALL_PREFIX as custom path.
+  as_fn_error $? "function 'EVP_aes_256_ctr' in library 'openssl' is required by libhdfs3.You can export DEPENDENCY_INSTALL_PREFIX as custom path.
 Check config.log for details. It is possible the compiler isn't looking in the proper directory." "$LINENO" 5
 fi
 

--- a/configure.in
+++ b/configure.in
@@ -1333,12 +1333,12 @@ if test "$PORTNAME" == "darwin"; then
     LDFLAGS="-L/usr/local/opt/openssl/lib $LDFLAGS"
 fi
 
-if test x"${DEPENDENCY_INSTALL_PREFIX}" == x""; then
+if test ! x"${DEPENDENCY_INSTALL_PREFIX}" == x""; then
     CPPFLAGS="-I${DEPENDENCY_INSTALL_PREFIX}/include $CPPFLAGS"
     LDFLAGS="-L${DEPENDENCY_INSTALL_PREFIX}/lib $LDFLAGS"
 fi
 
-AC_SEARCH_LIBS(EVP_aes_256_ctr,crypto, [], [AC_MSG_ERROR([function 'EVP_aes_256_ctr' in library 'openssl' is required by libhdfs3.You can export HDFS_DEPENDENCY_INSTALL_PREFIX as custom path.
+AC_SEARCH_LIBS(EVP_aes_256_ctr,crypto, [], [AC_MSG_ERROR([function 'EVP_aes_256_ctr' in library 'openssl' is required by libhdfs3.You can export DEPENDENCY_INSTALL_PREFIX as custom path.
 Check config.log for details. It is possible the compiler isn't looking in the proper directory.])])
 
 CPPFLAGS=${BACKUPCPPFLAG}

--- a/configure.in
+++ b/configure.in
@@ -1325,6 +1325,25 @@ Don't use --with-openssl if you don't want to the OpenSSL support.])])
   AC_CHECK_FUNCS([ERR_set_mark])
 fi
 
+BACKUPCPPFLAG=${CPPFLAGS}
+BACKUPLDFLAG=${LDFLAGS}
+
+if test "$PORTNAME" == "darwin"; then
+    CPPFLAGS="-I/usr/local/opt/openssl/include $CPPFLAGS"
+    LDFLAGS="-L/usr/local/opt/openssl/lib $LDFLAGS"
+fi
+
+if test x"${DEPENDENCY_INSTALL_PREFIX}" == x""; then
+    CPPFLAGS="-I${DEPENDENCY_INSTALL_PREFIX}/include $CPPFLAGS"
+    LDFLAGS="-L${DEPENDENCY_INSTALL_PREFIX}/lib $LDFLAGS"
+fi
+
+AC_SEARCH_LIBS(EVP_aes_256_ctr,crypto, [], [AC_MSG_ERROR([function 'EVP_aes_256_ctr' in library 'openssl' is required by libhdfs3.You can export HDFS_DEPENDENCY_INSTALL_PREFIX as custom path.
+Check config.log for details. It is possible the compiler isn't looking in the proper directory.])])
+
+CPPFLAGS=${BACKUPCPPFLAG}
+LDFLAGS=${BACKUPLDFLAG}
+
 if test "$with_pam" = yes ; then
   AC_CHECK_HEADERS(security/pam_appl.h, [],
                    [AC_CHECK_HEADERS(pam/pam_appl.h, [],

--- a/depends/libhdfs3/bootstrap
+++ b/depends/libhdfs3/bootstrap
@@ -32,7 +32,7 @@ binary_dir=`pwd`
 default_prefix=${source_dir}/dist
 
 # Choose the default dependency install prefix
-default_dependency=${DEPENDENCY_INSTALL_PREFIX}
+default_dependency=${HDFS_DEPENDENCY_INSTALL_PREFIX}
 
 if [ x"${default_dependency}" = x"" ]; then
     default_dependency="/opt/dependency"

--- a/depends/libhdfs3/bootstrap
+++ b/depends/libhdfs3/bootstrap
@@ -32,7 +32,7 @@ binary_dir=`pwd`
 default_prefix=${source_dir}/dist
 
 # Choose the default dependency install prefix
-default_dependency=${HDFS_DEPENDENCY_INSTALL_PREFIX}
+default_prefix=${DEPENDENCY_INSTALL_PREFIX}
 
 if [ x"${default_dependency}" = x"" ]; then
     default_dependency="/opt/dependency"

--- a/depends/libhdfs3/bootstrap
+++ b/depends/libhdfs3/bootstrap
@@ -32,7 +32,7 @@ binary_dir=`pwd`
 default_prefix=${source_dir}/dist
 
 # Choose the default dependency install prefix
-default_prefix=${DEPENDENCY_INSTALL_PREFIX}
+default_dependency=${DEPENDENCY_INSTALL_PREFIX}
 
 if [ x"${default_dependency}" = x"" ]; then
     default_dependency="/opt/dependency"


### PR DESCRIPTION
1. use environment HDFS_DEPENDENCY_INSTALL_PREFIX to indicate "libhdfs" used openssl path
2. do function check before HAWQ compilation in configure file