### PR TITLE
HAWQ-1587. Fix metadata parameters handling in PXF

### DIFF
--- a/pxf/pxf-service/src/main/java/org/apache/hawq/pxf/service/utilities/ProtocolData.java
+++ b/pxf/pxf-service/src/main/java/org/apache/hawq/pxf/service/utilities/ProtocolData.java
@@ -179,7 +179,7 @@ public class ProtocolData extends InputData {
         requestParametersMap = paramsMap;
         profile = profileString;
         setProfilePlugins();
-        metadata = getProperty("METADATA");
+        metadata = getUserProperty("METADATA");
 
         /* Kerberos token information */
         if (UserGroupInformation.isSecurityEnabled()) {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HAWQ-1581 separated the system params from the user param.s. installcheck-good reports the following error which is due to the incorrect handling of the METADATA property in the PXF server