### PR TITLE
HAWQ-1652. Update PXF keytab path to use PXF_HOME

### DIFF
--- a/pxf/pxf-service/src/main/java/org/apache/hawq/pxf/service/UGICache.java
+++ b/pxf/pxf-service/src/main/java/org/apache/hawq/pxf/service/UGICache.java
@@ -48,7 +48,8 @@ public class UGICache {
     private final Map<Integer, DelayQueue<Entry>> expirationQueueMap = new HashMap<>();
     private final UGIProvider ugiProvider;
     private final Ticker ticker;
-    final static long UGI_CACHE_EXPIRY = 15 * 60 * 1000L; // 15 Minutes
+    static final int NANOS_PER_MILLIS = 1000000;
+    static final long UGI_CACHE_EXPIRY = 15 * 60 * 1000L; // 15 Minutes
 
     /**
      * Create a UGICache with the given {@link Ticker} and {@link UGIProvider}. Intended for use by
@@ -343,7 +344,7 @@ public class UGICache {
          * System}.currentTimeMillis)
          */
         private long currentTimeMillis() {
-            return ticker.read() / 1000;
+            return ticker.read() / NANOS_PER_MILLIS;
         }
     }
 }

--- a/pxf/pxf-service/src/scripts/pxf-env.sh
+++ b/pxf/pxf-service/src/scripts/pxf-env.sh
@@ -46,9 +46,9 @@ export PXF_JVM_OPTS="-Xmx2g -Xms1g"
 
 # Kerberos
 # Path to keytab file owned by pxf service with permissions 0400
-export PXF_KEYTAB="/etc/security/keytab/pxf.service.keytab"
+export PXF_KEYTAB="${PXF_HOME}/conf/pxf.service.keytab"
 # Kerberos principal pxf service should use. _HOST is replaced automatically with hostnames FQDN
-export PXF_PRINCIPAL="pxf/_HOST@EXAMPLE.COM"
+export PXF_PRINCIPAL="gpadmin/_HOST@EXAMPLE.COM"
 
 # Hadoop Distribution Type (optional), supported values:
 # <empty> - for auto discovery of HDP, CDH or tarball based client installation

--- a/pxf/pxf-service/src/test/java/org/apache/hawq/pxf/service/UGICacheTest.java
+++ b/pxf/pxf-service/src/test/java/org/apache/hawq/pxf/service/UGICacheTest.java
@@ -58,7 +58,7 @@ public class UGICacheTest {
         }
 
         long advanceTime(long milliseconds) {
-            return nanos.addAndGet(milliseconds * 1000) / 1000;
+            return nanos.addAndGet(milliseconds * UGICache.NANOS_PER_MILLIS) / UGICache.NANOS_PER_MILLIS;
         }
     }
 


### PR DESCRIPTION
- Updates `PXF_KEYTAB` path to live inside `${PXF_HOME}/conf` and `PXF_PRINCIPAL` to default to gpadmin.
- Fixes nanoseconds to milliseconds conversion in UGICache.