### PR TITLE
HAWQ-1609. Implement Vectorized Motion Node

### DIFF
--- a/contrib/vexecutor/Makefile
+++ b/contrib/vexecutor/Makefile
@@ -17,7 +17,7 @@
 
 
 MODULE_big = vexecutor
-OBJS    = vexecutor.o vtype.o vcheck.o tuplebatch.o execVScan.o execVQual.o parquet_reader.o ao_reader.o
+OBJS    = vexecutor.o vtype.o vcheck.o tuplebatch.o execVScan.o execVQual.o parquet_reader.o ao_reader.o nodeVMotion.o
 
 PG_CXXFLAGS = -Wall -O0 -g -std=c++11
 PG_LIBS = $(libpq_pgport) 

--- a/contrib/vexecutor/execVQual.c
+++ b/contrib/vexecutor/execVQual.c
@@ -19,6 +19,7 @@
 #include "postgres.h"
 #include "utils/builtins.h"
 #include "execVQual.h"
+#include "cdb/cdbhash.h"
 static bool
 ExecVTargetList(List *targetlist,
 			   ExprContext *econtext,
@@ -105,7 +106,7 @@ ExecVProject(ProjectionInfo *projInfo, ExprDoneCond *isDone)
  *      This function will be invoked in V->N process.
  */
 bool
-VirtualNodeProc(ScanState* state,TupleTableSlot *slot){
+VirtualNodeProc(TupleTableSlot *slot){
     if(TupIsNull(slot) )
         return false;
 

--- a/contrib/vexecutor/execVQual.h
+++ b/contrib/vexecutor/execVQual.h
@@ -34,7 +34,7 @@ extern vbool*
 ExecVQual(List *qual, ExprContext *econtext, bool resultForNull);
 
 extern bool
-VirtualNodeProc(ScanState* state,TupleTableSlot *slot);
+VirtualNodeProc(TupleTableSlot *slot);
 
 extern ExprState *
 VExecInitExpr(Expr *node, PlanState *parent);

--- a/contrib/vexecutor/execVScan.c
+++ b/contrib/vexecutor/execVScan.c
@@ -75,7 +75,7 @@ TupleTableSlot *ExecTableVScanVirtualLayer(ScanState *scanState)
         TupleTableSlot* slot = scanState->ps.ps_ProjInfo ? scanState->ps.ps_ResultTupleSlot : scanState->ss_ScanTupleSlot;
         while(1)
         {
-            bool succ = VirtualNodeProc(scanState,slot);
+            bool succ = VirtualNodeProc(slot);
 
             if(!succ)
             {

--- a/contrib/vexecutor/nodeVMotion.c
+++ b/contrib/vexecutor/nodeVMotion.c
@@ -1,0 +1,410 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include "nodeVMotion.h"
+#include "tuplebatch.h"
+#include "execVQual.h"
+/*=========================================================================
+ * FUNCTIONS PROTOTYPES
+ */
+static TupleTableSlot *execVMotionSender(MotionState * node);
+static TupleTableSlot *execVMotionUnsortedReceiver(MotionState * node);
+
+TupleTableSlot *ExecVMotion(MotionState * node);
+static void doSendTupleBatch(Motion * motion, MotionState * node, TupleTableSlot *outerTupleSlot);
+static SendReturnCode
+SendTupleBatch(MotionLayerState *mlStates, ChunkTransportState *transportStates,
+               int16 motNodeID, TupleBatch tuplebatch, int16 targetRoute);
+/*=========================================================================
+ */
+
+TupleTableSlot *
+ExecVMotionVirtualLayer(MotionState *node)
+{
+    if(node->mstype == MOTIONSTATE_SEND)
+        return ExecVMotion(node);
+    else if(node->mstype == MOTIONSTATE_RECV)
+    {
+        TupleTableSlot* slot = node->ps.ps_ResultTupleSlot;
+        while(1)
+        {
+            bool succ = VirtualNodeProc(slot);
+            if(!succ)
+            {
+                slot = ExecVMotion(node);
+                if(TupIsNull(slot))
+                    break;
+                else
+                    continue;
+            }
+
+            break;
+        }
+        return slot;
+    }
+}
+
+/* ----------------------------------------------------------------
+ *		ExecVMotion
+ * ----------------------------------------------------------------
+ */
+TupleTableSlot *
+ExecVMotion(MotionState * node)
+{
+    Motion	   *motion = (Motion *) node->ps.plan;
+
+    /*
+     * at the top here we basically decide: -- SENDER vs. RECEIVER and --
+     * SORTED vs. UNSORTED
+     */
+    if (node->mstype == MOTIONSTATE_RECV)
+    {
+        TupleTableSlot *tuple;
+
+        if (node->ps.state->active_recv_id >= 0)
+        {
+            if (node->ps.state->active_recv_id != motion->motionID)
+            {
+                elog(LOG, "DEADLOCK HAZARD: Updating active_motion_id from %d to %d",
+                     node->ps.state->active_recv_id, motion->motionID);
+                node->ps.state->active_recv_id = motion->motionID;
+            }
+        } else
+            node->ps.state->active_recv_id = motion->motionID;
+
+        /* Running in diagnostic mode ? */
+        if (Gp_interconnect_type == INTERCONNECT_TYPE_NIL)
+        {
+            node->ps.state->active_recv_id = -1;
+            return NULL;
+        }
+
+        Assert(!motion->sendSorted);
+
+        tuple = execVMotionUnsortedReceiver(node);
+
+        if (tuple == NULL)
+            node->ps.state->active_recv_id = -1;
+        else
+        {
+            Gpmon_M_Incr(GpmonPktFromMotionState(node), GPMON_QEXEC_M_ROWSIN);
+            Gpmon_M_Incr_Rows_Out(GpmonPktFromMotionState(node));
+            setMotionStatsForGpmon(node);
+        }
+#ifdef MEASURE_MOTION_TIME
+        gettimeofday(&stopTime, NULL);
+
+		node->motionTime.tv_sec += stopTime.tv_sec - startTime.tv_sec;
+		node->motionTime.tv_usec += stopTime.tv_usec - startTime.tv_usec;
+
+		while (node->motionTime.tv_usec < 0)
+		{
+			node->motionTime.tv_usec += 1000000;
+			node->motionTime.tv_sec--;
+		}
+
+		while (node->motionTime.tv_usec >= 1000000)
+		{
+			node->motionTime.tv_usec -= 1000000;
+			node->motionTime.tv_sec++;
+		}
+#endif
+        CheckSendPlanStateGpmonPkt(&node->ps);
+        return tuple;
+    }
+    else if(node->mstype == MOTIONSTATE_SEND)
+    {
+        return execVMotionSender(node);
+    }
+
+    Assert(!"Non-active motion is executed");
+    return NULL;
+}
+
+static TupleTableSlot *
+execVMotionSender(MotionState * node)
+{
+    /* SENDER LOGIC */
+    TupleTableSlot *outerTupleSlot;
+    PlanState  *outerNode;
+    Motion	   *motion = (Motion *) node->ps.plan;
+    bool		done = false;
+
+
+#ifdef MEASURE_MOTION_TIME
+    struct timeval time1;
+	struct timeval time2;
+
+	gettimeofday(&time1, NULL);
+#endif
+
+    AssertState(motion->motionType == MOTIONTYPE_HASH ||
+                (motion->motionType == MOTIONTYPE_EXPLICIT && motion->segidColIdx > 0) ||
+                (motion->motionType == MOTIONTYPE_FIXED && motion->numOutputSegs <= 1));
+    Assert(node->ps.state->interconnect_context);
+
+    while (!done)
+    {
+        /* grab TupleTableSlot from our child. */
+        outerNode = outerPlanState(node);
+        outerTupleSlot = ExecProcNode(outerNode);
+
+        /* Running in diagnostic mode, we just drop all tuples. */
+        if (Gp_interconnect_type == INTERCONNECT_TYPE_NIL)
+        {
+            if (!TupIsNull(outerTupleSlot))
+                continue;
+
+            return NULL;
+        }
+
+        if (done || TupIsNull(outerTupleSlot))
+        {
+            doSendEndOfStream(motion, node);
+            done = true;
+        }
+        else
+        {
+            doSendTupleBatch(motion, node, outerTupleSlot);
+
+            Gpmon_M_Incr_Rows_Out(GpmonPktFromMotionState(node));
+            setMotionStatsForGpmon(node);
+            CheckSendPlanStateGpmonPkt(&node->ps);
+
+            if (node->stopRequested)
+            {
+                elog(gp_workfile_caching_loglevel, "Motion initiating Squelch walker");
+                /* propagate stop notification to our children */
+                ExecSquelchNode(outerNode);
+                done = true;
+            }
+        }
+#ifdef MEASURE_MOTION_TIME
+        gettimeofday(&time1, NULL);
+
+		node->motionTime.tv_sec += time1.tv_sec - time2.tv_sec;
+		node->motionTime.tv_usec += time1.tv_usec - time2.tv_usec;
+
+		while (node->motionTime.tv_usec < 0)
+		{
+			node->motionTime.tv_usec += 1000000;
+			node->motionTime.tv_sec--;
+		}
+
+		while (node->motionTime.tv_usec >= 1000000)
+		{
+			node->motionTime.tv_usec -= 1000000;
+			node->motionTime.tv_sec++;
+		}
+#endif
+    }
+
+    Assert(node->stopRequested || node->numTuplesFromChild == node->numTuplesToAMS);
+
+    /* nothing else to send out, so we return NULL up the tree. */
+    return NULL;
+}
+
+void
+doSendTupleBatch(Motion * motion, MotionState * node, TupleTableSlot *outerTupleSlot)
+{
+    int16		    targetRoute;
+    HeapTuple       tuple;
+    SendReturnCode  sendRC;
+    ExprContext    *econtext = node->ps.ps_ExprContext;
+
+    /* We got a tuple from the child-plan. */
+    node->numTuplesFromChild++;
+
+    if (motion->motionType == MOTIONTYPE_FIXED)
+    {
+        if (motion->numOutputSegs == 0) /* Broadcast */
+        {
+            targetRoute = BROADCAST_SEGIDX;
+        }
+        else /* Fixed Motion. */
+        {
+            Assert(motion->numOutputSegs == 1);
+            /*
+             * Actually, since we can only send to a single output segment
+             * here, we are guaranteed that we only have a single
+             * targetRoute setup that we could possibly send to.  So we
+             * can cheat and just fix the targetRoute to 0 (the 1st
+             * route).
+             */
+            targetRoute = 0;
+        }
+    }
+    else if (motion->motionType == MOTIONTYPE_HASH) /* Redistribute */
+    {
+        //TODO:: Implement later
+    }
+    else /* ExplicitRedistribute */
+    {
+        Datum segidColIdxDatum;
+
+        Assert(motion->segidColIdx > 0 && motion->segidColIdx <= list_length((motion->plan).targetlist));
+        bool is_null = false;
+        segidColIdxDatum = slot_getattr(outerTupleSlot, motion->segidColIdx, &is_null);
+        targetRoute = Int32GetDatum(segidColIdxDatum);
+        Assert(!is_null);
+    }
+
+    /* send the tuple out. */
+    sendRC = SendTupleBatch(node->ps.state->motionlayer_context,
+                            node->ps.state->interconnect_context,
+                            motion->motionID,
+                            outerTupleSlot->PRIVATE_tb,
+                            targetRoute);
+
+    Assert(sendRC == SEND_COMPLETE || sendRC == STOP_SENDING);
+    if (sendRC == SEND_COMPLETE)
+        node->numTuplesToAMS++;
+    else
+        node->stopRequested = true;
+}
+
+TupleTableSlot *execVMotionUnsortedReceiver(MotionState * node)
+{
+    /* RECEIVER LOGIC */
+    TupleTableSlot *slot;
+    HeapTuple	tuple;
+    Motion	   *motion = (Motion *) node->ps.plan;
+    ReceiveReturnCode recvRC;
+
+    AssertState(motion->motionType == MOTIONTYPE_HASH ||
+                (motion->motionType == MOTIONTYPE_EXPLICIT && motion->segidColIdx > 0) ||
+                (motion->motionType == MOTIONTYPE_FIXED && motion->numOutputSegs <= 1));
+
+    Assert(node->ps.state->motionlayer_context);
+    Assert(node->ps.state->interconnect_context);
+
+    if (node->stopRequested)
+    {
+        SendStopMessage(node->ps.state->motionlayer_context,
+                        node->ps.state->interconnect_context,
+                        motion->motionID);
+        return NULL;
+    }
+
+    recvRC = RecvTupleFrom(node->ps.state->motionlayer_context,
+                           node->ps.state->interconnect_context,
+                           motion->motionID, &tuple, ANY_ROUTE);
+
+    if (recvRC == END_OF_STREAM)
+    {
+        Assert(node->numTuplesFromAMS == node->numTuplesToParent);
+        Assert(node->numTuplesFromChild == 0);
+        Assert(node->numTuplesToAMS == 0);
+        return NULL;
+    }
+
+    node->numTuplesFromAMS++;
+    node->numTuplesToParent++;
+
+    /* store it in our result slot and return this. */
+    slot = node->ps.ps_ResultTupleSlot;
+    tbDeserialization(((MemTuple)tuple)->PRIVATE_mt_bits,&slot->PRIVATE_tb);
+
+    TupSetVirtualTupleNValid(slot, ((TupleBatch)slot->PRIVATE_tb)->ncols);
+    return slot;
+}
+
+/*
+ * Function:  SendTupleBatch - Sends a batch of tuples to the AMS layer.
+ */
+SendReturnCode
+SendTupleBatch(MotionLayerState *mlStates,
+               ChunkTransportState *transportStates,
+               int16 motNodeID,
+               TupleBatch tuplebatch,
+               int16 targetRoute)
+{
+    MotionNodeEntry *pMNEntry;
+    TupleChunkListData tcList;
+    MemoryContext oldCtxt;
+    SendReturnCode rc;
+
+    /*
+     * Analyze tools.  Do not send any thing if this slice is in the bit mask
+     */
+    if (gp_motion_slice_noop != 0 && (gp_motion_slice_noop & (1 << currentSliceId)) != 0)
+        return SEND_COMPLETE;
+
+    /*
+     * Pull up the motion node entry with the node's details.  This includes
+     * details that affect sending, such as whether the motion node needs to
+     * include backup segment-dbs.
+     */
+    pMNEntry = getMotionNodeEntry(mlStates, motNodeID, "SendTuple");
+
+    MemTuple tuple = tbSerialization(tuplebatch);
+
+    if (targetRoute != BROADCAST_SEGIDX)
+    {
+        struct directTransportBuffer b;
+
+        getTransportDirectBuffer(transportStates, motNodeID, targetRoute, &b);
+
+        if (b.pri != NULL && b.prilen > TUPLE_CHUNK_HEADER_SIZE)
+        {
+            int sent = 0;
+
+            sent = SerializeTupleDirect(tuple, &pMNEntry->ser_tup_info, &b);
+            if (sent > 0)
+            {
+                putTransportDirectBuffer(transportStates, motNodeID, targetRoute, sent);
+
+                tcList.num_chunks = 1;
+                tcList.serialized_data_length = sent;
+
+                statSendTuple(mlStates, pMNEntry, &tcList);
+
+                return SEND_COMPLETE;
+            }
+        }
+    }
+
+    /* Create and store the serialized form, and some stats about it. */
+    oldCtxt = MemoryContextSwitchTo(mlStates->motion_layer_mctx);
+
+
+    SerializeTupleIntoChunks(tuple, &pMNEntry->ser_tup_info, &tcList);
+    pfree(tuple);
+
+    MemoryContextSwitchTo(oldCtxt);
+
+    /* do the send. */
+    if (!SendTupleChunkToAMS(mlStates, transportStates, motNodeID, targetRoute, tcList.p_first))
+    {
+        pMNEntry->stopped = true;
+        rc = STOP_SENDING;
+    }
+    else
+    {
+        /* update stats */
+        statSendTuple(mlStates, pMNEntry, &tcList);
+
+        rc = SEND_COMPLETE;
+    }
+
+    /* cleanup */
+    clearTCList(&pMNEntry->ser_tup_info.chunkCache, &tcList);
+
+    return rc;
+}

--- a/contrib/vexecutor/nodeVMotion.h
+++ b/contrib/vexecutor/nodeVMotion.h
@@ -17,29 +17,24 @@
  * under the License.
  */
 
-#ifndef VCHECK_H
-#define VCHECK_H
+#ifndef NODEVMOTION_H
+#define NODEVMOTION_H
 
-#include "vtype.h"
-#include "tuplebatch.h"
-#include "nodes/execnodes.h"
+#include "postgres.h"
+#include "executor/nodeMotion.h"
 
-typedef struct aoinfo {
-	bool* proj;
-	bool isDone;
-} aoinfo;
+#include "access/heapam.h"
+#include "nodes/execnodes.h" /* Slice, SliceTable */
+#include "cdb/cdbheap.h"
+#include "cdb/cdbmotion.h"
+#include "cdb/cdbhash.h"
+#include "executor/executor.h"
+#include "executor/execdebug.h"
+#include "executor/nodeMotion.h"
+#include "utils/tuplesort.h"
+#include "utils/tuplesort_mk.h"
+#include "utils/memutils.h"
 
-/* vectorized executor state */
-typedef struct VectorizedState
-{
-	bool vectorized;
-	PlanState *parent;
-	aoinfo *ao;
-}VectorizedState;
-
-
-extern Plan* CheckAndReplacePlanVectorized(PlannerInfo *root, Plan *plan);
-extern Oid GetVtype(Oid ntype);
-extern Oid GetNtype(Oid vtype);
-
+extern TupleTableSlot *ExecVMotionVirtualLayer(MotionState *node);
 #endif
+

--- a/contrib/vexecutor/tuplebatch.c
+++ b/contrib/vexecutor/tuplebatch.c
@@ -150,19 +150,26 @@ tbSerialization(TupleBatch tb )
     return ret;
 }
 
-TupleBatch tbDeserialization(unsigned char *buffer)
+void tbDeserialization(unsigned char *buffer,TupleBatch* pTB )
 {
     size_t buflen;
     size_t len = 0;
     size_t tmplen = 0;
     tmplen = sizeof(size_t);
+    TupleBatch tb;
     memcpy(&buflen,buffer,tmplen);
     len += tmplen;
 
     if(buflen < sizeof(TupleBatchData))
-        return NULL;
+        return ;
 
-    TupleBatch tb = palloc0(sizeof(TupleBatchData));
+    if(!*pTB)
+        tb = palloc0(sizeof(TupleBatchData));
+    else
+    {
+        tb = *pTB;
+        tbReset(tb);
+    }
 
     //deserial tb main data
     tmplen = offsetof(TupleBatchData,skip);
@@ -173,7 +180,8 @@ TupleBatch tbDeserialization(unsigned char *buffer)
     if(tb->nrows != 0)
     {
         tmplen = sizeof(bool) * tb->nrows;
-        tb->skip = palloc(tmplen);
+        if(!tb->skip)
+            tb->skip = palloc(tmplen);
         memcpy(tb->skip,buffer+len,tmplen);
         len += tmplen;
     }
@@ -183,26 +191,28 @@ TupleBatch tbDeserialization(unsigned char *buffer)
     {
         int colid;
         tmplen = sizeof(vtype*) * tb->ncols;
-        tb->datagroup = palloc0(tmplen);
         //the buffer length is 8-bytes alignment, 
         //so we need align the current length before comparing.
+        if(!tb->datagroup)
+            tb->datagroup = palloc0(tmplen);
         while (((len + 0x8) & (~0x7)) < buflen)
         {
             memcpy(&colid,buffer + len,sizeof(int));
             len += sizeof(int);
 
             vtype* src = (vtype*)(buffer + len);
-            tb->datagroup[colid] = buildvtype(src->elemtype,tb->batchsize,tb->skip);
 
-            tmplen = VDATUMSZ(tb->batchsize);
+            if(!tb->datagroup[colid])
+                tb->datagroup[colid] = buildvtype(src->elemtype,tb->batchsize,tb->skip);
+
+            tmplen = VDATUMSZ(tb->nrows);
             //in vtype pointer isnull and skipref are't serialized
             memcpy(tb->datagroup[colid]->values,src->values - 2,tmplen);
 
-            memcpy(tb->datagroup[colid]->isnull,ISNULLOFFSET(src) - 2,tb->nrows * sizeof(bool));
+            memcpy(tb->datagroup[colid]->isnull,(unsigned char *)(src->values - 2) + tmplen,tb->nrows * sizeof(bool));
 
             len += VTYPESIZE(tb->nrows);
         }
     }
-
-    return tb;
+    *pTB = tb;
 }

--- a/contrib/vexecutor/tuplebatch.h
+++ b/contrib/vexecutor/tuplebatch.h
@@ -77,6 +77,6 @@ void tbfreeColumn(vtype** vh,int colid);
 /* TupleBatch serialization function */
 MemTuple tbSerialization(TupleBatch tb);
 /* TupleBatch deserialization function */
-TupleBatch tbDeserialization(unsigned char *buffer);
+void tbDeserialization(unsigned char *buffer,TupleBatch* pTB);
 
 #endif

--- a/src/backend/cdb/motion/cdbmotion.c
+++ b/src/backend/cdb/motion/cdbmotion.c
@@ -80,7 +80,6 @@ static void processIncomingChunks(MotionLayerState *mlStates,
 static inline void reconstructTuple(MotionNodeEntry * pMNEntry, ChunkSorterEntry * pCSEntry);
 
 /* Stats-function declarations. */
-static void statSendTuple(MotionLayerState *mlStates, MotionNodeEntry * pMNEntry, TupleChunkList tcList);
 static void statSendEOS(MotionLayerState *mlStates, MotionNodeEntry * pMNEntry);
 static void statChunksProcessed(MotionLayerState *mlStates, MotionNodeEntry * pMNEntry, int chunksProcessed, int chunkBytes, int tupleBytes);
 static void statNewTupleArrived(MotionNodeEntry * pMNEntry, ChunkSorterEntry * pCSEntry);
@@ -1169,7 +1168,7 @@ addChunkToSorter(MotionLayerState *mlStates,
  * tcList->num_chunks and tcList->serialized_data_length, and
  * SerializeTupleDirect() only fills those fields out.
  */
-static void
+void
 statSendTuple(MotionLayerState *mlStates, MotionNodeEntry * pMNEntry, TupleChunkList tcList)
 {
 	int			headerOverhead;

--- a/src/backend/executor/execProcnode.c
+++ b/src/backend/executor/execProcnode.c
@@ -903,9 +903,8 @@ ExecProcNode(PlanState *node)
 	Assert(nodeTag(node) >= T_PlanState_Start && nodeTag(node) < T_PlanState_End);
 
 	if(vmthd.vectorized_executor_enable
-	   && node->vectorized
 	   && vmthd.ExecProcNode_Hook
-	   && (result = vmthd.ExecProcNode_Hook(node)))
+	   && vmthd.ExecProcNode_Hook(node,&result))
 		goto Exec_Jmp_Done;
 
 	goto *ExecJmpTbl[nodeTag(node) - T_PlanState_Start];

--- a/src/backend/executor/execQual.c
+++ b/src/backend/executor/execQual.c
@@ -4519,6 +4519,7 @@ ExecInitExpr(Expr *node, PlanState *parent)
 	/* Initialize the vectorzied expressions */
 	if( vmthd.vectorized_executor_enable
 		&& vmthd.ExecInitExpr_Hook
+		&& parent
 		&& parent->plan->vectorized)
 	{
 		state = vmthd.ExecInitExpr_Hook(node, parent);

--- a/src/backend/executor/nodeMotion.c
+++ b/src/backend/executor/nodeMotion.c
@@ -129,7 +129,6 @@ static int
 CdbMergeComparator(void *lhs, void *rhs, void *context);
 static uint32 evalHashKey(ExprContext *econtext, List *hashkeys, List *hashtypes, CdbHash * h);
 
-static void doSendEndOfStream(Motion * motion, MotionState * node);
 static void doSendTuple(Motion * motion, MotionState * node, TupleTableSlot *outerTupleSlot);
 
 
@@ -212,7 +211,7 @@ bool isMotionRedistributeFromMaster(const Motion *m)
 /*
  * Set the statistic info in gpmon packet.
  */
-static void
+void
 setMotionStatsForGpmon(MotionState *node)
 {
 	MotionLayerState *mlStates = (MotionLayerState *)node->ps.state->motionlayer_context;
@@ -1475,7 +1474,7 @@ evalHashKey(ExprContext *econtext, List *hashkeys, List *hashtypes, CdbHash * h)
 	 * to assign a hash value for us.
 	 */
 	if (list_length(hashkeys) > 0)
-	{	
+	{
 		forboth(hk, hashkeys, ht, hashtypes)
 		{
 			ExprState  *keyexpr = (ExprState *) lfirst(hk);

--- a/src/include/cdb/cdbmotion.h
+++ b/src/include/cdb/cdbmotion.h
@@ -164,4 +164,5 @@ extern void setExpectedReceivers(MotionLayerState *mlStates, int16 motNodeID, in
  */
 extern TupleChunkListItem get_eos_tuplechunklist(void);
 
+extern void statSendTuple(MotionLayerState *mlStates, MotionNodeEntry * pMNEntry, TupleChunkList tcList);
 #endif   /* CDBMOTION_H */

--- a/src/include/executor/executor.h
+++ b/src/include/executor/executor.h
@@ -47,7 +47,7 @@ typedef struct vectorexe_t {
 	ExprState* (*ExecInitExpr_Hook)(Expr *node, PlanState *parent);
 	PlanState* (*ExecInitNode_Hook)(Plan *node, EState *eState,int eflags);
 	PlanState* (*ExecVecNode_Hook)(PlanState *Node, PlanState *parentNode, EState *eState,int eflags);
-	TupleTableSlot* (*ExecProcNode_Hook)(PlanState *node);
+	bool (*ExecProcNode_Hook)(PlanState *node,TupleTableSlot** pRtr);
 	bool (*ExecEndNode_Hook)(PlanState *node);
 	Oid (*GetNType)(Oid vtype);
 } VectorExecMthd;

--- a/src/include/executor/nodeMotion.h
+++ b/src/include/executor/nodeMotion.h
@@ -12,6 +12,7 @@
 #ifndef NODEMOTION_H
 #define NODEMOTION_H
 
+#include "cdb/cdbhash.h"
 #include "nodes/execnodes.h"
 
 extern int	ExecCountSlotsMotion(Motion *node);
@@ -28,6 +29,8 @@ extern bool isMotionGatherToMaster(const Motion *m);
 extern bool isMotionGatherToSegment(const Motion *m);
 extern bool isMotionRedistributeFromMaster(const Motion *m);
 
+extern void setMotionStatsForGpmon(MotionState *node);
+extern void doSendEndOfStream(Motion * motion, MotionState * node);
 
 enum 
 {


### PR DESCRIPTION
1. add vectorized motion node
2. Tuplebatch structure "create on used" in deserialization function, so that TB used memory reduce the allocation times.
3. change ExecVProcNode function return value type as boolean to indicate if the hook function takes responsibility for the execution process.
4. export some static function for vectorized library


New test code has not been created as previous feature test can cover this patch