### PR TITLE
Remove autogeneration of version number from pxf/build.gradle

### DIFF
--- a/pxf/build.gradle
+++ b/pxf/build.gradle
@@ -153,46 +153,6 @@ subprojects { subProject ->
 
 project('pxf-service') {
 
-// Copy existing sources and replace any occurrences of @tokenName@ with desired values
-    task generateSources {
-        doFirst {
-            copy {
-                from('src/main/java') {
-                    include '**/*.java'
-                    filter(ReplaceTokens,
-                        tokens:['pxfProtocolVersion': project.pxfProtocolVersion ])}
-                into "tmp/generatedSources"
-            }
-        }
-    }
-
-// Call cleanup taskAfter Java code compilation
-    compileJava.doLast {
-        tasks.cleanGeneratedSources.execute()
-    }
-
-// Delete "tmp" directory under current project directory
-// rm -r pxf-service/tmp
-    task cleanGeneratedSources() {
-        doFirst {
-            delete "tmp"
-        }
-    }
-
-// Call generateSources task before Java compilation
-    gradle.projectsEvaluated {
-        compileJava.dependsOn(generateSources)
-    }
-
-// Use custom sources directory with generated sources
-    sourceSets {
-        main {
-            java {
-                srcDirs = ["tmp/generatedSources"]
-            }
-        }
-    }
-
     apply plugin: 'war'
     tasks.war {
         archiveName = 'pxf.war'
@@ -545,7 +505,7 @@ def buildNumber() {
 }
 
 task wrapper(type: Wrapper) {
-    gradleVersion = '2.13'
+    gradleVersion = '3.0'
 }
 
 def distSubprojects = subprojects - project(':pxf-api')

--- a/pxf/gradle/wrapper/gradle-wrapper.properties
+++ b/pxf/gradle/wrapper/gradle-wrapper.properties
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 #Mon Jul 09 15:02:34 PDT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists

--- a/pxf/gradle/wrapper/gradle-wrapper.properties
+++ b/pxf/gradle/wrapper/gradle-wrapper.properties
@@ -1,23 +1,6 @@
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-# 
-#   http://www.apache.org/licenses/LICENSE-2.0
-# 
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
-
-#Wed Aug 05 16:07:21 PDT 2015
+#Mon Jul 09 15:02:34 PDT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.13-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.0-bin.zip

--- a/pxf/gradlew
+++ b/pxf/gradlew
@@ -1,6 +1,20 @@
 #!/usr/bin/env bash
 
-##############################################################################
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 ##
 ##  Gradle start up script for UN*X
 ##

--- a/pxf/gradlew
+++ b/pxf/gradlew
@@ -1,74 +1,10 @@
 #!/usr/bin/env bash
 
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.
-# The ASF licenses this file to You under the Apache License, Version 2.0
-# (the "License"); you may not use this file except in compliance with
-# the License.  You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
+##############################################################################
 ##
-## Tries to recreate Gradle's gradlew command in pure bash.
-## This way you don't have to worry about binaries in your build.
+##  Gradle start up script for UN*X
 ##
-## Depdencies
-## unzip
-##
-
-set -e
-set -o pipefail
-
-APP_NAME="Gradle"
-APP_BASE_NAME=`basename "$0"`
-
-# Use the maximum available, or set MAX_FD != -1 to use that value.
-    MAX_FD="maximum"
-
-# Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
-DEFAULT_JVM_OPTS="-Dorg.gradle.appname=$APP_BASE_NAME"
-
-bin=`dirname "$0"`
-bin=`cd "$bin">/dev/null; pwd`
-
-if [ -e "$bin/gradle/wrapper/gradle-wrapper.properties" ]; then
-  . "$bin/gradle/wrapper/gradle-wrapper.properties"
-else
-  # the location that the wrapper is at doesn't have a properties
-  # check PWD, gradlew may be shared
-  if [ -e "$PWD/gradle/wrapper/gradle-wrapper.properties" ]; then
-    . "$PWD/gradle/wrapper/gradle-wrapper.properties"
-  else
-    echo "Unable to locate gradle-wrapper.properties.  Not at $PWD/gradle/wrapper/gradle-wrapper.properties or $bin/gradle/wrapper/gradle-wrapper.properties" 1>&2
-    exit 1
-  fi
-fi
-
-warn ( ) {
-    echo "$*"
-}
-
-die ( ) {
-    echo
-    echo "$*"
-    echo
-    exit 1
-}
-
-# OS specific support (must be 'true' or 'false').
-darwin=false
-case "`uname`" in
-  Darwin* )
-    darwin=true
-    ;;
-esac
+##############################################################################
 
 # Attempt to set APP_HOME
 # Resolve links: $0 may be a link
@@ -84,9 +20,49 @@ while [ -h "$PRG" ] ; do
     fi
 done
 SAVED="`pwd`"
-cd "`dirname \"$PRG\"`/" >&-
+cd "`dirname \"$PRG\"`/" >/dev/null
 APP_HOME="`pwd -P`"
-cd "$SAVED" >&-
+cd "$SAVED" >/dev/null
+
+APP_NAME="Gradle"
+APP_BASE_NAME=`basename "$0"`
+
+# Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
+DEFAULT_JVM_OPTS=""
+
+# Use the maximum available, or set MAX_FD != -1 to use that value.
+MAX_FD="maximum"
+
+warn ( ) {
+    echo "$*"
+}
+
+die ( ) {
+    echo
+    echo "$*"
+    echo
+    exit 1
+}
+
+# OS specific support (must be 'true' or 'false').
+cygwin=false
+msys=false
+darwin=false
+nonstop=false
+case "`uname`" in
+  CYGWIN* )
+    cygwin=true
+    ;;
+  Darwin* )
+    darwin=true
+    ;;
+  MINGW* )
+    msys=true
+    ;;
+  NONSTOP* )
+    nonstop=true
+    ;;
+esac
 
 CLASSPATH=$APP_HOME/gradle/wrapper/gradle-wrapper.jar
 
