### PR TITLE
HAWQ-1593. Vectorized execution condition check in plan tree

### DIFF
--- a/contrib/vexecutor/vcheck.c
+++ b/contrib/vexecutor/vcheck.c
@@ -159,13 +159,18 @@ CheckVectorizedExpression(Node *node, VectorizedContext *ctx)
 
 		voper = (Form_pg_operator)GETSTRUCT(tuple);
 		if(voper->oprresult != rettype)
+		{
+			ReleaseOperator(tuple);
 			return true;
+		}
 
 		if(ctx->replace)
 		{
 			op->opresulttype = rettype;
 			op->opfuncid = voper->oprcode;
 		}
+
+		ReleaseOperator(tuple);
 
 		ctx->retType = rettype;
 		return false;

--- a/contrib/vexecutor/vcheck.c
+++ b/contrib/vexecutor/vcheck.c
@@ -19,13 +19,19 @@
 
 #include "postgres.h"
 #include "access/htup.h"
+#include "catalog/catquery.h"
 #include "catalog/pg_operator.h"
 #include "cdb/cdbappendonlyam.h"
 #include "cdb/cdbllize.h"
 #include "parser/parse_oper.h"
+#include "nodes/makefuncs.h"
+#include "nodes/primnodes.h"
+#include "nodes/plannodes.h"
+#include "nodes/relation.h"
+#include "optimizer/walkers.h"
 #include "utils/lsyscache.h"
 #include "vcheck.h"
-#include "catalog/catquery.h"
+#include "vadt.h"
 
 
 static const vFuncMap funcMap[] = {
@@ -54,7 +60,259 @@ typedef struct VecFuncHashEntry
     vFuncMap *vFunc;
 } VecFuncHashEntry;
 
+typedef struct VecTypeHashEntry
+{
+	Oid src;
+	Oid dest;
+}VecTypeHashEntry;
 
