### PR TITLE
HAWQ-1624. Change libhdfs3 to be ABI compatible with libhdfs

### DIFF
--- a/depends/libhdfs3/src/client/Hdfs.cpp
+++ b/depends/libhdfs3/src/client/Hdfs.cpp
@@ -836,12 +836,12 @@ tSize hdfsWrite(hdfsFS fs, hdfsFile file, const void * buffer, tSize length) {
 }
 
 int hdfsFlush(hdfsFS fs, hdfsFile file) {
-    PARAMETER_ASSERT(fs && file && file, -1, EINVAL);
+    PARAMETER_ASSERT(fs && file, -1, EINVAL);
     return hdfsHFlush(fs, file);
 }
 
 int hdfsHFlush(hdfsFS fs, hdfsFile file) {
-    PARAMETER_ASSERT(fs && file && file, -1, EINVAL);
+    PARAMETER_ASSERT(fs && file, -1, EINVAL);
     PARAMETER_ASSERT(!file->isInput(), -1, EINVAL);
 
     try {
@@ -863,7 +863,7 @@ int hdfsSync(hdfsFS fs, hdfsFile file) {
 }
 
 int hdfsHSync(hdfsFS fs, hdfsFile file) {
-    PARAMETER_ASSERT(fs && file && file, -1, EINVAL);
+    PARAMETER_ASSERT(fs && file, -1, EINVAL);
     PARAMETER_ASSERT(!file->isInput(), -1, EINVAL);
 
     try {
@@ -881,7 +881,7 @@ int hdfsHSync(hdfsFS fs, hdfsFile file) {
 }
 
 int hdfsAvailable(hdfsFS fs, hdfsFile file) {
-    PARAMETER_ASSERT(fs && file && file, -1, EINVAL);
+    PARAMETER_ASSERT(fs && file, -1, EINVAL);
     PARAMETER_ASSERT(file->isInput(), -1, EINVAL);
 
     try {

--- a/depends/libhdfs3/src/client/Hdfs.cpp
+++ b/depends/libhdfs3/src/client/Hdfs.cpp
@@ -834,6 +834,10 @@ int hdfsHFlush(hdfsFS fs, hdfsFile file) {
 }
 
 int hdfsSync(hdfsFS fs, hdfsFile file) {
+    return hdfsHSync(fs, file);
+}
+
+int hdfsHSync(hdfsFS fs, hdfsFile file) {
     PARAMETER_ASSERT(fs && file && file, -1, EINVAL);
     PARAMETER_ASSERT(!file->isInput(), -1, EINVAL);
 

--- a/depends/libhdfs3/src/client/hdfs.h
+++ b/depends/libhdfs3/src/client/hdfs.h
@@ -39,6 +39,15 @@
 #define EINTERNAL 255
 #endif
 
+#if defined(__GNUC__) || defined(__clang__)
+#define DEPRECATED __attribute__((deprecated))
+#elif defined(_MSC_VER)
+#define DEPRECATED __declspec(deprecated)
+#else
+#pragma message("WARNING: DEPRECATED is not supported by the compiler.")
+#define DEPRECATED
+#endif
+
 /** All APIs set errno to meaningful values */
 
 #ifdef __cplusplus
@@ -387,13 +396,24 @@ int hdfsFlush(hdfsFS fs, hdfsFile file);
 int hdfsHFlush(hdfsFS fs, hdfsFile file);
 
 /**
+ * This function is deprecated. Please use hdfsHSync instead.
+ *
  * hdfsSync - Flush out and sync the data in client's user buffer. After the
  * return of this call, new readers will see the data.
  * @param fs configured filesystem handle
  * @param file file handle
  * @return 0 on success, -1 on error and sets errno
  */
-int hdfsSync(hdfsFS fs, hdfsFile file);
+DEPRECATED int hdfsSync(hdfsFS fs, hdfsFile file);
+
+/**
+ * hdfsHSync - Flush out and sync the data in client's user buffer. After the
+ * return of this call, new readers will see the data.
+ * @param fs configured filesystem handle
+ * @param file file handle
+ * @return 0 on success, -1 on error and sets errno
+ */
+int hdfsHSync(hdfsFS fs, hdfsFile file);
 
 /**
  * hdfsAvailable - Number of bytes that can be read from this

--- a/depends/libhdfs3/src/client/hdfs.h
+++ b/depends/libhdfs3/src/client/hdfs.h
@@ -372,12 +372,12 @@ tSize hdfsRead(hdfsFS fs, hdfsFile file, void * buffer, tSize length);
   * hdfsPread - Positional read of data from an open file.
   * @param fs The configured filesystem handle.
   * @param file The file handle.
-  * @param position Position from which to read
+  * @param offset Position from which to read
   * @param buffer The buffer to copy read bytes into.
   * @param length The length of the buffer.
   * @return      See hdfsRead
   */
-tSize hdfsPread(hdfsFS fs, hdfsFile file, tOffset position,
+tSize hdfsPread(hdfsFS fs, hdfsFile file, tOffset offset,
                 void * buffer, tSize length);
 
 /**

--- a/depends/libhdfs3/src/client/hdfs.h
+++ b/depends/libhdfs3/src/client/hdfs.h
@@ -369,6 +369,18 @@ tOffset hdfsTell(hdfsFS fs, hdfsFile file);
 tSize hdfsRead(hdfsFS fs, hdfsFile file, void * buffer, tSize length);
 
 /**
+  * hdfsPread - Positional read of data from an open file.
+  * @param fs The configured filesystem handle.
+  * @param file The file handle.
+  * @param position Position from which to read
+  * @param buffer The buffer to copy read bytes into.
+  * @param length The length of the buffer.
+  * @return      See hdfsRead
+  */
+tSize hdfsPread(hdfsFS fs, hdfsFile file, tOffset position,
+                void * buffer, tSize length);
+
+/**
  * hdfsWrite - Write data into an open file.
  * @param fs The configured filesystem handle.
  * @param file The file handle.

--- a/depends/libhdfs3/test/function/TestCInterface.cpp
+++ b/depends/libhdfs3/test/function/TestCInterface.cpp
@@ -1761,7 +1761,7 @@ static void TestHFlushAndSync(hdfsFS fs, hdfsFile file, const char * path, int64
         EXPECT_EQ(batch, hdfsWrite(fs, file, &buffer[0], batch));
 
         if (sync) {
-            EXPECT_EQ(0, hdfsSync(fs, file));
+            EXPECT_EQ(0, hdfsHSync(fs, file));
         } else {
             EXPECT_EQ(0, hdfsHFlush(fs, file));
         }
@@ -2057,7 +2057,7 @@ TEST_F(TestCInterface, TestGetBlockFileLocations_Success) {
     out = hdfsOpenFile(fs, BASE_DIR"/TestGetBlockFileLocations_Failure", O_WRONLY, 0, 0, 1024);
     ASSERT_TRUE(NULL != out);
     ASSERT_TRUE(buffer.size() == hdfsWrite(fs, out, &buffer[0], buffer.size()));
-    ASSERT_TRUE(0 == hdfsSync(fs, out));
+    ASSERT_TRUE(0 == hdfsHSync(fs, out));
     EXPECT_TRUE(NULL != (bl = hdfsGetFileBlockLocations(fs, BASE_DIR"/TestGetBlockFileLocations_Failure", 0, buffer.size(), &size)));
     EXPECT_EQ(2, size);
     EXPECT_FALSE(bl[0].corrupt);
@@ -2103,7 +2103,7 @@ TEST_F(TestCInterface, TestGetHosts_Success) {
                        1024);
     ASSERT_TRUE(NULL != out);
     ASSERT_TRUE(buffer.size() == hdfsWrite(fs, out, &buffer[0], buffer.size()));
-    ASSERT_TRUE(0 == hdfsSync(fs, out));
+    ASSERT_TRUE(0 == hdfsHSync(fs, out));
     hosts =
         hdfsGetHosts(fs, BASE_DIR "/TestGetHosts_Success", 0, buffer.size());
     EXPECT_TRUE(NULL != hosts);

--- a/depends/libhdfs3/test/function/TestCInterface.cpp
+++ b/depends/libhdfs3/test/function/TestCInterface.cpp
@@ -1678,11 +1678,11 @@ TEST_F(TestCInterface, TestSync_InvalidInput) {
     in = hdfsOpenFile(fs, BASE_DIR"/testFlush1", O_RDONLY, 0, 0, 0);
     ASSERT_TRUE(in != NULL);
     //test invalid input
-    err = hdfsSync(NULL, out);
+    err = hdfsHSync(NULL, out);
     EXPECT_TRUE(err != 0 && EINVAL == errno);
-    err = hdfsSync(fs, NULL);
+    err = hdfsHSync(fs, NULL);
     EXPECT_TRUE(err != 0 && EINVAL == errno);
-    err = hdfsSync(fs, in);
+    err = hdfsHSync(fs, in);
     EXPECT_TRUE(err != 0 && EINVAL == errno);
     EXPECT_EQ(0, hdfsCloseFile(fs, out));
     EXPECT_EQ(0, hdfsCloseFile(fs, in));


### PR DESCRIPTION
I have been working on this in the context of tensorflow/tensorflow#16919, and the three discrepancies I've identified are:

* libhdfs3 does not define `hdfsPread` which nonetheless can be implemented in terms of `hdfsTell`, `hdfsSeek` and `hdfsRead`;
* `hdfsSync` is called `hdfsHSync` in libhdfs3;
* In libhdfs `hdfsFlush` flushes the internal buffer of the `BufferedInputStream`; in libhdfs3 it always flushes to HDFS, i.e. it does what `hdfsHFlush` should do. One way to address this is to make hdfsFlush a noop, but I guess it's already too late to change the implementation, wdyt?

Do you want me to add a test for `hdfsPread`? It does not do much on its own, but I can add one nonetheless.