### PR TITLE
HAWQ-1604. Add A New GUC hawq_hashjoin_bloomfilter 

### DIFF
--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -234,7 +234,7 @@ int 		gp_hashagg_spillbatch_min = 0;
 int 		gp_hashagg_spillbatch_max = 0;
 
 /* hash join to use bloom filter: default to 0, means not used */
-int 	 	gp_hashjoin_bloomfilter = 0;
+int 	 	hawq_hashjoin_bloomfilter = 0;
 
 /* Analyzing aid */
 int 		gp_motion_slice_noop = 0;

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -5834,13 +5834,13 @@ static struct config_int ConfigureNamesInt[] =
 	},
 
 	{
-		{"gp_hashjoin_bloomfilter", PGC_USERSET, GP_ARRAY_TUNING,
+		{"hawq_hashjoin_bloomfilter", PGC_USERSET, GP_ARRAY_TUNING,
 		 gettext_noop("Use bloomfilter in hash join"),
-		 gettext_noop("Use bloomfilter may speed up hashtable probing"),
+		 gettext_noop("Use bloomfilter may speed up hash join performance"),
 		 GUC_NOT_IN_SAMPLE | GUC_NO_SHOW_ALL | GUC_GPDB_ADDOPT
 		},
-		&gp_hashjoin_bloomfilter,
-		1, 0, 1, NULL, NULL
+		&hawq_hashjoin_bloomfilter,
+		0, 0, 1, NULL, NULL
 	},
 
 	{

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -937,7 +937,7 @@ extern int gp_hashagg_spillbatch_min;
 extern int gp_hashagg_spillbatch_max;
 
 /* Hashjoin use bloom filter */
-extern int gp_hashjoin_bloomfilter;
+extern int hawq_hashjoin_bloomfilter;
 
 /* Get statistics for partitioned parent from a child */
 extern bool 	gp_statistics_pullup_from_child_partition;

--- a/src/include/executor/hashjoin.h
+++ b/src/include/executor/hashjoin.h
@@ -167,7 +167,7 @@ typedef struct HashJoinTableData
 	int			nbuckets;		/* # buckets in the in-memory hash table */
 	/* buckets[i] is head of list of tuples in i'th in-memory bucket */
 	struct HashJoinTupleData **buckets;
-	uint64     				  *bloom; /* bloom[i] is bloomfilter for buckets[i] */
+
 	/* buckets array is per-batch storage, as are all the tuples */
 
 	int			nbatch;			/* number of batches */

--- a/src/test/unit/mock/mock_info.json
+++ b/src/test/unit/mock/mock_info.json
@@ -13929,10 +13929,6 @@
             "filename": "src/backend/cdb/cdbvars.c", 
             "header filename": "src/include/cdb/cdbvars.h"
         }, 
-        "gp_hashjoin_bloomfilter": {
-            "filename": "src/backend/cdb/cdbvars.c", 
-            "header filename": "src/include/cdb/cdbvars.h"
-        }, 
         "gp_hashjoin_tuples_per_bucket": {
             "filename": "src/backend/cdb/cdbvars.c", 
             "header filename": "src/include/cdb/cdbvars.h"


### PR DESCRIPTION
HAWQ-1604. Add A New GUC hawq_hashjoin_bloomfilter to indicate if use Bloom filter for hash join.
Remove gp_hashjoin_bloomfilter and bloom filter in hash join table, this part of legacy codes has been verified that it won't improve hash join performance.

Please review, thanks!