+/* Map between the vectorized types and non-vectorized types */
+static HTAB *hashMapN2V = NULL;
+
+/*
+ * We check the expressions tree recursively becuase the args can be a sub expression,
+ * we must check the return type of sub expression to fit the parent expressions.
+ * so the retType in Vectorized is a temporary values, after we check on expression,
+ * we set the retType of this expression, and transfer this value to his parent.
+ */
+typedef struct VectorizedContext
+{
+	plan_tree_base_prefix base; /* Required prefix for plan_tree_walker/mutator */
+	Oid retType;
+	bool	 replace;
+}VectorizedContext;
+
+/*
+ * Check all the expressions if they can be vectorized
+ * NOTE: if an expressions is vectorized, we return false...,because we should check
+ * all the expressions in the Plan node, if we return true, then the walker will be
+ * over...
+ */
+static bool
+CheckVectorizedExpression(Node *node, VectorizedContext *ctx)
+{
+    if(NULL == node)
+        return false;
+
+    if(is_plan_node(node))
+        return false;
+
+    //check the type of Var if it can be vectorized
+    if(IsA(node, Var))
+    {
+        Var *var = (Var*)node;
+        Oid vtype = GetVtype(var->vartype);
+        if(InvalidOid == vtype)
+        	    return true;
+        ctx->retType = vtype;
+        if(ctx->replace)
+        	    var->vartype = vtype;
+        return false;
+    }
+
+    //Const treat as can be vectorzied, its return type is non-vectorized type
+    //because we support the function like this: vtype op(vtype, const);
+    if(IsA(node, Const))
+    {
+    	    Const *c = (Const*)node;
+    	    ctx->retType = c->consttype;
+    	    return false;
+    }
+
+    //OpExpr:args, return types should can be vectorized,
+    //and there must exists an vectorized function to implement the operator
+    if(IsA(node, OpExpr))
+    {
+        OpExpr *op = (OpExpr*)node;
+        Node *argnode = NULL;
+        Oid ltype, rtype, rettype;
+        Form_pg_operator voper;
+        HeapTuple tuple;
+
+        //OpExpr mostly have two args, check the first one
+        argnode = linitial(op->args);
+        if(CheckVectorizedExpression(argnode, ctx))
+        	    return true;
+
+        ltype = ctx->retType;
+
+        //check the second one
+        argnode = lsecond(op->args);
+        if(CheckVectorizedExpression(argnode, ctx))
+        	    return true;
+
+        rtype = ctx->retType;
+
+        //check the return type
+        rettype = GetVtype(op->opresulttype);
+        if(InvalidOid == rettype)
+        	    return true;
+
+
+        //get the vectorized operator functions
+        //NOTE:we have no ParseState now, Give the NULL value is OK but not good...
+        tuple = oper(NULL, list_make1(makeString(get_opname(op->opno))),
+        				ltype, rtype, false, -1);
+        if(NULL == tuple)
+        	    return true;
+
+        voper = (Form_pg_operator)GETSTRUCT(tuple);
+        if(voper->oprresult != rettype)
+        	    return true;
+
+        if(ctx->replace)
+        {
+        	    op->opresulttype = rettype;
+        	    op->opfuncid = voper->oprcode;
+        }
+
+        ctx->retType = rettype;
+        return false;
+    }
+
+    //now, other nodes treat as can not be vectorized
+    return plan_tree_walker(node, CheckVectorizedExpression, ctx);;
+}
+
+/*
+ * check an plan node, all the expressions in it should be checked
+ * set the flag if an plan node can be vectorized
+ */
+static bool
+CheckPlanNodeWalker(PlannerInfo *root, Plan *plan)
+{
+	VectorizedContext ctx;
+
+    if(plan->vectorized)
+    	    return true;
+
+    ctx.replace =false;
+
+    ctx.retType = InvalidOid;
+    plan->vectorized = !plan_tree_walker((Node*)plan,
+    							 CheckVectorizedExpression,
+							 &ctx);
+
+    return false;
+}
+
+/*
+ * check the plan tree
+ */
+Plan*
+CheckPlanVectorzied(PlannerInfo *root, Plan *plan)
+{
+    if(NULL == plan)
+        return plan;
+
+    CheckPlanVectorzied(root, plan->lefttree);
+    CheckPlanVectorzied(root, plan->righttree);
+    CheckPlanNodeWalker(root, plan);
+
+    return plan;
+}
+
+/*
+ * Replace the non-vectorirzed type to vectorized type
+ */
+static bool
+ReplacePlanNodeWalker(Plan *plan)
+{
+	VectorizedContext ctx;
+	bool beVec = false;
+
+    ctx.replace =true;
+
+    ctx.retType = InvalidOid;
+    plan_tree_walker((Node*)plan,
+    					CheckVectorizedExpression,
+					&ctx);
+
+
+    return false;
+}
+
+/*
+ * check the plan tree
+ */
+Plan*
+ReplacePlanVectorzied(Plan *plan)
+{
+    if(NULL == plan)
+        return plan;
+
+    if(!plan->vectorized)
+    		return plan;
+
+    ReplacePlanNodeWalker(root, plan);
+
+    return plan;
+}
+
+/*
+ * map non-vectorized type to vectorized type.
+ * To scan the PG_TYPE is inefficient, so we create a hashtable to map
+ * the vectorized type and non-vectorized types.
+ */
+Oid GetVtype(Oid ntype)
+{
+    HeapTuple tuple;
+	cqContext *pcqCtx;
+	Oid vtype;
+	VecTypeHashEntry *entry = NULL;
+	bool found = false;
+
+	//construct the hash table
+	if(NULL == hashMapV2N)
+	{
+		HASHCTL	hash_ctl;
+		MemSet(&hash_ctl, 0, sizeof(hash_ctl));
+
+		hash_ctl.keysize = sizeof(Oid);
+		hash_ctl.entrysize = sizeof(VecTypeHashEntry);
+		hash_ctl.hash = oid_hash;
+
+		hashMapV2N = hash_create("vectorized_v2n", 64/*enough?*/,
+								&hash_ctl, HASH_ELEM | HASH_FUNCTION);
+	}
+
+	//first, find the vectorized type in hash table
+	entry = hash_search(hashMapV2N, &ntype, HASH_ENTER, &found);
+	if(found)
+		return entry->dest;
+
+	Assert(!found);
+
+	//Second, if it can not be found in hash table, find in PG_TYPE
+	pcqCtx = caql_beginscan(NULL,
+							cql("SELECT * FROM pg_type "
+								" WHERE typelem = :1 "
+								" AND typstorage = :2 ",
+								ObjectIdGetDatum(ntype),
+								CharGetDatum('e')));
+
+	tuple = caql_getnext(pcqCtx);
+
+	if(!HeapTupleIsValid(tuple))
+	{
+		caql_endscan(pcqCtx);
+		entry->dest = InvalidOid; /* storage the InvalidOid in hash table*/
+		return InvalidOid;
+	}
+
+    vtype = HeapTupleGetOid(tuple);
+
+    //storage in the hash table
+    entry->dest = vtype;
+
+	caql_endscan(pcqCtx);
+
+	return DatumGetObjectId(vtype);
+}
+
+/*
+ * Get the functions for the vectorized types
+ */
 const vFuncMap* GetVFunc(Oid vtype){
 	HeapTuple tuple;
 	bool isNull = true;
@@ -108,3 +366,4 @@ const vFuncMap* GetVFunc(Oid vtype){
 
 	return entry->vFunc ;
 }
+

--- a/contrib/vexecutor/vcheck.h
+++ b/contrib/vexecutor/vcheck.h
@@ -21,6 +21,7 @@
 #define VCHECK_H
 
 #include "vadt.h"
+#include "nodes/execnodes.h"
 typedef struct vFuncMap
 {
     Oid ntype;
@@ -31,9 +32,16 @@ typedef struct vFuncMap
     Datum (*deserialization)(unsigned char* buf,size_t* len);
 }vFuncMap;
 
+/* vectorized executor state */
+typedef struct VectorizedState
+{
+	bool vectorized;
+	PlanState *parent;
+}VectorizedState;
+
+
 extern const vFuncMap* GetVFunc(Oid vtype);
-extern Plan* CheckPlanVectorzied(PlannerInfo *root, Plan *plan);
-extern Plan* ReplacePlanVectorzied(PlannerInfo *root, Plan *plan);
+extern Plan* CheckAndReplacePlanVectorized(PlannerInfo *root, Plan *plan);
 extern Oid GetVtype(Oid ntype);
 
 #endif

--- a/contrib/vexecutor/vcheck.h
+++ b/contrib/vexecutor/vcheck.h
@@ -30,5 +30,10 @@ typedef struct vFuncMap
     size_t (*serialization)(vheader* vh, unsigned char* buf);
     Datum (*deserialization)(unsigned char* buf,size_t* len);
 }vFuncMap;
