### PR TITLE
Changes to enable reuse of PXF Parquet classes, for data in S3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,4 @@ CodeCoverage*
 
 .vscode
 cmake-build-debug
+.*.swp

--- a/pxf/pxf-hdfs/src/main/java/org/apache/hawq/pxf/plugins/hdfs/ParquetDataFragmenter.java
+++ b/pxf/pxf-hdfs/src/main/java/org/apache/hawq/pxf/plugins/hdfs/ParquetDataFragmenter.java
@@ -104,4 +104,5 @@ public class ParquetDataFragmenter extends Fragmenter {
 
             return result;
         }
-    }
+}
+

--- a/pxf/pxf-hdfs/src/main/java/org/apache/hawq/pxf/plugins/hdfs/ParquetResolver.java
+++ b/pxf/pxf-hdfs/src/main/java/org/apache/hawq/pxf/plugins/hdfs/ParquetResolver.java
@@ -101,6 +101,12 @@ public class ParquetResolver extends Plugin implements ReadResolver {
                     field.type = DataType.BYTEA.getOID();
                     field.val = g.getFieldRepetitionCount(columnIndex) == 0 ?
                             null : g.getBinary(columnIndex, 0).getBytes();
+                } else if (originalType == OriginalType.DATE) { // DATE type
+                    field.type = DataType.DATE.getOID();
+                    field.val = g.getFieldRepetitionCount(columnIndex) == 0 ? null : g.getString(columnIndex, 0);
+                } else if (originalType == OriginalType.TIMESTAMP_MILLIS) { // TIMESTAMP type
+                    field.type = DataType.TIMESTAMP.getOID();
+                    field.val = g.getFieldRepetitionCount(columnIndex) == 0 ? null : g.getString(columnIndex, 0);
                 } else {
                     field.type = DataType.TEXT.getOID();
                     field.val = g.getFieldRepetitionCount(columnIndex) == 0 ?

--- a/pxf/pxf-hdfs/src/main/java/org/apache/hawq/pxf/plugins/hdfs/ParquetResolver.java
+++ b/pxf/pxf-hdfs/src/main/java/org/apache/hawq/pxf/plugins/hdfs/ParquetResolver.java
@@ -29,6 +29,7 @@ import org.apache.hawq.pxf.api.utilities.Plugin;
 
 import org.apache.hawq.pxf.plugins.hdfs.utilities.HdfsUtilities;
 import org.apache.parquet.example.data.Group;
+import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.OriginalType;
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.Type;
@@ -55,6 +56,16 @@ public class ParquetResolver extends Plugin implements ReadResolver {
         super(metaData);
     }
 
+    // This method facilitates passing in the MessageType instance, which is
+    // found in the Parquet file footer
+    public List<OneField> getFields(OneRow row, MessageType schema) throws Exception
+    {
+      ParquetUserData parquetUserData = new ParquetUserData(schema);
+      Group g = (Group) row.getData();
+      List<OneField> output = resolveRecord(parquetUserData, g);
+      return output;
+    }
+    
 
     @Override
     public List<OneField> getFields(OneRow row) throws Exception {

--- a/pxf/pxf-hdfs/src/main/java/org/apache/hawq/pxf/plugins/hdfs/ParquetResolver.java
+++ b/pxf/pxf-hdfs/src/main/java/org/apache/hawq/pxf/plugins/hdfs/ParquetResolver.java
@@ -56,8 +56,10 @@ public class ParquetResolver extends Plugin implements ReadResolver {
         super(metaData);
     }
 
-    // This method facilitates passing in the MessageType instance, which is
-    // found in the Parquet file footer
+    /**
+     * @inheritDoc
+     * @param schema the MessageType instance, which is obtained from the Parquet file footer
+     */
     public List<OneField> getFields(OneRow row, MessageType schema) throws Exception
     {
       ParquetUserData parquetUserData = new ParquetUserData(schema);
@@ -65,7 +67,6 @@ public class ParquetResolver extends Plugin implements ReadResolver {
       List<OneField> output = resolveRecord(parquetUserData, g);
       return output;
     }
-    
 
     @Override
     public List<OneField> getFields(OneRow row) throws Exception {


### PR DESCRIPTION
I am working on adding support for read/write of Parquet formatted data, stored in S3, over PXF.  I wanted to reuse these existing Parquet classes since they are very functional, but I had to add a few methods since their members were private, as was a method I needed to use.

I'd like to submit this PR for just these changes.  The PR for the overall S3 Parquet project is in a different module and I will submit this separately.
