### PR TITLE
HAWQ-1646. Fixes travis CI issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ language: c
 os:
   - osx
 
+osx_image: xcode8.3
+
 compiler:
   - clang
 


### PR DESCRIPTION
Travis CI is using a new default OSX image starting July 31st, which is causing compilation issues in javadocs. This PR sets the previously known working osx_image in .travis.yml.