@@ -113,7 +89,7 @@ location of your Java installation."
 fi
 
 # Increase the maximum file descriptors if we can.
-if [ "$darwin" = "false" ] ; then
+if [ "$cygwin" = "false" -a "$darwin" = "false" -a "$nonstop" = "false" ] ; then
     MAX_FD_LIMIT=`ulimit -H -n`
     if [ $? -eq 0 ] ; then
         if [ "$MAX_FD" = "maximum" -o "$MAX_FD" = "max" ] ; then
@@ -133,88 +109,61 @@ if $darwin; then
     GRADLE_OPTS="$GRADLE_OPTS \"-Xdock:name=$APP_NAME\" \"-Xdock:icon=$APP_HOME/media/gradle.icns\""
 fi
 
-# does not match gradle's hash
-# waiting for http://stackoverflow.com/questions/26642077/java-biginteger-in-bash-rewrite-gradlew
-hash() {
-  local input="$1"
-  if $darwin; then
-    md5 -q -s "$1"
-  else
-    echo -n "$1" | md5sum  | cut -d" " -f1
-  fi
-}
+# For Cygwin, switch paths to Windows format before running java
+if $cygwin ; then
+    APP_HOME=`cygpath --path --mixed "$APP_HOME"`
+    CLASSPATH=`cygpath --path --mixed "$CLASSPATH"`
+    JAVACMD=`cygpath --unix "$JAVACMD"`
 
