### PR TITLE
HAWQ-1615. Fix accessing invalid memory when run a hash-join query with Bloomfilter enable. 

### DIFF
--- a/src/backend/executor/nodeTableScan.c
+++ b/src/backend/executor/nodeTableScan.c
@@ -84,12 +84,15 @@ FreeScanRuntimefilterState(RuntimeFilterState* rfstate)
 					 "outer table filtered row number:%d, filtered rate:%.3f",
 			 bf->nInserted, bf->nTested, bf->nMatched, bf->nTested - bf->nMatched,
 			 bf->nTested == 0 ? 0 : (float)((float)(bf->nTested - bf->nMatched)/(float)(bf->nTested)));
+		DestroyBloomFilter(rfstate->bloomfilter);
 	}
-	rfstate->bloomfilter = NULL;
-	if(rfstate->joinkeys)
+	if (rfstate->joinkeys != NIL)
 	{
 		list_free(rfstate->joinkeys);
-		rfstate->joinkeys = NIL;
+	}
+	if (rfstate->hashfunctions != NULL)
+	{
+		pfree(rfstate->hashfunctions);
 	}
 	pfree(rfstate);
 }


### PR DESCRIPTION
The BloomFilter structure in RuntimeFilterState should be allocated, instead of using the address of HashJoinTable's BloomFilter, since it may be released when function FreeScanRuntimefilterState() tries to access it.


Please review, thanks! 