+
 extern const vFuncMap* GetVFunc(Oid vtype);
+extern Plan* CheckPlanVectorzied(PlannerInfo *root, Plan *plan);
+extern Plan* ReplacePlanVectorzied(PlannerInfo *root, Plan *plan);
+extern Oid GetVtype(Oid ntype);
+
 #endif

--- a/contrib/vexecutor/vexecutor.c
+++ b/contrib/vexecutor/vexecutor.c
@@ -39,6 +39,7 @@ void
 _PG_init(void)
 {
 	elog(DEBUG3, "PG INIT VEXECTOR");
+	vmthd.CheckPlanVectorized_Hook = CheckPlanVectorzied;
 	vmthd.ExecInitNode_Hook = VExecInitNode;
 	vmthd.ExecProcNode_Hook = VExecProcNode;
 	vmthd.ExecEndNode_Hook = VExecEndNode;
@@ -58,6 +59,7 @@ void
 _PG_fini(void)
 {
 	elog(DEBUG3, "PG FINI VEXECTOR");
+	vmthd.CheckPlanVectorized_Hook = NULL;
 	vmthd.ExecInitNode_Hook = NULL;
 	vmthd.ExecProcNode_Hook = NULL;
 	vmthd.ExecEndNode_Hook = NULL;

--- a/contrib/vexecutor/vexecutor.c
+++ b/contrib/vexecutor/vexecutor.c
@@ -20,13 +20,14 @@
 
 #include "vexecutor.h"
 #include "utils/guc.h"
+#include "vcheck.h"
 
 PG_MODULE_MAGIC;
 
 /*
  * hook function
  */
-static PlanState* VExecInitNode(Plan *node,EState *eState,int eflags);
+static PlanState* VExecInitNode(PlanState *node,EState *eState,int eflags);
 static TupleTableSlot* VExecProcNode(PlanState *node);
 static bool VExecEndNode(PlanState *node);
 
@@ -39,7 +40,7 @@ void
 _PG_init(void)
 {
 	elog(DEBUG3, "PG INIT VEXECTOR");
-	vmthd.CheckPlanVectorized_Hook = CheckPlanVectorzied;
+	vmthd.CheckPlanVectorized_Hook = CheckAndReplacePlanVectorized;
 	vmthd.ExecInitNode_Hook = VExecInitNode;
 	vmthd.ExecProcNode_Hook = VExecProcNode;
 	vmthd.ExecEndNode_Hook = VExecEndNode;
@@ -65,10 +66,40 @@ _PG_fini(void)
 	vmthd.ExecEndNode_Hook = NULL;
 }
 
-static PlanState* VExecInitNode(Plan *node,EState *eState,int eflags)
+static PlanState* VExecInitNode(PlanState *node,EState *eState,int eflags)
 {
+	Plan *plan = node->plan;
+	PlanState *subState = NULL;
+	VectorizedState *vstate = (VectorizedState*)palloc0(sizeof(VectorizedState));
+
+	if(NULL == node)
+		return node;
+
+	/* set state */
+	node->vectorized = (void*)vstate;
+
+	vstate->vectorized = plan->vectorized;
+
+	/* set the parent state of son */
+	if(innerPlanState(node))
+	{
+		subState = innerPlanState(node);
+		Assert(NULL != subState);
+
+		((VectorizedState*)(subState->vectorized))->parent = node;
+	}
+	if(outerPlanState(node))
+	{
+		subState = outerPlanState(node);
+		Assert(NULL != subState);
+
+		((VectorizedState*)(subState->vectorized))->parent = node;
+	}
+
+	//***TODO:process the vectorized execution operators here
+
 	elog(DEBUG3, "PG VEXEC INIT NODE");
-	return NULL;
+	return node;
 }
 static TupleTableSlot* VExecProcNode(PlanState *node)
 {
@@ -79,4 +110,24 @@ static bool VExecEndNode(PlanState *node)
 {
 	elog(DEBUG3, "PG VEXEC END NODE");
 	return false;
+}
+
+/* check if there is an vectorized execution operator */
+bool
+HasVecExecOprator(NodeTag tag)
+{
+	bool result = false;
+
+	switch(tag)
+	{
+	case T_AppendOnlyScan:
+	case T_ParquetScan:
+		result = true;
+		break;
+	default:
+		result = false;
+		break;
+	}
+
+	return result;
 }

--- a/contrib/vexecutor/vexecutor.h
+++ b/contrib/vexecutor/vexecutor.h
@@ -29,4 +29,6 @@
 extern void _PG_init(void);
 extern void _PG_fini(void);
 
+extern bool HasVecExecOprator(NodeTag tag);
+
 #endif

--- a/src/backend/commands/explain.c
+++ b/src/backend/commands/explain.c
@@ -1332,6 +1332,9 @@ explain_outNode(StringInfo str,
 			break;
 	}
 
+	if(plan->vectorized)
+		appendStringInfoString(str, "vectorized ");
+
 	appendStringInfoString(str, pname);
 	switch (nodeTag(plan))
 	{

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -145,6 +145,7 @@ CopyPlanFields(Plan *from, Plan *newnode)
 	COPY_SCALAR_FIELD(directDispatch.isDirectDispatch);
 	COPY_NODE_FIELD(directDispatch.contentIds);
 	COPY_SCALAR_FIELD(operatorMemKB);
+	COPY_SCALAR_FIELD(vectorized);
 
 }
 

--- a/src/backend/nodes/outfast.c
+++ b/src/backend/nodes/outfast.c
@@ -376,6 +376,7 @@ _outPlanInfo(StringInfo str, Plan *node)
 	{
 		WRITE_UINT64_FIELD(operatorMemKB);
 	}
+	WRITE_BOOL_FIELD(vectorized);
 }
 
 /*

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -3815,6 +3815,7 @@ void readPlanInfo(const char ** str, Plan *local_node)
     READ_NODE_FIELD(initPlan);
     
     READ_UINT64_FIELD(operatorMemKB);
+    READ_BOOL_FIELD(vectorized);
 }
 
 void readJoinInfo(const char ** str, Join *local_node)

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -820,6 +820,11 @@ standard_planner(Query *parse, int cursorOptions, ParamListInfo boundParams)
 
 	top_plan = zap_trivial_result(root, top_plan);
 
+	/* check if the plan tree can be vectorized */
+	if(vmthd.vectorized_executor_enable && vmthd.CheckPlanVectorized_Hook)
+		top_plan =  vmthd.CheckPlanVectorized_Hook(root, top_plan);
+
+
 	
 	/* build the PlannedStmt result */
 	result = makeNode(PlannedStmt);

--- a/src/include/executor/executor.h
+++ b/src/include/executor/executor.h
@@ -43,6 +43,7 @@
 
 typedef struct vectorexe_t {
 	bool vectorized_executor_enable;
+	Plan* (*CheckPlanVectorized_Hook)(PlannerInfo *root, Plan *plan);
 	PlanState* (*ExecInitNode_Hook)(Plan *node,EState *eState,int eflags);
 	TupleTableSlot* (*ExecProcNode_Hook)(PlanState *node);
 	bool (*ExecEndNode_Hook)(PlanState *node);

--- a/src/include/executor/executor.h
+++ b/src/include/executor/executor.h
@@ -43,8 +43,8 @@
 
 typedef struct vectorexe_t {
 	bool vectorized_executor_enable;
-	Plan* (*CheckPlanVectorized_Hook)(PlannerInfo *root, Plan *plan);
-	PlanState* (*ExecInitNode_Hook)(Plan *node,EState *eState,int eflags);
+	Plan* (*CheckPlanVectorized_Hook)(PlannerInfo *node, Plan *plan);
+	PlanState* (*ExecInitNode_Hook)(PlanState *node,EState *eState,int eflags);
 	TupleTableSlot* (*ExecProcNode_Hook)(PlanState *node);
 	bool (*ExecEndNode_Hook)(PlanState *node);
 } VectorExecMthd;

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -1255,6 +1255,7 @@ typedef struct PlanState
         List           *qual;                        /* implicitly-ANDed qual conditions */
         struct PlanState *lefttree; /* input plan tree(s) */
         struct PlanState *righttree;
+        struct PlanState *parent;
         List           *initPlan;                /* Init SubPlanState nodes (un-correlated expr
                                                                  * subselects) */
         List           *subPlan;                /* SubPlanState nodes in my expressions */
@@ -1293,6 +1294,9 @@ typedef struct PlanState
          */
         int gpmon_plan_tick;
         gpmon_packet_t gpmon_pkt;
+
+        /* If the executor operator is vectorized */
+        bool vectorized;
 } PlanState;
 
 typedef struct Gpmon_NameUnit_MaxVal
@@ -1357,6 +1361,7 @@ static inline void Gpmon_M_Reset(gpmon_packet_t *pkt, int nth)
  */
 #define innerPlanState(node)                (((PlanState *)(node))->righttree)
 #define outerPlanState(node)                (((PlanState *)(node))->lefttree)
+#define parentPlanState(node)               (((PlanState *)(node))->parent)
 
 
 /* ----------------

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -1295,8 +1295,8 @@ typedef struct PlanState
         int gpmon_plan_tick;
         gpmon_packet_t gpmon_pkt;
 
-        /* If the executor operator is vectorized */
-        bool vectorized;
+        /* state of executor operator  */
+        void* vectorized;
 } PlanState;
 
 typedef struct Gpmon_NameUnit_MaxVal

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -1255,7 +1255,6 @@ typedef struct PlanState
         List           *qual;                        /* implicitly-ANDed qual conditions */
         struct PlanState *lefttree; /* input plan tree(s) */
         struct PlanState *righttree;
-        struct PlanState *parent;
         List           *initPlan;                /* Init SubPlanState nodes (un-correlated expr
                                                                  * subselects) */
         List           *subPlan;                /* SubPlanState nodes in my expressions */
@@ -1361,7 +1360,6 @@ static inline void Gpmon_M_Reset(gpmon_packet_t *pkt, int nth)
  */
 #define innerPlanState(node)                (((PlanState *)(node))->righttree)
 #define outerPlanState(node)                (((PlanState *)(node))->lefttree)
-#define parentPlanState(node)               (((PlanState *)(node))->parent)
 
 
 /* ----------------

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -339,6 +339,9 @@ typedef struct Plan
 
 	/* MemoryAccount to use for recording the memory usage of different plan nodes. */
 	MemoryAccount* memoryAccount;
+
+	/* if the plan can be vectorized */
+	bool vectorized;
 } Plan;
 
 /* ----------------


### PR DESCRIPTION
 1. Replace the vectorized data types and expressions immediately after check.
 2.Move the VExecInitNode to the end of the ExecInitNode.
 3.Process the Parent PlanState and the vectorized flag in the VExecInitNode.