-dist_path() {
-  local dir=$(basename $distributionUrl | sed 's;.zip;;g')
-  local id=$(hash "$distributionUrl")
+    # We build the pattern for arguments to be converted via cygpath
+    ROOTDIRSRAW=`find -L / -maxdepth 1 -mindepth 1 -type d 2>/dev/null`
+    SEP=""
+    for dir in $ROOTDIRSRAW ; do
+        ROOTDIRS="$ROOTDIRS$SEP$dir"
+        SEP="|"
+    done
+    OURCYGPATTERN="(^($ROOTDIRS))"
+    # Add a user-defined pattern to the cygpath arguments
+    if [ "$GRADLE_CYGPATTERN" != "" ] ; then
+        OURCYGPATTERN="$OURCYGPATTERN|($GRADLE_CYGPATTERN)"
+    fi
+    # Now convert the arguments - kludge to limit ourselves to /bin/sh
+    i=0
+    for arg in "$@" ; do
+        CHECK=`echo "$arg"|egrep -c "$OURCYGPATTERN" -`
+        CHECK2=`echo "$arg"|egrep -c "^-"`                                 ### Determine if an option
 
-  echo "$HOME/.gradle/${distributionPath:-wrapper/dists}/$dir/$id"
-}
-
-zip_path() {
-  local dir=$(basename $distributionUrl | sed 's;.zip;;g')
-  local id=$(hash "$distributionUrl")
-
-  echo "$HOME/.gradle/${zipStorePath:-wrapper/dists}/$dir/$id"
-}
-
-download() {
-  local base_path=$(dist_path)
-  local file_name=$(basename $distributionUrl)
-  local dir_name=$(echo "$file_name" | sed 's;-bin.zip;;g' | sed 's;-src.zip;;g' |sed 's;-all.zip;;g')
-
-  if [ ! -d "$base_path" ]; then
-    mkdir -p "$base_path"
-  else
-    # if data already exists, it means we failed to do this before
-    # so cleanup last run and try again
-    rm -rf $base_path/*
-  fi
-
-  # download dist. curl on mac doesn't like the cert provided...
-  local zip_path=$(zip_path)
-  curl --insecure -L -o "$zip_path/$file_name" "$distributionUrl"
-
-  pushd "$base_path"
-    touch "$file_name.lck"
-    unzip "$zip_path/$file_name" 1> /dev/null
-    touch "$file_name.ok"
-  popd
-}
-
-is_cached() {
-  local file_name=$(basename $distributionUrl)
-
-  [ -e "$(dist_path)/$file_name.ok" ]
-}
-
-lib_path() {
-  local base_path=$(dist_path)
-  local file_name=$(basename $distributionUrl | sed 's;-bin.zip;;g' | sed 's;-src.zip;;g' |sed 's;-all.zip;;g')
-
-  echo "$base_path/$file_name/lib"
-}
-
-classpath() {
-  local dir=$(lib_path)
-  local cp=$(ls -1 $dir/*.jar | tr '\n' ':')
-  echo "$dir:$cp"
-}
+        if [ $CHECK -ne 0 ] && [ $CHECK2 -eq 0 ] ; then                    ### Added a condition
+            eval `echo args$i`=`cygpath --path --ignore --mixed "$arg"`
+        else
+            eval `echo args$i`="\"$arg\""
+        fi
+        i=$((i+1))
+    done
+    case $i in
+        (0) set -- ;;
+        (1) set -- "$args0" ;;
+        (2) set -- "$args0" "$args1" ;;
+        (3) set -- "$args0" "$args1" "$args2" ;;
+        (4) set -- "$args0" "$args1" "$args2" "$args3" ;;
+        (5) set -- "$args0" "$args1" "$args2" "$args3" "$args4" ;;
+        (6) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" ;;
+        (7) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" "$args6" ;;
+        (8) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" "$args6" "$args7" ;;
+        (9) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" "$args6" "$args7" "$args8" ;;
+    esac
+fi
 
 # Split up the JVM_OPTS And GRADLE_OPTS values into an array, following the shell quoting and substitution rules
 function splitJvmOpts() {
     JVM_OPTS=("$@")
 }
+eval splitJvmOpts $DEFAULT_JVM_OPTS $JAVA_OPTS $GRADLE_OPTS
+JVM_OPTS[${#JVM_OPTS[*]}]="-Dorg.gradle.appname=$APP_BASE_NAME"
 
-main() {
-  if ! is_cached; then
-    download
-  fi
+# by default we should be in the correct project dir, but when run from Finder on Mac, the cwd is wrong
+if [[ "$(uname)" == "Darwin" ]] && [[ "$HOME" == "$PWD" ]]; then
+  cd "$(dirname "$0")"
+fi
 
-  eval splitJvmOpts $DEFAULT_JVM_OPTS $JAVA_OPTS $GRADLE_OPTS
-  JVM_OPTS[${#JVM_OPTS[*]}]="-Dorg.gradle.appname=$APP_BASE_NAME"
-
-  $JAVACMD "${JVM_OPTS[@]}" -cp $(classpath) org.gradle.launcher.GradleMain "$@"
-}
-
-main "$@"
+exec "$JAVACMD" "${JVM_OPTS[@]}" -classpath "$CLASSPATH" org.gradle.wrapper.GradleWrapperMain "$@"

--- a/pxf/pxf-service/src/main/java/org/apache/hawq/pxf/service/rest/VersionResource.java
+++ b/pxf/pxf-service/src/main/java/org/apache/hawq/pxf/service/rest/VersionResource.java
@@ -39,7 +39,7 @@ class Version {
      * actual value on build stage, using pxfProtocolVersion parameter from
      * gradle.properties
      */
-    final static String PXF_PROTOCOL_VERSION = "@pxfProtocolVersion@";
+    final static String PXF_PROTOCOL_VERSION = "v15";
 
     public Version() {
     }

--- a/pxf/pxf-service/src/main/webapp/WEB-INF/web.xml
+++ b/pxf/pxf-service/src/main/webapp/WEB-INF/web.xml
@@ -67,7 +67,7 @@ under the License.
     </filter>
     <filter-mapping>
         <filter-name>PXF Security Filter</filter-name>
-        <url-pattern>/@pxfProtocolVersion@/*</url-pattern>
+        <url-pattern>/v15/*</url-pattern>
     </filter-mapping>
 
     <!-- log4j configuration 


### PR DESCRIPTION
This enables us to use IntelliJ's code navigation and refactoring
features. Previously, IntelliJ would navigate to / refactor the
generated files rather than the source files since the generated files
were the ones that actually got compiled.

We also upgraded Gradle to 3.0 because we suspected IntelliJ might not have good support for older Gradle versions.

Co-authored-by: Lav Jain <ljain@pivotal.io>
Co-authored-by: Ben Christel <bchristel@pivotal.io>